### PR TITLE
Prevent generating an invalid default date and time on scheduling form

### DIFF
--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -4,15 +4,18 @@ import Input from "../../../src/components/Input";
 import Label from "../../../src/components/Label";
 import ErrorMessage from "../ErrorMessage";
 import FormGroup from "../FormGroup";
+import moment from "moment";
 
 const DateSelect = ({ onChange, hasError, errorMessage }) => {
   const today = new Date();
+  var defaultDate = moment(today).add(10, "m").toDate();
+
   const [date, setDate] = useState({
-    year: today.getFullYear(),
-    month: today.getMonth(),
-    day: today.getDate(),
-    hour: today.getHours(),
-    minute: today.getMinutes() + 10,
+    year: defaultDate.getFullYear(),
+    month: defaultDate.getMonth(),
+    day: defaultDate.getDate(),
+    hour: defaultDate.getHours().toString().padStart(2, "0"),
+    minute: defaultDate.getMinutes().toString().padStart(2, "0"),
   });
 
   useEffect(() => onChange(date), [date]);


### PR DESCRIPTION
# What

Refactor the default date on the "Schedule a visit" form to use the `add` function of `Moment.js` instead of adding time to the minutes of the date.

# Why

To prevent an invalid time being generated like "18 68". 

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/79842354-9aa1d000-83b0-11ea-93c4-2ff9ab89d1b0.png)

# Notes

Added padding of zeros as that how we specify we want the input in the hint text. Does that make sense?
