### PR TITLE
Add constraints to ward code table

### DIFF
--- a/db/migrations/008_add_unique_and_not_null_to_wards_code.sql
+++ b/db/migrations/008_add_unique_and_not_null_to_wards_code.sql
@@ -1,0 +1,2 @@
+ALTER TABLE wards ALTER COLUMN code SET NOT NUll;
+ALTER TABLE wards ADD UNIQUE(code);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -60,7 +60,7 @@ CREATE TABLE public.wards (
     id integer NOT NULL,
     name character varying(255) NOT NULL,
     hospital_name character varying(255) NOT NULL,
-    code character varying(255)
+    code character varying(255) NOT NULL
 );
 
 
@@ -112,6 +112,14 @@ ALTER TABLE ONLY public.scheduled_calls_table
 
 ALTER TABLE ONLY public.scheduled_calls_table
     ADD CONSTRAINT scheduled_calls_table_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: wards wards_code_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wards
+    ADD CONSTRAINT wards_code_key UNIQUE (code);
 
 
 --


### PR DESCRIPTION
# What

Add `UNIQUE` and `NOT NULL` constraints to the wards table

# Why

To ensure data integrity as we scale up
