### PR TITLE
Rename visitations content to visits

### DIFF
--- a/pages/visitors/waiting-room/[id].js
+++ b/pages/visitors/waiting-room/[id].js
@@ -40,18 +40,15 @@ const PreJoin = () => {
   });
 
   return (
-    <Layout title="Join your virtual visitation" hasErrors={errors.length != 0}>
+    <Layout title="Join your virtual visit" hasErrors={errors.length != 0}>
       <GridRow>
         <GridColumn width="two-thirds">
           <ErrorSummary errors={errors} />
-          <Heading>Join your virtual visitation</Heading>
+          <Heading>Join your virtual visit</Heading>
+          <Text>You're about to join a video call for your virtual visit.</Text>
           <Text>
-            You're about to join a video call for your virtual visitation.
-          </Text>
-          <Text>
-            Please enter your name below. When you click "Join virtual
-            visitation" you will be provided with instructions on how to join
-            the call.
+            Please enter your name below. When you click "Join virtual visit"
+            you will be provided with instructions on how to join the call.
           </Text>
           <form onSubmit={onSubmit}>
             <FormGroup>
@@ -66,7 +63,7 @@ const PreJoin = () => {
                 name="name"
               />
               <Button className="nhsuk-u-margin-top-5">
-                Join virtual visitation
+                Join virtual visit
               </Button>
             </FormGroup>
           </form>

--- a/pages/wards/[id]/schedule-visitation.js
+++ b/pages/wards/[id]/schedule-visitation.js
@@ -114,21 +114,21 @@ const Home = ({ id }) => {
 
   if (success) {
     return (
-      <Layout title="Schedule a virtual visitation">
+      <Layout title="Schedule a virtual visit">
         <GridRow>
           <GridColumn width="two-thirds">
-            <Heading>Virtual visitation scheduled</Heading>
+            <Heading>Virtual visit scheduled</Heading>
 
             <Text>
-              Your virtual visitation has been scheduled and the key contact has
-              been sent an SMS with their scheduled time.
+              Your virtual visit has been scheduled and the key contact has been
+              sent an SMS with their scheduled time.
             </Text>
 
             <ActionLink href={`/wards/${id}/schedule-visitation`}>
-              Schedule another visitation
+              Schedule another visit
             </ActionLink>
             <ActionLink href={`/wards/${id}/visitations`}>
-              View visitations
+              View visits
             </ActionLink>
           </GridColumn>
         </GridRow>
@@ -137,15 +137,12 @@ const Home = ({ id }) => {
   }
 
   return (
-    <Layout
-      title="Schedule a virtual visitation"
-      hasErrors={errors.length != 0}
-    >
+    <Layout title="Schedule a virtual visit" hasErrors={errors.length != 0}>
       <GridRow>
         <GridColumn width="two-thirds">
           <ErrorSummary errors={errors} />
           <form onSubmit={onSubmit}>
-            <Heading>Schedule a virtual visitation</Heading>
+            <Heading>Schedule a virtual visit</Heading>
             <FormGroup>
               <Label htmlFor="patient-name">What's the patients name?</Label>
               <Input
@@ -189,9 +186,7 @@ const Home = ({ id }) => {
                 errorMessage="Enter a valid date"
               ></DateSelect>
               <br></br>
-              <Button className="nhsuk-u-margin-top-5">
-                Schedule visitation
-              </Button>
+              <Button className="nhsuk-u-margin-top-5">Schedule visit</Button>
             </FormGroup>
           </form>
         </GridColumn>

--- a/pages/wards/[id]/visitations.js
+++ b/pages/wards/[id]/visitations.js
@@ -12,7 +12,7 @@ import { useState } from "react";
 
 export default function WardVisits({ scheduledCalls, error, id }) {
   const [userError, setUserError] = useState(
-    error ? "Unable to display ward visitations" : null
+    error ? "Unable to display ward visits" : null
   );
 
   const joinCall = async ({ callId, contactNumber }) => {
@@ -53,26 +53,26 @@ export default function WardVisits({ scheduledCalls, error, id }) {
   }
 
   return (
-    <Layout title="Ward visitations">
+    <Layout title="Ward visits">
       <GridRow>
         <GridColumn width="full">
-          <Heading>Ward visitations</Heading>
-          <h2 className="nhsuk-heading-l">Schedule a new visitation</h2>
+          <Heading>Ward visits</Heading>
+          <h2 className="nhsuk-heading-l">Schedule a new visit</h2>
           <Text>
             You'll need the mobile number of your patient's loved one in order
-            to set up a visitation.
+            to set up a visit.
           </Text>
           <ActionLink href={`/wards/${id}/schedule-visitation`}>
-            Schedule visitation
+            Schedule visit
           </ActionLink>
-          <h2 className="nhsuk-heading-l">Pre-booked visitations</h2>
+          <h2 className="nhsuk-heading-l">Pre-booked visits</h2>
           {scheduledCalls.length > 0 ? (
             <VisitationsTable
               visitations={scheduledCalls}
               joinCall={joinCall}
             />
           ) : (
-            <Text>There are no upcoming visitations.</Text>
+            <Text>There are no upcoming visits.</Text>
           )}
         </GridColumn>
       </GridRow>

--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -20,7 +20,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
   return (
     <>
       <FormGroup>
-        <Label>What is the date of their virtual visitation?</Label>
+        <Label>What is the date of their virtual visit?</Label>
         <Hint>For example, 16 4 2020</Hint>
         {hasError ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
         <div className="nhsuk-date-input__item">
@@ -73,7 +73,7 @@ const DateSelect = ({ onChange, hasError, errorMessage }) => {
         </div>
       </FormGroup>
       <FormGroup>
-        <Label>What is the time of their virtual visitation?</Label>
+        <Label>What is the time of their virtual visit?</Label>
         <Hint>For example, 15 00</Hint>
         <div className="nhsuk-date-input__item">
           <Label>Hour</Label>

--- a/src/components/VisitationsTable/index.js
+++ b/src/components/VisitationsTable/index.js
@@ -6,9 +6,7 @@ const formatDate = (date) => moment(date).format("D MMMM YYYY, h.mma");
 const Visitations = ({ visitations, joinCall }) => (
   <div className="nhsuk-table-responsive">
     <table className="nhsuk-table">
-      <caption className="nhsuk-table__caption">
-        List of ward visitations
-      </caption>
+      <caption className="nhsuk-table__caption">List of ward visits</caption>
       <thead className="nhsuk-table__head">
         <tr className="nhsuk-table__row">
           <th className="nhsuk-table__header" scope="col">

--- a/src/usecases/createVisitation.js
+++ b/src/usecases/createVisitation.js
@@ -1,7 +1,7 @@
 const createVisitation = ({ getDb }) => async (visitation) => {
   const db = getDb();
 
-  console.log("Creating visitation for ", visitation);
+  console.log("Creating visit for ", visitation);
   return await db.one(
     `INSERT INTO scheduled_calls_table
       (id, patient_name, recipient_number, call_time, call_id)


### PR DESCRIPTION
https://trello.com/c/wj2m4sWS/94-change-virtual-visitations-to-virtual-visits-across-all-screens-and-text-messages

# What
Renamed all instances of 'Visitations' to 'Visits' in the content

# Why
Because visitations it not the right word to use in this context 👽 

# Screenshots
![Screenshot 2020-04-20 at 12 11 04](https://user-images.githubusercontent.com/7527178/79745367-0d06a780-8300-11ea-93ac-a4870507b594.png)
![Screenshot 2020-04-20 at 12 11 14](https://user-images.githubusercontent.com/7527178/79745372-0e37d480-8300-11ea-8e6c-f4b6c0d2ecb2.png)

# Notes
We will do the file changes in a separate PR as they require potentially breaking changes