### PR TITLE
Add verify ward code use case

### DIFF
--- a/src/usecases/verifyWardCode.js
+++ b/src/usecases/verifyWardCode.js
@@ -1,0 +1,25 @@
+const verifyWardCode = ({ getDb }) => async (wardCode) => {
+  const db = await getDb();
+
+  try {
+    const dbResponse = await db.any(
+      `SELECT code FROM wards WHERE code = $1 LIMIT 1`,
+      [wardCode]
+    );
+
+    if (dbResponse.length > 0) {
+      return { validWardCode: true, error: null };
+    } else {
+      return { validWardCode: false, error: null };
+    }
+  } catch (error) {
+    console.log(error);
+
+    return {
+      validWardCode: false,
+      error: error.toString(),
+    };
+  }
+};
+
+export default verifyWardCode;

--- a/src/usecases/verifyWardCode.test.js
+++ b/src/usecases/verifyWardCode.test.js
@@ -1,0 +1,53 @@
+import verifyWardCode from "./verifyWardCode";
+
+describe("verifyWardCode", () => {
+  describe("Given a matching ward code", () => {
+    it("Returns true", async () => {
+      const container = {
+        getDb: async () => ({
+          any: jest.fn(async () => [
+            {
+              id: 1,
+              name: "Ward name",
+              hospital_name: "London Meowdical Hospital",
+              ward_code: "MEOW",
+            },
+          ]),
+        }),
+      };
+
+      let response = await verifyWardCode(container)("MEOW");
+      expect(response.validWardCode).toEqual(true);
+    });
+  });
+
+  describe("Given a non matching ward code", () => {
+    it("Returns false", async () => {
+      const container = {
+        getDb: async () => ({
+          any: jest.fn(async () => []),
+        }),
+      };
+
+      let response = await verifyWardCode(container)("WOOF");
+      expect(response.validWardCode).toEqual(false);
+    });
+  });
+
+  describe("Given a DB error", () => {
+    it("Returns an error", async () => {
+      const container = {
+        async getDb() {
+          return {
+            any: jest.fn(() => {
+              throw new Error("DB Error!");
+            }),
+          };
+        },
+      };
+
+      let response = await verifyWardCode(container)("MEOW");
+      expect(response.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
# What

Add use case for verifying ward codes against the DB

# Why

So that we can begin to authorize against the DB rather than environment variables

# Screenshots

# Notes
