### PR TITLE
Use AppContainer in schedule-visitation

### DIFF
--- a/pageTests/api/schedule-visitation.test.js
+++ b/pageTests/api/schedule-visitation.test.js
@@ -1,0 +1,56 @@
+import scheduleVisitation from "../../pages/api/schedule-visitation";
+
+jest.mock("notifications-node-client");
+
+describe("schedule-visitation", () => {
+  let req;
+  let res;
+  let container;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      status: jest.fn(),
+      setHeader: jest.fn(),
+      send: jest.fn(),
+      end: jest.fn(),
+    };
+    container = {
+      getCreateVisitation: jest.fn(),
+      getDb: jest.fn(),
+    };
+  });
+
+  it("inserts a visitation if valid", async () => {
+    const createVisitationSpy = jest.fn();
+
+    await scheduleVisitation(
+      {
+        method: "POST",
+        body: {
+          patientName: "Bob Smith",
+          contactNumber: "07123456789",
+          callTime: "2020-04-05T10:10:10",
+        },
+      },
+      res,
+      {
+        container: {
+          ...container,
+          getCreateVisitation: () => createVisitationSpy,
+        },
+      }
+    );
+
+    expect(res.status).toHaveBeenCalledWith(204);
+
+    expect(createVisitationSpy).toHaveBeenCalled();
+
+    expect(createVisitationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patientName: "Bob Smith",
+        contactNumber: "07123456789",
+      })
+    );
+  });
+});

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -1,0 +1,17 @@
+import pgp from "pg-promise";
+import createVisitation from "../usecases/createVisitation";
+
+export default class AppContainer {
+  getDb() {
+    return pgp()({
+      connectionString: process.env.URI,
+      ssl: {
+        rejectUnauthorized: false,
+      },
+    });
+  }
+
+  getCreateVisitation() {
+    return createVisitation(this);
+  }
+}

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -1,0 +1,17 @@
+import AppContainer from "./AppContainer";
+
+describe("AppContainer", () => {
+  let container;
+
+  beforeEach(() => {
+    container = new AppContainer();
+  });
+
+  it("returns getDb", () => {
+    expect(container.getDb()).toBeDefined();
+  });
+
+  it("returns createVistiation", () => {
+    expect(container.getCreateVisitation).toBeDefined();
+  });
+});

--- a/src/middleware/withContainer.js
+++ b/src/middleware/withContainer.js
@@ -1,0 +1,9 @@
+import AppContainer from "../containers/AppContainer";
+
+export default (handler) => {
+  return (req, res, ctx) => {
+    ctx = ctx || {};
+    ctx.container = ctx.container || new AppContainer();
+    return handler(req, res, ctx);
+  };
+};

--- a/src/usecases/createVisitation.js
+++ b/src/usecases/createVisitation.js
@@ -1,6 +1,6 @@
 import RandomIdProvider from "../../src/providers/RandomIdProvider";
 
-const createVisitation = async ({ getDb }, visitation) => {
+const createVisitation = ({ getDb }) => async (visitation) => {
   const db = getDb();
 
   console.log("Creating visitation for ", visitation);

--- a/src/usecases/createVisitation.test.js
+++ b/src/usecases/createVisitation.test.js
@@ -18,7 +18,7 @@ describe("createVisitation", () => {
       callId: 12345,
     };
 
-    const resultingId = await createVisitation(container, request);
+    const resultingId = await createVisitation(container)(request);
 
     expect(resultingId).toEqual(10);
 

--- a/testSetup.js
+++ b/testSetup.js
@@ -1,4 +1,4 @@
-import Adapter from 'enzyme-adapter-react-16';
-import { configure } from 'enzyme';
+import Adapter from "enzyme-adapter-react-16";
+import { configure } from "enzyme";
 
 configure({ adapter: new Adapter() });


### PR DESCRIPTION
New AppContainer using inspiration from Luke's website.

Usecases should be provided via the container. The container itself can
be passed into usecases that require it by currying.

# What
We need to start decoupling the API from the externals (GovNotify, DB, etc). Passing a container around enables us to easily mock these externals out in testing, and adds clear separations in the code.

Thanks Luke!

# Why
Separation is important, as is keeping code simple. This is a balance of separating and trying to keep the code relatively simple :see_no_evil: 

# Screenshots
n/a
# Notes
