### PR TITLE
Add filtering for ward visitations

### DIFF
--- a/src/usecases/retreiveVisitations.js
+++ b/src/usecases/retreiveVisitations.js
@@ -2,7 +2,7 @@ export default async function retreiveVisitations({ getDb }) {
   const db = getDb();
   try {
     const scheduledCalls = await db.any(
-      "SELECT * FROM scheduled_calls_table ORDER BY call_time DESC"
+      "SELECT * FROM scheduled_calls_table WHERE call_time > NOW() - INTERVAL '30 minutes' ORDER BY call_time DESC"
     );
 
     return {


### PR DESCRIPTION
# What

Add filtering by only showing visitations that are more than 30 minutes from now.

# Why

This way we don't clog up the page with old visitations.

# Screenshots

![screencapture-localhost-3000-wards-123-visitations-2020-04-16-18_21_10](https://user-images.githubusercontent.com/42817036/79487005-7b511e80-800f-11ea-81a9-2c4e20633b75.png)

# Notes

N/A
