### PR TITLE
Allow staff to still see visits up to 4 hours instead of 30 minutes

### DIFF
--- a/src/usecases/retrieveVisits.js
+++ b/src/usecases/retrieveVisits.js
@@ -2,7 +2,7 @@ export default async function retrieveVisits({ getDb }) {
   const db = await getDb();
   try {
     const scheduledCalls = await db.any(
-      "SELECT * FROM scheduled_calls_table WHERE call_time > NOW() - INTERVAL '30 minutes' ORDER BY call_time ASC"
+      "SELECT * FROM scheduled_calls_table WHERE call_time > NOW() - INTERVAL '4 hours' ORDER BY call_time ASC"
     );
 
     return {


### PR DESCRIPTION
# What

Update the `retrieveVisits` usecase to get visits that are now - 4 hours.

# Why

We received user feedback regarding this and that 30 minutes is not long enough. 

# Screenshots

## Before

![screencapture-localhost-3000-wards-123-visits-2020-04-27-11_22_54](https://user-images.githubusercontent.com/42817036/80361912-9d516900-8879-11ea-933d-f26a03ef45cb.png)

## After

![screencapture-localhost-3000-wards-123-visits-2020-04-27-11_22_15](https://user-images.githubusercontent.com/42817036/80361917-9f1b2c80-8879-11ea-8267-05aa786447fa.png)

# Notes

N/A