### PR TITLE
Updated inline styling for inputs to set height instead of vertical p…

### DIFF
--- a/pages/wards/[id]/schedule-visit.js
+++ b/pages/wards/[id]/schedule-visit.js
@@ -174,7 +174,7 @@ const Home = ({
                 hasError={hasError("patient-name")}
                 errorMessage="Enter the patient's name"
                 className="nhsuk-u-font-size-32 nhsuk-input--width-10 nhsuk-u-margin-bottom-5"
-                style={{ padding: "32px 16px!important" }}
+                style={{ padding: "16px!important", height: "64px" }}
                 onChange={(event) => setPatientName(event.target.value)}
                 name="patient-name"
                 autoComplete="off"
@@ -190,7 +190,7 @@ const Home = ({
                 hasError={hasError("contact-name")}
                 errorMessage="Enter the key contact's name"
                 className="nhsuk-u-font-size-32 nhsuk-input--width-10 nhsuk-u-margin-bottom-5"
-                style={{ padding: "32px 16px!important" }}
+                style={{ padding: "16px!important", height: "64px" }}
                 onChange={(event) => setContactName(event.target.value)}
                 name="contact-name"
                 autoComplete="off"
@@ -215,7 +215,7 @@ const Home = ({
                 hasError={hasError("contact-number")}
                 errorMessage="Enter a UK mobile number"
                 className="nhsuk-u-font-size-32 nhsuk-input--width-10 nhsuk-u-margin-bottom-5"
-                style={{ padding: "32px 16px!important" }}
+                style={{ padding: "16px!important", height: "64px" }}
                 onChange={(event) => setContactNumber(event.target.value)}
                 value={contactNumber || ""}
                 name="contact"

--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -46,7 +46,7 @@ const DateSelect = ({
         <div className="nhsuk-date-input__item">
           <Label>Day</Label>
           <Input
-            style={{ padding: "32px 16px!important" }}
+            style={{ padding: "16px!important", height: "64px" }}
             type="number"
             hasError={hasDateError}
             onChange={(event) => {
@@ -62,7 +62,7 @@ const DateSelect = ({
         <div className="nhsuk-date-input__item">
           <Label>Month</Label>
           <Input
-            style={{ padding: "32px 16px!important" }}
+            style={{ padding: "16px!important", height: "64px" }}
             type="number"
             hasError={hasDateError}
             className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-u-font-size-32 nhsuk-input--width-10"
@@ -78,7 +78,7 @@ const DateSelect = ({
         <div className="nhsuk-date-input__item nhsuk-u-padding-bottom-5">
           <Label>Year</Label>
           <Input
-            style={{ padding: "32px 16px!important" }}
+            style={{ padding: "16px!important", height: "64px" }}
             type="number"
             hasError={hasDateError}
             className="nhsuk-input--width-4 nhsuk-u-font-size-32 nhsuk-input--width-10"
@@ -99,7 +99,7 @@ const DateSelect = ({
         <div className="nhsuk-date-input__item">
           <Label>Hour</Label>
           <Input
-            style={{ padding: "32px 16px!important" }}
+            style={{ padding: "16px!important", height: "64px" }}
             type="number"
             hasError={hasTimeError}
             className="nhsuk-input--width-2 nhsuk-u-font-size-32"
@@ -115,7 +115,7 @@ const DateSelect = ({
         <div className="nhsuk-date-input__item">
           <Label>Minutes</Label>
           <Input
-            style={{ padding: "32px 16px!important" }}
+            style={{ padding: "16px!important", height: "64px" }}
             type="number"
             hasError={hasTimeError}
             className="nhsuk-input--width-2 nhsuk-u-font-size-32"


### PR DESCRIPTION
…adding

# What
Change inline styling for inputs to use height instead of vertical padding so works in Firefox

# Why
Numeric input was not working on Firefox due to the large vertical padding.

# Screenshots
![image](https://user-images.githubusercontent.com/63007877/80398731-00f68900-88b0-11ea-903d-594e4755e2c1.png)

# Notes
