### PR TITLE
Use propsWithContainer in /visits/end

### DIFF
--- a/pageTests/visits/end.test.js
+++ b/pageTests/visits/end.test.js
@@ -37,30 +37,28 @@ describe("end", () => {
   });
 
   describe("getServerSideProps", () => {
-    it("provides the ward id if the user is authenticated", () => {
-      process.env.JWT_SIGNING_KEY = "test-key";
-      const tokenProvider = new TokenProvider(process.env.JWT_SIGNING_KEY);
-      const token = tokenProvider.generate("test-ward-id");
+    const req = {
+      headers: {
+        cookie: "",
+      },
+    };
 
-      const req = {
-        headers: {
-          cookie: `token=${token}`,
-        },
+    it("provides the ward id if the user is authenticated", () => {
+      const container = {
+        getUserIsAuthenticated: () => () => ({ ward: "test-ward-id" }),
       };
 
-      const { props } = getServerSideProps({ req });
+      const { props } = getServerSideProps({ req, container });
 
       expect(props.wardId).toEqual("test-ward-id");
     });
 
     it("does not provides the ward id if the user is unauthenticated", () => {
-      const req = {
-        headers: {
-          cookie: "",
-        },
+      const container = {
+        getUserIsAuthenticated: () => () => false,
       };
 
-      const { props } = getServerSideProps({ req });
+      const { props } = getServerSideProps({ req, container });
 
       expect(props.wardId).toBeNull();
     });

--- a/pages/visits/end.js
+++ b/pages/visits/end.js
@@ -3,6 +3,7 @@ import Layout from "../../src/components/Layout";
 import ActionLink from "../../src/components/ActionLink";
 import userIsAuthenticated from "../../src/usecases/userIsAuthenticated";
 import TokenProvider from "../../src/providers/TokenProvider";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
 
 export default ({ wardId }) => (
   <Layout>
@@ -55,11 +56,12 @@ export default ({ wardId }) => (
   </Layout>
 );
 
-export const getServerSideProps = ({ req: { headers }, res }) => {
-  const token = userIsAuthenticated({
-    getTokenProvider: () => new TokenProvider(process.env.JWT_SIGNING_KEY),
-  })(headers.cookie);
-  console.log(token);
+export const getServerSideProps = propsWithContainer(
+  ({ req: { headers }, container }) => {
+    const userIsAuthenticated = container.getUserIsAuthenticated();
 
-  return { props: { wardId: token?.ward || null } };
-};
+    const token = userIsAuthenticated(headers.cookie);
+
+    return { props: { wardId: token?.ward || null } };
+  }
+);

--- a/src/middleware/propsWithContainer.js
+++ b/src/middleware/propsWithContainer.js
@@ -2,5 +2,5 @@ import AppContainer from "../containers/AppContainer";
 
 export default (callback) => (context) => {
   context.container = context.container || new AppContainer();
-  callback(context);
+  return callback(context);
 };


### PR DESCRIPTION
# What
Continuing from #84, I have fixed a bug in that the ward staff would not have seen a link to go back to the list, and we now use the AppContainer in the end page `getServerSideProps` function. 

# Why
To make the code DRY

# Screenshots

# Notes
