### PR TITLE
Update time formatting to be consistent against GOV.UK style

### DIFF
--- a/pageTests/api/schedule-visit.test.js
+++ b/pageTests/api/schedule-visit.test.js
@@ -84,7 +84,7 @@ describe("schedule-visit", () => {
         ward_name: "Defoe Ward",
         hospital_name: "Northwick Park Hospital",
         visit_date: "5 April 2020",
-        visit_time: "10.10am",
+        visit_time: "10:10am",
       },
       null
     );

--- a/pages/api/schedule-visit.js
+++ b/pages/api/schedule-visit.js
@@ -3,6 +3,9 @@ import ConsoleNotifyProvider from "../../src/providers/ConsoleNotifyProvider";
 import moment from "moment";
 import withContainer from "../../src/middleware/withContainer";
 import fetch from "node-fetch";
+import formatDateAndTime from "../../src/helpers/formatDateAndTime";
+import formatDate from "../../src/helpers/formatDate";
+import formatTime from "../../src/helpers/formatTime";
 
 const ids = new RandomIdProvider();
 const notifier = new ConsoleNotifyProvider();
@@ -27,10 +30,6 @@ const wherebyCallId = async (callTime) => {
   let roomUrl = new URL(jsonResponse.roomUrl);
   return roomUrl.pathname.slice(1);
 };
-
-const formatDateAndTime = (date) => moment(date).format("D MMMM YYYY, h.mma");
-const formatDate = (date) => moment(date).format("D MMMM YYYY");
-const formatTime = (date) => moment(date).format("h.mma");
 
 const getValidationErrors = ({
   patientName,

--- a/pages/wards/[id]/schedule-confirmation.js
+++ b/pages/wards/[id]/schedule-confirmation.js
@@ -7,6 +7,8 @@ import Layout from "../../../src/components/Layout";
 import fetch from "isomorphic-unfetch";
 import moment from "moment";
 import Router from "next/router";
+import formatDate from "../../../src/helpers/formatDate";
+import formatTime from "../../../src/helpers/formatTime";
 
 const ScheduleConfirmation = ({
   id,
@@ -110,7 +112,7 @@ const ScheduleConfirmation = ({
               <div className="nhsuk-summary-list__row">
                 <dt className="nhsuk-summary-list__key">Date of call</dt>
                 <dd className="nhsuk-summary-list__value">
-                  {moment(callTime).format("D MMMM YYYY")}
+                  {formatDate(callTime)}
                 </dd>
                 <dd className="nhsuk-summary-list__actions">
                   <a href="#" onClick={changeLink}>
@@ -126,7 +128,7 @@ const ScheduleConfirmation = ({
               <div className="nhsuk-summary-list__row">
                 <dt className="nhsuk-summary-list__key">Time of call</dt>
                 <dd className="nhsuk-summary-list__value">
-                  {moment(callTime).format("hh:mma")}
+                  {formatTime(callTime)}
                 </dd>
                 <dd className="nhsuk-summary-list__actions">
                   <a href="#" onClick={changeLink}>

--- a/pages/wards/[id]/visit-start.js
+++ b/pages/wards/[id]/visit-start.js
@@ -7,10 +7,11 @@ import Layout from "../../../src/components/Layout";
 import retrieveVisitByCallId from "../../../src/usecases/retrieveVisitByCallId";
 import propsWithContainer from "../../../src/middleware/propsWithContainer";
 import fetch from "isomorphic-unfetch";
-import moment from "moment";
 import Router from "next/router";
 import { useState } from "react";
 import Error from "next/error";
+import formatDate from "../../../src/helpers/formatDate";
+import formatTime from "../../../src/helpers/formatTime";
 
 const VisitStart = ({
   patientName,
@@ -100,8 +101,9 @@ export const getServerSideProps = propsWithContainer(
       callId
     );
 
-    const callTime = moment(scheduledCall.callTime).format("h.mma");
-    const callDate = moment(scheduledCall.callTime).format("D MMMM YYYY");
+    const callTime = formatTime(scheduledCall.callTime);
+    const callDate = formatDate(scheduledCall.callTime);
+
     return {
       props: {
         id,

--- a/src/components/VisitsTable/index.js
+++ b/src/components/VisitsTable/index.js
@@ -1,8 +1,6 @@
 import React from "react";
-import moment from "moment";
 import Router from "next/router";
-
-const formatDate = (date) => moment(date).format("D MMMM YYYY, h.mma");
+import formatDateAndTime from "../../helpers/formatDateAndTime";
 
 const Visits = ({ id, visits }) => (
   <div className="nhsuk-table-responsive">
@@ -31,7 +29,9 @@ const Visits = ({ id, visits }) => (
             <td className="nhsuk-table__cell">{visit.patientName}</td>
             <td className="nhsuk-table__cell">{visit.recipientName}</td>
             <td className="nhsuk-table__cell">{visit.recipientNumber}</td>
-            <td className="nhsuk-table__cell">{formatDate(visit.callTime)}</td>
+            <td className="nhsuk-table__cell">
+              {formatDateAndTime(visit.callTime)}
+            </td>
             <td className="nhsuk-table__cell">
               <button
                 className="nhsuk-button"

--- a/src/helpers/formatDate.js
+++ b/src/helpers/formatDate.js
@@ -1,0 +1,3 @@
+import moment from "moment";
+
+export default (time) => moment(time).format("D MMMM YYYY");

--- a/src/helpers/formatDate.test.js
+++ b/src/helpers/formatDate.test.js
@@ -1,0 +1,7 @@
+import formatDate from "./formatDate";
+
+describe("formatDate", () => {
+  it("returns the formatted date", () => {
+    expect(formatDate("2020-04-05T10:10:10")).toEqual("5 April 2020");
+  });
+});

--- a/src/helpers/formatDateAndTime.js
+++ b/src/helpers/formatDateAndTime.js
@@ -1,0 +1,3 @@
+import moment from "moment";
+
+export default (time) => moment(time).format("D MMMM YYYY, h:mma");

--- a/src/helpers/formatDateAndTime.test.js
+++ b/src/helpers/formatDateAndTime.test.js
@@ -1,0 +1,9 @@
+import formatDateAndTime from "./formatDateAndTime";
+
+describe("formatDateAndTime", () => {
+  it("returns the formatted date and time", () => {
+    expect(formatDateAndTime("2020-04-05T10:10:10")).toEqual(
+      "5 April 2020, 10:10am"
+    );
+  });
+});

--- a/src/helpers/formatTime.js
+++ b/src/helpers/formatTime.js
@@ -1,0 +1,3 @@
+import moment from "moment";
+
+export default (time) => moment(time).format("h:mma");

--- a/src/helpers/formatTime.test.js
+++ b/src/helpers/formatTime.test.js
@@ -1,0 +1,7 @@
+import formatTime from "./formatTime";
+
+describe("formatTime", () => {
+  it("returns the formatted time", () => {
+    expect(formatTime("2020-04-05T10:10:10")).toEqual("10:10am");
+  });
+});


### PR DESCRIPTION
# What

Make time formatting consistent across the service and what GOV.UK recommends - see https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times.

# Why

We're currently inconsistent and there's recommendations around this.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/42817036/80375819-ce896380-8890-11ea-87a7-f98f8856038a.png)

![image](https://user-images.githubusercontent.com/42817036/80375947-fd9fd500-8890-11ea-8436-f36ea35905a0.png)

## After

![image](https://user-images.githubusercontent.com/42817036/80375891-e52fba80-8890-11ea-9ab9-a99bcdeae13d.png)

![image](https://user-images.githubusercontent.com/42817036/80375922-f2e54000-8890-11ea-9131-7b205750daa3.png)

# Notes

😅 