### PR TITLE
Add ward id to scheduled calls

### DIFF
--- a/db/migrations/005_add_ward_id_to_scheduled_calls_table.sql
+++ b/db/migrations/005_add_ward_id_to_scheduled_calls_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scheduled_calls_table ADD ward_id int REFERENCES wards (id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -27,7 +27,8 @@ CREATE TABLE public.scheduled_calls_table (
     recipient_number text,
     call_id text,
     recipient_name character varying(255),
-    provider character varying(255) DEFAULT 'jitsi'::character varying NOT NULL
+    provider character varying(255) DEFAULT 'jitsi'::character varying NOT NULL,
+    ward_id integer
 );
 
 
@@ -118,6 +119,14 @@ ALTER TABLE ONLY public.scheduled_calls_table
 
 ALTER TABLE ONLY public.wards
     ADD CONSTRAINT wards_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: scheduled_calls_table scheduled_calls_table_ward_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_calls_table
+    ADD CONSTRAINT scheduled_calls_table_ward_id_fkey FOREIGN KEY (ward_id) REFERENCES public.wards(id);
 
 
 --


### PR DESCRIPTION
# What
Adds a ward_id foreign key to the scheduled calls table

# Why
This will eventually allow for support of multiple wards

# Screenshots

# Notes
Allowing for NULL ward_ids for now as we will need to seed the environments with ward records and then update the scheduled calls login to use the stored ward
