### PR TITLE
Update visitor link in second text message when call is ready

### DIFF
--- a/pageTests/api/send-visit-ready-notification.test.js
+++ b/pageTests/api/send-visit-ready-notification.test.js
@@ -78,7 +78,7 @@ describe("send-visit-ready-notification", () => {
         "meow-woof-quack",
         "07123456789",
         {
-          call_url: "http://localhost:3000/visitors/waiting-room/much-wow",
+          call_url: "http://localhost:3000/visitors/much-wow/start",
           ward_name: "Defoe Ward",
           hospital_name: "Northwick Park Hospital",
         },

--- a/pages/api/send-visit-ready-notification.js
+++ b/pages/api/send-visit-ready-notification.js
@@ -22,7 +22,7 @@ export default withContainer(async (req, res, { container }) => {
 
   let { callId, contactNumber } = body;
 
-  const waitingRoomUrl = `${process.env.ORIGIN}/visitors/waiting-room/${callId}`;
+  const visitorsUrl = `${process.env.ORIGIN}/visitors/${callId}/start`;
   const visitsUrl = `${process.env.ORIGIN}/visits/${callId}?name=Ward`;
 
   const sendTextMessage = container.getSendTextMessage();
@@ -33,7 +33,7 @@ export default withContainer(async (req, res, { container }) => {
       templateId,
       contactNumber,
       {
-        call_url: waitingRoomUrl,
+        call_url: visitorsUrl,
         ward_name: "Defoe Ward",
         hospital_name: "Northwick Park Hospital",
       },
@@ -41,7 +41,7 @@ export default withContainer(async (req, res, { container }) => {
     );
 
     if (response.success) {
-      notifier.notify(body.contactNumber, waitingRoomUrl);
+      notifier.notify(body.contactNumber, visitorsUrl);
 
       res.status(201);
       res.end(JSON.stringify({ id: callId, callUrl: visitsUrl }));


### PR DESCRIPTION
# What

Update the link we send in the text message we send to a visitor when the call is ready to be the new start page.

# Why

We want to provide guidance as to what to expect and not do up front. Simply adding this to our current "Join a virtual visit" page will be overloading and may be missed. As a result, we want to split that page into first guidance and then the form to enter their name.

# Screenshots

N/A

# Notes

Related PRs:

- Adding new visitor start page - https://github.com/madetech/nhs-virtual-visit/pull/143
- Adding new visitor name page - https://github.com/madetech/nhs-virtual-visit/pull/145

Once we have thoroughly tested on staging we can remove the old page.