### PR TITLE
Add new 'Attend a virtual visit' page for visitors

### DIFF
--- a/pages/visitors/[id]/start.js
+++ b/pages/visitors/[id]/start.js
@@ -1,0 +1,49 @@
+import React, { useCallback } from "react";
+import { GridRow, GridColumn } from "../../../src/components/Grid";
+import Layout from "../../../src/components/Layout";
+import Heading from "../../../src/components/Heading";
+import Lead from "../../../src/components/Lead";
+import Text from "../../../src/components/Text";
+import Button from "../../../src/components/Button";
+
+const Start = () => {
+  const onSubmit = useCallback(async (event) => {
+    event.preventDefault();
+  });
+
+  return (
+    <Layout title="Attend a virtual visit">
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <Heading>Attend a virtual visit</Heading>
+          <Lead>
+            Attend a virtual visit is a new service for the London North West
+            University Healthcare Trust being trialled to connect patients with
+            their visitor via virtual visits.
+          </Lead>
+
+          <h2 className="nhsuk-heading-l">Confirm the patient's identity</h2>
+
+          <Text>
+            You must be ready to confirm the <b>patient name</b> and{" "}
+            <b>date of birth</b> to the NHS staff member when you join the video
+            call.
+          </Text>
+
+          <h2 className="nhsuk-heading-l">Do not take screenshots</h2>
+
+          <Text>
+            During your virtual visit you <b>must not take screenshots</b>, as
+            this will break patient confidentiality. This virtual visit is not a
+            medical visit, medical questions may not be answered during this
+            visit.
+          </Text>
+
+          <Button onSubmit={onSubmit}>Start now</Button>
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export default Start;


### PR DESCRIPTION
# What

Add a new start page for visitors to see to provide them with guidance around the service.

# Why

We want to provide guidance as to what to expect and not do up front. Simply adding this to our current "Join a virtual visit" page will be overloading and may be missed. As a result, we want to split that page into first guidance and then the form to enter their name.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/80587114-eafeda80-8a0d-11ea-8b00-65cf8dc8db67.png)

# Notes

This will be the first of 3 PRs. Next steps are to add a new page for entering their name and then updating the link provided in the text message.