### PR TITLE
Update page title and heading of ward login

### DIFF
--- a/pages/wards/login.js
+++ b/pages/wards/login.js
@@ -49,15 +49,18 @@ const Login = () => {
   });
 
   return (
-    <Layout title="Log in" hasErrors={errors.length > 0}>
+    <Layout
+      title="Log in to book a virtual visit"
+      hasErrors={errors.length > 0}
+    >
       <GridRow>
-        <GridColumn width="one-half">
+        <GridColumn width="two-thirds">
           <ErrorSummary errors={errors} />
-          <Heading>Log in</Heading>
+          <Heading>Log in to book a virtual visit</Heading>
 
           <form onSubmit={onSubmit}>
             <FormGroup>
-              <Label htmlFor="name">Ward code</Label>
+              <Label htmlFor="code">Ward code</Label>
               <Hint>You'll have been given a ward code to use.</Hint>
               <Input
                 id="code"


### PR DESCRIPTION
# What

- Update page title and heading of ward login from "Log in" to "Log in to book a virtual visit".
- Make it two-thirds as this is the common layout.

# Why

We received some feedback related to this.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/80694304-3aa3db80-8acc-11ea-8ea4-ccad27f3f906.png)

# Notes

N/A