### PR TITLE
Add node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "*.{js,css,md,yml}": [
       "prettier --write"
     ]
+  },
+  "engines": {
+    "node": "12.16.x"
   }
 }


### PR DESCRIPTION
# What
Add LTS node version to package.json file

# Why
Because Heroku has started complaining that it is not defined in the file, and has started failing builds because of it.

# Screenshots
![image](https://user-images.githubusercontent.com/2429225/80015409-97e6ce00-84c9-11ea-8fc8-a481c7fbaf31.png)

# Notes
