### PR TITLE
Add new separate visitor name page

### DIFF
--- a/pages/visitors/[id]/name.js
+++ b/pages/visitors/[id]/name.js
@@ -1,0 +1,93 @@
+import React, { useCallback, useState } from "react";
+import { useRouter } from "next/router";
+import Button from "../../../src/components/Button";
+import FormGroup from "../../../src/components/FormGroup";
+import { GridRow, GridColumn } from "../../../src/components/Grid";
+import Hint from "../../../src/components/Hint";
+import Input from "../../../src/components/Input";
+import Layout from "../../../src/components/Layout";
+import LabelHeader from "../../../src/components/LabelHeader";
+import Text from "../../../src/components/Text";
+import BackLink from "../../../src/components/BackLink";
+import ErrorSummary from "../../../src/components/ErrorSummary";
+
+const Name = () => {
+  const router = useRouter();
+  const nameError = "Enter your name";
+  const [name, setName] = useState("");
+  const [errors, setErrors] = useState([]);
+
+  const hasError = (field) =>
+    errors.find((error) => error.id === `${field}-error`);
+
+  const onSubmit = useCallback(async (event) => {
+    event.preventDefault();
+    const errors = [];
+
+    if (!name) {
+      errors.push({
+        id: "name-error",
+        message: nameError,
+      });
+    }
+
+    setErrors(errors);
+
+    if (errors.length === 0) {
+      router.push(`/visits/${router.query.id}?name=${name}`);
+    }
+  });
+
+  return (
+    <Layout
+      title="What is your name? - Attend a virtual visit"
+      hasErrors={errors.length != 0}
+    >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <BackLink href={`/visitors/${router.query.id}/start`}>
+            Go back
+          </BackLink>
+
+          <ErrorSummary errors={errors} />
+
+          <form onSubmit={onSubmit}>
+            <FormGroup>
+              <LabelHeader
+                htmlFor="name"
+                className="nhsuk-label nhsuk-label--xl"
+              >
+                <span className="nhsuk-caption-l">
+                  Attend a virtual visit
+                  <span className="nhsuk-u-visually-hidden">-</span>
+                </span>
+                What is your name?
+              </LabelHeader>
+
+              <Hint>This will be displayed on the video call.</Hint>
+
+              <Input
+                id="name"
+                type="text"
+                onChange={(event) => setName(event.target.value)}
+                hasError={hasError("name")}
+                errorMessage={nameError}
+                name="name"
+              />
+
+              <Text className="nhsuk-body nhsuk-u-margin-top-4">
+                You may be required to download an app. This will depend on your
+                device and software installed on it. If this is the case, then
+                instructions will be provided.
+              </Text>
+
+              <Button>Attend visit</Button>
+            </FormGroup>
+          </form>
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export default Name;

--- a/pages/visitors/[id]/name.js
+++ b/pages/visitors/[id]/name.js
@@ -13,6 +13,10 @@ import ErrorSummary from "../../../src/components/ErrorSummary";
 
 const Name = () => {
   const router = useRouter();
+
+  const backLink = (
+    <BackLink href={`/visitors/${router.query.id}/start`}>Go back</BackLink>
+  );
   const nameError = "Enter your name";
   const [name, setName] = useState("");
   const [errors, setErrors] = useState([]);
@@ -42,13 +46,10 @@ const Name = () => {
     <Layout
       title="What is your name? - Attend a virtual visit"
       hasErrors={errors.length != 0}
+      backLink={backLink}
     >
       <GridRow>
         <GridColumn width="two-thirds">
-          <BackLink href={`/visitors/${router.query.id}/start`}>
-            Go back
-          </BackLink>
-
           <ErrorSummary errors={errors} />
 
           <form onSubmit={onSubmit}>

--- a/pages/visitors/[id]/start.js
+++ b/pages/visitors/[id]/start.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { useRouter } from "next/router";
 import { GridRow, GridColumn } from "../../../src/components/Grid";
 import Layout from "../../../src/components/Layout";
 import Heading from "../../../src/components/Heading";
@@ -7,8 +8,11 @@ import Text from "../../../src/components/Text";
 import Button from "../../../src/components/Button";
 
 const Start = () => {
-  const onSubmit = useCallback(async (event) => {
+  const onClick = useCallback(async (event) => {
     event.preventDefault();
+
+    const router = useRouter();
+    router.push(`/visitors/${router.query.id}/name`);
   });
 
   return (
@@ -39,7 +43,7 @@ const Start = () => {
             visit.
           </Text>
 
-          <Button onSubmit={onSubmit}>Start now</Button>
+          <Button onClick={onClick}>Start now</Button>
         </GridColumn>
       </GridRow>
     </Layout>

--- a/pages/visitors/[id]/start.js
+++ b/pages/visitors/[id]/start.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { useRouter } from "next/router";
 import { GridRow, GridColumn } from "../../../src/components/Grid";
 import Layout from "../../../src/components/Layout";
@@ -8,12 +8,8 @@ import Text from "../../../src/components/Text";
 import Button from "../../../src/components/Button";
 
 const Start = () => {
-  const onClick = useCallback(async (event) => {
-    event.preventDefault();
-
-    const router = useRouter();
-    router.push(`/visitors/${router.query.id}/name`);
-  });
+  const router = useRouter();
+  const onClick = () => router.push(`/visitors/${router.query.id}/name`);
 
   return (
     <Layout title="Attend a virtual visit">

--- a/src/components/BackLink/index.js
+++ b/src/components/BackLink/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+const BackLink = ({ href, children }) => (
+  <div className="nhsuk-back-link">
+    <a className="nhsuk-back-link__link" href={href}>
+      <svg
+        className="nhsuk-icon nhsuk-icon__chevron-left"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+      </svg>
+      {children}
+    </a>
+  </div>
+);
+
+export default BackLink;

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,7 +1,13 @@
 import { styles } from "./styles.scss";
 import Head from "next/head";
 
-const Layout = ({ title, hasErrors, children, mainStyleOverride }) => (
+const Layout = ({
+  title,
+  hasErrors,
+  children,
+  backLink,
+  mainStyleOverride,
+}) => (
   <>
     <Head>
       <title>
@@ -35,6 +41,7 @@ const Layout = ({ title, hasErrors, children, mainStyleOverride }) => (
         style={mainStyleOverride ? { paddingTop: "0" } : {}}
       >
         {children}
+        {backLink}
       </main>
     </div>
   </>


### PR DESCRIPTION
# What

Add a new separate visitor name page and a `BackLink` component.

# Why

We want to provide guidance as to what to expect and not do up front. Simply adding this to our current "Join a virtual visit" page will be overloading and may be missed. As a result, we want to split that page into first guidance and then the form to enter their name.

# Screenshots (Updated 14:07)

![image](https://user-images.githubusercontent.com/42817036/80599399-c5300080-8a22-11ea-8dd2-cbc6473dc40b.png)

# Notes

Previous PR https://github.com/madetech/nhs-virtual-visit/pull/143, added the new start page for a visitor.

Next step is to update the link in the second text message to the visitor.