### PR TITLE
Use ward id from token

### DIFF
--- a/pageTests/wards/schedule-visit.test.js
+++ b/pageTests/wards/schedule-visit.test.js
@@ -76,6 +76,44 @@ describe("ward/[id]/schedule-visit", () => {
         expect(props.id).toEqual("ward-id");
       });
     });
+
+    describe("returning from schedule-confirmation", () => {
+      it("provides the form data from query params", async () => {
+        const query = {
+          patientName: "Patient Name",
+          contactName: "Visitor Name",
+          contactNumber: "07123456789",
+          day: "4",
+          month: "12",
+          year: "2020",
+          hour: "13",
+          minute: "44",
+        };
+
+        const { props } = await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query,
+          container: {},
+        });
+
+        expect(props).toMatchObject(
+          expect.objectContaining({
+            initialPatientName: query.patientName,
+            initialContactName: query.contactName,
+            initialContactNumber: query.contactNumber,
+            initialCallDateTime: {
+              day: query.day,
+              month: query.month,
+              year: query.year,
+              hour: query.hour,
+              minute: query.minute,
+            },
+          })
+        );
+      });
+    });
+
     describe("with rebookCallId parameter", () => {
       it("provides the visit records from the database", async () => {
         const container = {

--- a/pageTests/wards/schedule-visit.test.js
+++ b/pageTests/wards/schedule-visit.test.js
@@ -46,9 +46,7 @@ describe("ward/[id]/schedule-visit", () => {
       const { props } = await getServerSideProps({
         req: authenticatedReq,
         res,
-        query: {
-          id: "ward-id",
-        },
+        query: {},
         container,
       });
 
@@ -67,13 +65,11 @@ describe("ward/[id]/schedule-visit", () => {
         const { props } = await getServerSideProps({
           req: authenticatedReq,
           res,
-          query: {
-            id: "ward-id",
-          },
+          query: {},
           container,
         });
         expect(res.writeHead).not.toHaveBeenCalled();
-        expect(props.id).toEqual("ward-id");
+        expect(props.id).toEqual("123");
       });
     });
 
@@ -137,13 +133,12 @@ describe("ward/[id]/schedule-visit", () => {
           req: authenticatedReq,
           res,
           query: {
-            id: "ward-id",
             rebookCallId: "cat-meow",
           },
           container,
         });
         expect(res.writeHead).not.toHaveBeenCalled();
-        expect(props.id).toEqual("ward-id");
+        expect(props.id).toEqual("123");
         expect(props.initialPatientName).toEqual("Fred Bloggs");
         expect(props.initialContactName).toEqual("John Doe");
         expect(props.initialContactNumber).toEqual("07001231234");

--- a/pages/api/send-visit-ready-notification.js
+++ b/pages/api/send-visit-ready-notification.js
@@ -5,10 +5,12 @@ const notifier = new ConsoleNotifyProvider();
 
 export default withContainer(async (req, res, { container }) => {
   const { body, method } = req;
-  const tokenProvider = container.getTokenProvider();
-  const verifyTokenOrRedirect = container.getVerifyTokenOrRedirect();
+  const cookie = req.headers.cookie;
+  const userIsAuthenticated = container.getUserIsAuthenticated();
 
-  if (verifyTokenOrRedirect(req, res, { tokens: tokenProvider }) !== true) {
+  if (userIsAuthenticated(cookie) !== true) {
+    res.status(401);
+    res.end();
     return;
   }
 

--- a/pages/wards/[id]/schedule-visit.js
+++ b/pages/wards/[id]/schedule-visit.js
@@ -253,8 +253,8 @@ const queryContainsInitialData = (query) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyToken(
-    async ({ query, container }) => {
-      const { id } = query;
+    async ({ query, container, authenticationToken }) => {
+      const id = authenticationToken.ward;
       let props = { id };
       if (queryContainsInitialData(query)) {
         const {

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -42,10 +42,6 @@ class AppContainer {
   getSendTextMessage() {
     return sendTextMessage(this);
   }
-
-  getVerifyTokenOrRedirect() {
-    return verifyTokenOrRedirect;
-  }
 }
 
 export default (() => {

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -46,10 +46,6 @@ describe("AppContainer", () => {
     expect(container.getSendTextMessage()).toBeDefined();
   });
 
-  it("returns verifyTokenOrRedirect", () => {
-    expect(container.getVerifyTokenOrRedirect()).toBeDefined();
-  });
-
   it("returns createWard", () => {
     expect(container.getCreateWard()).toBeDefined();
   });

--- a/src/usecases/verifyToken.js
+++ b/src/usecases/verifyToken.js
@@ -4,28 +4,14 @@ export default function (callback, container) {
   return function (context) {
     const { req, res } = context;
 
-    if (verifyTokenOrRedirect(req, res, container) === true) {
-      return callback(context) ?? { props: {} };
+    const authenticationToken = userIsAuthenticated({
+      getTokenProvider: () => container.tokens,
+    })(req.headers.cookie);
+
+    if (authenticationToken) {
+      return callback({ ...context, authenticationToken }) ?? { props: {} };
+    } else {
+      res.writeHead(302, { Location: "/wards/login" }).end();
     }
   };
-}
-
-export function verifyTokenOrRedirect(req, res, { tokens }) {
-  const redirectToLogin = () => {
-    res.writeHead(302, { Location: "/wards/login" }).end();
-  };
-
-  try {
-    if (
-      !userIsAuthenticated({ getTokenProvider: () => tokens })(
-        req.headers.cookie
-      )
-    ) {
-      return redirectToLogin();
-    }
-
-    return true;
-  } catch (error) {
-    return redirectToLogin();
-  }
 }

--- a/src/usecases/verifyToken.test.js
+++ b/src/usecases/verifyToken.test.js
@@ -15,14 +15,17 @@ describe("verifyToken", () => {
   it("calls the supplied callback if the token is valid", async () => {
     const expectedProps = { a: 1 };
     const callback = jest.fn(() => expectedProps);
+    const authenticationToken = {
+      foo: true,
+    };
     const container = {
       tokens: {
-        validate: jest.fn(() => true),
+        validate: jest.fn(() => authenticationToken),
       },
     };
 
     const result = verifyToken(callback, container)({ req, res });
-    expect(callback).toHaveBeenCalledWith({ req, res });
+    expect(callback).toHaveBeenCalledWith({ req, res, authenticationToken });
     expect(result).toBe(expectedProps);
   });
 
@@ -33,6 +36,21 @@ describe("verifyToken", () => {
         validate: jest.fn(() => false),
       },
     };
+
+    verifyToken(callback, container)({ req, res });
+    expect(res.writeHead).toHaveBeenCalledWith(302, {
+      Location: "/wards/login",
+    });
+  });
+
+  it("redirects if there are no cookies", async () => {
+    const callback = jest.fn();
+    const container = {
+      tokens: {
+        validate: jest.fn(() => false),
+      },
+    };
+    req.headers.cookie = "";
 
     verifyToken(callback, container)({ req, res });
     expect(res.writeHead).toHaveBeenCalledWith(302, {


### PR DESCRIPTION
# What
Refactor verifyToken to provide the getServerSideProps with the authenticationToken if valid.
Use auth token to retrieve ward ID

# Why
Prepare for removing ward id from url path

# Screenshots

# Notes
