### PR TITLE
Single AppContainer and Database

### DIFF
--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -4,17 +4,11 @@ import userIsAuthenticated from "../usecases/userIsAuthenticated";
 import TokenProvider from "../providers/TokenProvider";
 import { NotifyClient } from "notifications-node-client";
 import { verifyTokenOrRedirect } from "../usecases/verifyToken";
+import Database from "../gateways/Database";
 
 class AppContainer {
-  async getDb() {
-    const { default: pgp } = await import("pg-promise");
-
-    return pgp()({
-      connectionString: process.env.URI,
-      ssl: {
-        rejectUnauthorized: false,
-      },
-    });
+  getDb() {
+    return Database.getInstance();
   }
 
   getCreateVisit() {

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -5,7 +5,7 @@ import TokenProvider from "../providers/TokenProvider";
 import { NotifyClient } from "notifications-node-client";
 import { verifyTokenOrRedirect } from "../usecases/verifyToken";
 
-export default class AppContainer {
+class AppContainer {
   async getDb() {
     const { default: pgp } = await import("pg-promise");
 
@@ -43,3 +43,18 @@ export default class AppContainer {
     return verifyTokenOrRedirect;
   }
 }
+
+export default (() => {
+  let instance;
+
+  return {
+    getInstance: () => {
+      if (!instance) {
+        instance = new AppContainer();
+        delete instance.constructor;
+      }
+
+      return instance;
+    },
+  };
+})();

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -5,11 +5,21 @@ describe("AppContainer", () => {
 
   beforeEach(() => {
     process.env.API_KEY = "notify-api-key-meow";
-    container = new AppContainer();
+    container = AppContainer.getInstance();
   });
 
   afterEach(() => {
     process.env.API_KEY = undefined;
+  });
+
+  it("provides a singleton", () => {
+    const instance = AppContainer.getInstance();
+
+    expect(instance).toBeDefined();
+
+    const secondInstance = AppContainer.getInstance();
+
+    expect(instance).toEqual(secondInstance);
   });
 
   it("returns getDb", async () => {

--- a/src/gateways/Database/index.js
+++ b/src/gateways/Database/index.js
@@ -1,0 +1,21 @@
+export default (() => {
+  let instance;
+
+  return {
+    getInstance: async () => {
+      if (!instance) {
+        const { default: pgp } = await import("pg-promise");
+
+        instance = pgp()({
+          connectionString: process.env.URI,
+          ssl: {
+            rejectUnauthorized: false,
+          },
+        });
+        delete instance.constructor;
+      }
+
+      return instance;
+    },
+  };
+})();

--- a/src/gateways/Database/index.test.js
+++ b/src/gateways/Database/index.test.js
@@ -1,0 +1,13 @@
+import Database from "./";
+
+describe("database", () => {
+  it("Produces a singleton", () => {
+    const instanceOne = Database.getInstance();
+
+    expect(instanceOne).toBeDefined();
+
+    const instanceTwo = Database.getInstance();
+
+    expect(instanceOne).toEqual(instanceTwo);
+  });
+});

--- a/src/middleware/propsWithContainer.js
+++ b/src/middleware/propsWithContainer.js
@@ -1,6 +1,6 @@
 import AppContainer from "../containers/AppContainer";
 
 export default (callback) => (context) => {
-  context.container = context.container || new AppContainer();
+  context.container = context.container || AppContainer.getInstance();
   return callback(context);
 };

--- a/src/middleware/propsWithContainer.test.js
+++ b/src/middleware/propsWithContainer.test.js
@@ -1,6 +1,8 @@
 import propsWithContainer from "./propsWithContainer";
 
-jest.mock("../containers/AppContainer");
+jest.mock("../containers/AppContainer", () => ({
+  getInstance: () => "mockedAppContainerInstance",
+}));
 
 describe("propsWithContainer", () => {
   it("creates and inserts an app container into the context", (done) => {

--- a/src/middleware/withContainer.js
+++ b/src/middleware/withContainer.js
@@ -3,7 +3,7 @@ import AppContainer from "../containers/AppContainer";
 export default (handler) => {
   return (req, res, ctx) => {
     ctx = ctx || {};
-    ctx.container = ctx.container || new AppContainer();
+    ctx.container = ctx.container || AppContainer.getInstance();
     return handler(req, res, ctx);
   };
 };


### PR DESCRIPTION
# What
Introduce singletons for the AppContainer and Database

# Why
In an effort to reduce the memory footprint of the app, and reduce the database connection warnings in the console


# Screenshots

# Notes
There are still warnings in the console that appear, I think this is due to the lifecycle within next.js, which I don't fully understand yet. However, this appears to reduce the number of db connections in the mean time.
