### PR TITLE
Remove old TEMPLATE_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ URI=
 ORIGIN=
 # GovNotify Initial Template ID
 SMS_INITIAL_TEMPLATE_ID=
-TEMPLATE_ID=
 # GovNotify Join Template ID
 SMS_JOIN_TEMPLATE_ID=
 # Valid Ward Codes

--- a/pageTests/api/send-visit-ready-notification.test.js
+++ b/pageTests/api/send-visit-ready-notification.test.js
@@ -58,12 +58,12 @@ describe("send-visit-ready-notification", () => {
         },
         headers: { cookie: "token=valid.token.value" },
       };
-      process.env.TEMPLATE_ID = "meow-woof-quack";
+      process.env.SMS_JOIN_TEMPLATE_ID = "meow-woof-quack";
       process.env.ORIGIN = "http://localhost:3000";
     });
 
     afterEach(() => {
-      process.env.TEMPLATE_ID = undefined;
+      process.env.SMS_JOIN_TEMPLATE_ID = undefined;
       process.env.ORIGIN = undefined;
     });
 

--- a/pages/api/send-visit-ready-notification.js
+++ b/pages/api/send-visit-ready-notification.js
@@ -26,7 +26,7 @@ export default withContainer(async (req, res, { container }) => {
   const visitsUrl = `${process.env.ORIGIN}/visits/${callId}?name=Ward`;
 
   const sendTextMessage = container.getSendTextMessage();
-  const templateId = process.env.TEMPLATE_ID;
+  const templateId = process.env.SMS_JOIN_TEMPLATE_ID;
 
   try {
     // Passing in null as we don't care about the ID just yet


### PR DESCRIPTION
# What
Tech debt

# Why
We don't need two template env vars for the joijn SMS

# Screenshots

# Notes
Best to check that the `SMS_JOIN_TEMPLATE_ID` is populated properly in all environments