### PR TITLE
Migration for adding ward_code to the database

### DIFF
--- a/db/migrations/007_add_ward_code_to_wards_table.sql
+++ b/db/migrations/007_add_ward_code_to_wards_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE wards ADD code VARCHAR(255);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -59,7 +59,8 @@ ALTER SEQUENCE public.scheduled_calls_table_id_seq OWNED BY public.scheduled_cal
 CREATE TABLE public.wards (
     id integer NOT NULL,
     name character varying(255) NOT NULL,
-    hospital_name character varying(255) NOT NULL
+    hospital_name character varying(255) NOT NULL,
+    code character varying(255)
 );
 
 


### PR DESCRIPTION
# What

Adds the `ward_code` to the database for use in the future

# Why

So that we can stop storing `ward_codes` in environment variables

# Screenshots

# Notes

- This is **nullable** for now as making it `NOT NULL` will cause failures, subsequent PR will address this
