### PR TITLE
Add API endpoint to create a new ward

### DIFF
--- a/pageTests/api/create-ward.test.js
+++ b/pageTests/api/create-ward.test.js
@@ -36,14 +36,14 @@ describe("create-ward", () => {
     };
   });
 
-  it("returns 406 if not POST method", async () => {
+  it("returns 405 if not POST method", async () => {
     validRequest.method = "GET";
 
     await createWard(validRequest, response, {
       container: container,
     });
 
-    expect(response.status).toHaveBeenCalledWith(406);
+    expect(response.status).toHaveBeenCalledWith(405);
   });
 
   it("returns a 401 if no token provided", async () => {

--- a/pageTests/api/create-ward.test.js
+++ b/pageTests/api/create-ward.test.js
@@ -1,0 +1,200 @@
+import createWard from "../../pages/api/create-ward";
+import fetch from "node-fetch";
+
+jest.mock("node-fetch");
+
+describe("create-ward", () => {
+  let validRequest;
+  let response;
+  let container;
+
+  beforeEach(() => {
+    validRequest = {
+      method: "POST",
+      body: {
+        name: "Seto Kaiba Ward",
+        hospitalName: "Yugi Muto Hospital",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+    response = {
+      status: jest.fn(),
+      setHeader: jest.fn(),
+      send: jest.fn(),
+      end: jest.fn(),
+      body: jest.fn(),
+    };
+    container = {
+      getCreateWard: jest.fn().mockReturnValue(() => {
+        return { wardId: 1, error: null };
+      }),
+      getUserIsAuthenticated: jest
+        .fn()
+        .mockReturnValue((cookie) => cookie === "token=valid.token.value"),
+    };
+  });
+
+  it("returns 406 if not POST method", async () => {
+    validRequest.method = "GET";
+
+    await createWard(validRequest, response, {
+      container: container,
+    });
+
+    expect(response.status).toHaveBeenCalledWith(406);
+  });
+
+  it("returns a 401 if no token provided", async () => {
+    const userIsAuthenticatedSpy = jest.fn().mockReturnValue(false);
+
+    await createWard(
+      {
+        method: "POST",
+        body: {},
+        headers: {},
+      },
+      response,
+      {
+        container: {
+          ...container,
+          getUserIsAuthenticated: () => userIsAuthenticatedSpy,
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(userIsAuthenticatedSpy).toHaveBeenCalled();
+  });
+
+  it("creates a new ward if valid", async () => {
+    const createWardSpy = jest
+      .fn()
+      .mockReturnValue({ wardId: 123, error: null });
+
+    await createWard(validRequest, response, {
+      container: {
+        ...container,
+        getCreateWard: () => createWardSpy,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(createWardSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Seto Kaiba Ward",
+        hospitalName: "Yugi Muto Hospital",
+      })
+    );
+  });
+
+  it("returns a 400 status if errors", async () => {
+    const createWardStub = jest
+      .fn()
+      .mockReturnValue({ wardId: 123, error: "Error message" });
+
+    await createWard(validRequest, response, {
+      container: {
+        ...container,
+        getCreateWard: () => createWardStub,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns a 400 if the name is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "",
+        hospitalName: "Yugi Muto Hospital",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createWard(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "name must be present" })
+    );
+  });
+
+  it("returns a 400 if the name is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        hospitalName: "Yugi Muto Hospital",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createWard(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "name must be present" })
+    );
+  });
+
+  it("returns a 400 if the hospital name is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Seto Kaiba Ward",
+        hospitalName: "",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createWard(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "hospital name must be present" })
+    );
+  });
+
+  it("returns a 400 if the hospital name is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Seto Kaiba Ward",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createWard(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "hospital name must be present" })
+    );
+  });
+});

--- a/pages/api/create-ward.js
+++ b/pages/api/create-ward.js
@@ -4,7 +4,7 @@ import fetch from "node-fetch";
 export default withContainer(
   async ({ headers, body, method }, res, { container }) => {
     if (method !== "POST") {
-      res.status(406);
+      res.status(405);
       res.end();
       return;
     }

--- a/pages/api/create-ward.js
+++ b/pages/api/create-ward.js
@@ -1,0 +1,49 @@
+import withContainer from "../../src/middleware/withContainer";
+import fetch from "node-fetch";
+
+export default withContainer(
+  async ({ headers, body, method }, res, { container }) => {
+    if (method !== "POST") {
+      res.status(406);
+      res.end();
+      return;
+    }
+
+    const userIsAuthenticated = container.getUserIsAuthenticated();
+
+    if (!userIsAuthenticated(headers.cookie)) {
+      res.status(401);
+      res.end();
+      return;
+    }
+
+    if (!body.name || body.name.length === 0) {
+      res.status(400);
+      res.end(JSON.stringify({ err: "name must be present" }));
+      return;
+    }
+
+    if (!body.hospitalName || body.hospitalName.length === 0) {
+      res.status(400);
+      res.end(JSON.stringify({ err: "hospital name must be present" }));
+      return;
+    }
+
+    res.setHeader("Content-Type", "application/json");
+
+    const createWard = container.getCreateWard();
+
+    const { wardId, error } = await createWard({
+      name: body.name,
+      hospitalName: body.hospitalName,
+    });
+
+    if (error) {
+      res.status(400);
+      res.end();
+    } else {
+      res.status(201);
+      res.end();
+    }
+  }
+);

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -1,4 +1,5 @@
 import createVisit from "../usecases/createVisit";
+import createWard from "../usecases/createWard";
 import sendTextMessage from "../usecases/sendTextMessage";
 import userIsAuthenticated from "../usecases/userIsAuthenticated";
 import TokenProvider from "../providers/TokenProvider";
@@ -13,6 +14,10 @@ class AppContainer {
 
   getCreateVisit() {
     return createVisit(this);
+  }
+
+  getCreateWard() {
+    return createWard(this);
   }
 
   getTokenProvider() {

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -49,4 +49,8 @@ describe("AppContainer", () => {
   it("returns verifyTokenOrRedirect", () => {
     expect(container.getVerifyTokenOrRedirect()).toBeDefined();
   });
+
+  it("returns createWard", () => {
+    expect(container.getCreateWard()).toBeDefined();
+  });
 });

--- a/src/usecases/createWard.js
+++ b/src/usecases/createWard.js
@@ -3,7 +3,7 @@ const createWard = ({ getDb }) => async (ward) => {
 
   try {
     console.log("Creating ward for ", ward);
-    const wardId = await db.one(
+    const createdWard = await db.one(
       `INSERT INTO wards
         (id, name, hospital_name)
         VALUES (default, $1, $2)
@@ -13,7 +13,7 @@ const createWard = ({ getDb }) => async (ward) => {
     );
 
     return {
-      wardId: wardId,
+      wardId: createdWard.id,
       error: null,
     };
   } catch (error) {

--- a/src/usecases/createWard.js
+++ b/src/usecases/createWard.js
@@ -1,15 +1,28 @@
 const createWard = ({ getDb }) => async (ward) => {
   const db = await getDb();
 
-  console.log("Creating ward for ", ward);
-  return await db.one(
-    `INSERT INTO wards
-      (id, name, hospital_name)
-      VALUES (default, $1, $2)
-      RETURNING id
-    `,
-    [ward.name, ward.hospitalName]
-  );
+  try {
+    console.log("Creating ward for ", ward);
+    const wardId = await db.one(
+      `INSERT INTO wards
+        (id, name, hospital_name)
+        VALUES (default, $1, $2)
+        RETURNING id
+      `,
+      [ward.name, ward.hospitalName]
+    );
+
+    return {
+      wardId: wardId,
+      error: null,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      wardId: null,
+      error: error.toString(),
+    };
+  }
 };
 
 export default createWard;

--- a/src/usecases/createWard.js
+++ b/src/usecases/createWard.js
@@ -1,0 +1,15 @@
+const createWard = ({ getDb }) => async (ward) => {
+  const db = await getDb();
+
+  console.log("Creating ward for ", ward);
+  return await db.one(
+    `INSERT INTO wards
+      (id, name, hospital_name)
+      VALUES (default, $1, $2)
+      RETURNING id
+    `,
+    [ward.name, ward.hospitalName]
+  );
+};
+
+export default createWard;

--- a/src/usecases/createWard.test.js
+++ b/src/usecases/createWard.test.js
@@ -2,7 +2,7 @@ import createWard from "./createWard";
 
 describe("createWard", () => {
   it("creates a ward in the db when valid", async () => {
-    const oneSpy = jest.fn().mockReturnValue(10);
+    const oneSpy = jest.fn().mockReturnValue({ id: 10 });
     const container = {
       async getDb() {
         return {

--- a/src/usecases/createWard.test.js
+++ b/src/usecases/createWard.test.js
@@ -16,9 +16,10 @@ describe("createWard", () => {
       hospitalName: "Test Hospital",
     };
 
-    const resultingId = await createWard(container)(request);
+    const { wardId, error } = await createWard(container)(request);
 
-    expect(resultingId).toEqual(10);
+    expect(wardId).toEqual(10);
+    expect(error).toBeNull();
 
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.name,

--- a/src/usecases/createWard.test.js
+++ b/src/usecases/createWard.test.js
@@ -1,0 +1,28 @@
+import createWard from "./createWard";
+
+describe("createWard", () => {
+  it("creates a ward in the db when valid", async () => {
+    const oneSpy = jest.fn().mockReturnValue(10);
+    const container = {
+      async getDb() {
+        return {
+          one: oneSpy,
+        };
+      },
+    };
+
+    const request = {
+      name: "Defoe Ward",
+      hospitalName: "Test Hospital",
+    };
+
+    const resultingId = await createWard(container)(request);
+
+    expect(resultingId).toEqual(10);
+
+    expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
+      request.name,
+      request.hospitalName,
+    ]);
+  });
+});


### PR DESCRIPTION
# What

- Add a `createWard` usecase
- Add `AppContainer#getCreateWard` method
- Add `/api/create-ward` endpoint with validation to check that `name` and `hospitalName` is provided

# Why

We want to be able to support multiple wards.

# Screenshots

N/A

# Notes

In a previous PR, we added the migration to add a `wards` table: https://github.com/madetech/nhs-virtual-visit/pull/130.

Best reviewed commit by commit.