### PR TITLE
Set a NOT NULL constraint on scheduled_calls_table.ward_id

### DIFF
--- a/db/migrations/006_add_not_null_constraint_to_ward_id.sql
+++ b/db/migrations/006_add_not_null_constraint_to_ward_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scheduled_calls_table ALTER COLUMN ward_id SET NOT NUll;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE public.scheduled_calls_table (
     call_id text,
     recipient_name character varying(255),
     provider character varying(255) DEFAULT 'jitsi'::character varying NOT NULL,
-    ward_id integer
+    ward_id integer NOT NULL
 );
 
 


### PR DESCRIPTION
# What
Sets a NOT NULL constraint on scheduled_calls_table.ward_id

# Why
Ensure that scheduled calls are created with a ward assigned 

# Screenshots

# Notes
Old scheduled calls with no ward_id set will need to be updated before running this migration