### PR TITLE
Guard against no cookies

### DIFF
--- a/pages/wards/login.js
+++ b/pages/wards/login.js
@@ -94,4 +94,6 @@ export const getServerSideProps = ({ req: { headers }, res }) => {
   if (token && token.ward) {
     res.writeHead(302, { Location: `/wards/${token.ward}/visitations` }).end();
   }
+
+  return { props: {} };
 };

--- a/src/usecases/userIsAuthenticated.js
+++ b/src/usecases/userIsAuthenticated.js
@@ -1,7 +1,11 @@
 import cookie from "cookie";
 
 export default ({ requestCookie, tokens }) => {
-  const { token } = cookie.parse(requestCookie);
+  try {
+    const { token } = cookie.parse(requestCookie);
 
-  return token && tokens.validate(token);
+    return token && tokens.validate(token);
+  } catch (err) {
+    return false;
+  }
 };


### PR DESCRIPTION
# What
New users won't have cookies, so don't assume they have!

Null/undefined string caused 500 errors on the login page where a user has not logged in.

# Why
Because we haven't set a cookie on them before

# Screenshots

# Notes
