### PR TITLE
Update start and end time of Whereby meetings

### DIFF
--- a/pages/api/schedule-visit.js
+++ b/pages/api/schedule-visit.js
@@ -12,7 +12,7 @@ const notifier = new ConsoleNotifyProvider();
 
 const wherebyCallId = async (callTime) => {
   let startTime = moment(callTime).format();
-  let endTime = moment(callTime).add(2, "hours").format();
+  let endTime = moment(callTime).add(1, "years").format();
 
   const response = await fetch("https://api.whereby.dev/v1/meetings", {
     method: "POST",

--- a/pages/api/schedule-visit.js
+++ b/pages/api/schedule-visit.js
@@ -11,7 +11,7 @@ const ids = new RandomIdProvider();
 const notifier = new ConsoleNotifyProvider();
 
 const wherebyCallId = async (callTime) => {
-  let startTime = moment(callTime).subtract(30, "minutes").format();
+  let startTime = moment(callTime).format();
   let endTime = moment(callTime).add(2, "hours").format();
 
   const response = await fetch("https://api.whereby.dev/v1/meetings", {


### PR DESCRIPTION
# What

- Update start time of Whereby meetings to the scheduled time
- Update end time of Whereby meetings to 1 year after the scheduled time

# Why

From user testing, we found out that visits considerably run over. So we want to increase the time that a meeting can last.

# Screenshots

N/A

# Notes

Wasn't able to double check that Whereby still works, if you can test locally might be worth it.