### PR TITLE
Remove call_time from personalisation of initial text message

### DIFF
--- a/pageTests/api/schedule-visit.test.js
+++ b/pageTests/api/schedule-visit.test.js
@@ -79,7 +79,6 @@ describe("schedule-visit", () => {
       "meow-woof-quack",
       "07123456789",
       {
-        call_time: "5 April 2020, 10.10am",
         ward_name: "Defoe Ward",
         hospital_name: "Northwick Park Hospital",
         visit_date: "5 April 2020",

--- a/pages/api/schedule-visit.js
+++ b/pages/api/schedule-visit.js
@@ -100,7 +100,6 @@ export default withContainer(
         templateId,
         body.contactNumber,
         {
-          call_time: formatDateAndTime(body.callTime),
           visit_date: formatDate(body.callTime),
           visit_time: formatTime(body.callTime),
           ward_name: "Defoe Ward",


### PR DESCRIPTION
# What

Remove `call_time` from personalisation when send the initial text message.

# Why

`call_time` is the combination of `visit_date` and `visit_time` so we no longer need to send this to Notify.

The templates on Notify for staging and production have already been updated to use `visit_date` and `visit_time`.

# Screenshots

N/A

# Notes

Related PRs:

1. #76 
2. #83
3. #92 
4. #97 
5. https://github.com/madetech/nhs-virtual-visit/pull/104