### PR TITLE
Disables `autoComplete` on schedule form

### DIFF
--- a/pages/wards/[id]/schedule-visitation.js
+++ b/pages/wards/[id]/schedule-visitation.js
@@ -134,6 +134,7 @@ const Home = () => {
                 style={{ padding: "32px 16px!important" }}
                 onChange={(event) => setContactNumber(event.target.value)}
                 name="contact"
+                autoComplete="off"
               />
               <Label htmlFor="patient-name">Patient name</Label>
               <Hint className="nhsuk-u-margin-bottom-2">
@@ -149,6 +150,7 @@ const Home = () => {
                 style={{ padding: "32px 16px!important" }}
                 onChange={(event) => setPatientName(event.target.value)}
                 name="patient-name"
+                autoComplete="off"
               />
               <DateSelect
                 onChange={(date) => setCallTime(date)}

--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -38,6 +38,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
           id="day"
           name="day"
           value={date.day}
+          autoComplete="off"
         />
       </div>
       <div class="nhsuk-date-input__item">
@@ -52,6 +53,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
             setDate({ ...date, month: parseInt(event.target.value) });
           }}
           value={date.month}
+          autoComplete="off"
         />
       </div>
       <div class="nhsuk-date-input__item">
@@ -66,6 +68,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
             setDate({ ...date, year: parseInt(event.target.value) });
           }}
           value={date.year}
+          autoComplete="off"
         />
       </div>
       <div class="nhsuk-date-input__item">
@@ -80,6 +83,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
             setDate({ ...date, hour: parseInt(event.target.value) });
           }}
           value={date.hour}
+          autoComplete="off"
         />
       </div>
       <div class="nhsuk-date-input__item">
@@ -94,6 +98,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
             setDate({ ...date, min: parseInt(event.target.value) });
           }}
           value={date.min}
+          autoComplete="off"
         />
       </div>
     </div>


### PR DESCRIPTION
# What
Disabled auto complete on all form elements in the schedule visitation form.

# Why
Prevents remembering patient data and accidentally selecting previous values.

# Screenshots
![image](https://user-images.githubusercontent.com/5405916/79491566-8f4c4e80-8016-11ea-8d69-4043e8c69bb5.png)
