### PR TITLE
Update page title of virtual visit scheduled to match page heading

### DIFF
--- a/pages/wards/[id]/schedule-success.js
+++ b/pages/wards/[id]/schedule-success.js
@@ -9,7 +9,7 @@ import TokenProvider from "../../../src/providers/TokenProvider";
 
 const Success = ({ id }) => {
   return (
-    <Layout title="Schedule a virtual visit">
+    <Layout title="Virtual visit scheduled">
       <GridRow>
         <GridColumn width="two-thirds">
           <Heading>Virtual visit scheduled</Heading>


### PR DESCRIPTION
# What

Update page title of "Virtual visit scheduled" instead "Schedule a virtual visit". 🍝 

# Why

It mismatched the page heading.

# Screenshots

N/A

# Notes

🍝 