### PR TITLE
Add sendTextMessage usecase

### DIFF
--- a/src/usecases/sendTextMessage.js
+++ b/src/usecases/sendTextMessage.js
@@ -1,0 +1,23 @@
+const sendTextMessage = ({ getNotifyClient }) => async (
+  templateId,
+  phoneNumber,
+  personalisation,
+  reference
+) => {
+  const notifyClient = getNotifyClient();
+
+  try {
+    await notifyClient.sendSms(
+      templateId,
+      phoneNumber,
+      personalisation,
+      reference
+    );
+
+    return { success: true, error: null };
+  } catch (error) {
+    return { success: false, error: error };
+  }
+};
+
+export default sendTextMessage;

--- a/src/usecases/sendTextMessage.test.js
+++ b/src/usecases/sendTextMessage.test.js
@@ -1,0 +1,54 @@
+import sendTextMessage from "./sendTextMessage";
+
+describe("sendTextMessage", () => {
+  let sendSmsSpy;
+  let container;
+
+  beforeEach(() => {
+    sendSmsSpy = jest.fn();
+    container = {
+      getNotifyClient: () => ({ sendSms: sendSmsSpy }),
+    };
+  });
+
+  it("sends a text message", async () => {
+    const templateId = "meow-woof-quack";
+    const phoneNumber = "07123456789";
+    const personalisation = { name_of_doggo: "Moon Moon" };
+    const reference = "text-message-one";
+
+    await sendTextMessage(container)(
+      templateId,
+      phoneNumber,
+      personalisation,
+      reference
+    );
+
+    expect(sendSmsSpy).toHaveBeenCalledWith(
+      templateId,
+      phoneNumber,
+      personalisation,
+      reference
+    );
+  });
+
+  it("returns success if successfully sends a text message", async () => {
+    const response = await sendTextMessage(container)("", "", {}, "");
+
+    expect(response).toEqual({ success: true, error: null });
+  });
+
+  it("returns the error if Notify raises an error", async () => {
+    container = {
+      getNotifyClient: () => ({
+        sendSms: () => {
+          throw "Error message";
+        },
+      }),
+    };
+
+    const response = await sendTextMessage(container)("", "", {}, {});
+
+    expect(response).toEqual({ success: false, error: "Error message" });
+  });
+});


### PR DESCRIPTION
# What

Add a usecase for sending text messages.

# Why

We want to remove the need for creating a Notify client every time we send a text message and also make it easier to test in API endpoints. Next step is to refactor places that send text messages to use the usecase instead.

# Screenshots

N/A

# Notes

Related PR: https://github.com/madetech/nhs-virtual-visit/pull/76.
