### PR TITLE
Remove duplicated visitors definition in glossary

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -2,10 +2,6 @@
 
 ## Vocabulary
 
-### Visitors (noun)
-
-Users wanting to have a virtual visit with **Patients**.
-
 ### Ward Nurses (noun)
 
 Users who are caring for **Patients** and helping **Visitors** connect with Patients.


### PR DESCRIPTION
# What

Remove duplicated visitors definition in glossary.

# Why

We have it defined twice. 

# Screenshots

N/A

# Notes

I just picked the longest definition. ¯\_(ツ)_/¯