### PR TITLE
Update to use 24 hours time format when booking

### DIFF
--- a/pageTests/wards/cancel-visit-confirmation.test.js
+++ b/pageTests/wards/cancel-visit-confirmation.test.js
@@ -87,7 +87,7 @@ describe("ward/cancel-visit-confirmation", () => {
         expect(props.contactName).toEqual("John Doe");
         expect(props.contactNumber).toEqual("07001231234");
         expect(props.callDate).toEqual("20 April 2020");
-        expect(props.callTime).toEqual("5:20pm");
+        expect(props.callTime).toEqual("17:20");
       });
     });
   });

--- a/pageTests/wards/cancel-visit-success.test.js
+++ b/pageTests/wards/cancel-visit-success.test.js
@@ -86,7 +86,7 @@ describe("ward/cancel-visit-success", () => {
         expect(props.contactName).toEqual("John Doe");
         expect(props.contactNumber).toEqual("07001231234");
         expect(props.callDate).toEqual("20 April 2020");
-        expect(props.callTime).toEqual("5:20pm");
+        expect(props.callTime).toEqual("17:20");
       });
     });
   });

--- a/pages/wards/cancel-visit-confirmation.js
+++ b/pages/wards/cancel-visit-confirmation.js
@@ -115,7 +115,7 @@ export const getServerSideProps = propsWithContainer(
         };
       }
 
-      const callTime = formatTime(scheduledCall.callTime);
+      const callTime = formatTime(scheduledCall.callTime, "HH:mm");
       const callDate = formatDate(scheduledCall.callTime);
 
       return {

--- a/pages/wards/cancel-visit-success.js
+++ b/pages/wards/cancel-visit-success.js
@@ -95,7 +95,7 @@ export const getServerSideProps = propsWithContainer(
         };
       }
 
-      const callTime = formatTime(scheduledCall.callTime);
+      const callTime = formatTime(scheduledCall.callTime, "HH:mm");
       const callDate = formatDate(scheduledCall.callTime);
 
       let { success, error: deleteError } = await deleteVisitByCallId(

--- a/pages/wards/schedule-confirmation.js
+++ b/pages/wards/schedule-confirmation.js
@@ -129,7 +129,7 @@ const ScheduleConfirmation = ({
               <div className="nhsuk-summary-list__row">
                 <dt className="nhsuk-summary-list__key">Time of call</dt>
                 <dd className="nhsuk-summary-list__value">
-                  {formatTime(callTime)}
+                  {formatTime(callTime, "HH:mm")}
                 </dd>
                 <dd className="nhsuk-summary-list__actions">
                   <a href="#" onClick={changeLink}>

--- a/pages/wards/visit-start.js
+++ b/pages/wards/visit-start.js
@@ -100,7 +100,7 @@ export const getServerSideProps = propsWithContainer(
         callId
       );
 
-      const callTime = formatTime(scheduledCall.callTime);
+      const callTime = formatTime(scheduledCall.callTime, "HH:mm");
       const callDate = formatDate(scheduledCall.callTime);
 
       return {

--- a/src/components/VisitsTable/index.js
+++ b/src/components/VisitsTable/index.js
@@ -30,7 +30,7 @@ const Visits = ({ visits }) => (
             <td className="nhsuk-table__cell">{visit.recipientName}</td>
             <td className="nhsuk-table__cell">{visit.recipientNumber}</td>
             <td className="nhsuk-table__cell">
-              {formatDateAndTime(visit.callTime)}
+              {formatDateAndTime(visit.callTime, "HH:mm")}
             </td>
             <td className="nhsuk-table__cell">
               <button

--- a/src/helpers/formatDateAndTime.js
+++ b/src/helpers/formatDateAndTime.js
@@ -1,3 +1,4 @@
 import moment from "moment";
 
-export default (time) => moment(time).format("D MMMM YYYY, h:mma");
+export default (time, timeFormat = "h:mma") =>
+  moment(time).format(`D MMMM YYYY, ${timeFormat}`);

--- a/src/helpers/formatDateAndTime.test.js
+++ b/src/helpers/formatDateAndTime.test.js
@@ -6,4 +6,10 @@ describe("formatDateAndTime", () => {
       "5 April 2020, 10:10am"
     );
   });
+
+  it("returns the formatted date and time with time format provided", () => {
+    expect(formatDateAndTime("2020-04-05T17:10:10", "HH:mm")).toEqual(
+      "5 April 2020, 17:10"
+    );
+  });
 });

--- a/src/helpers/formatTime.js
+++ b/src/helpers/formatTime.js
@@ -1,3 +1,3 @@
 import moment from "moment";
 
-export default (time) => moment(time).format("h:mma");
+export default (time, timeFormat = "h:mma") => moment(time).format(timeFormat);

--- a/src/helpers/formatTime.test.js
+++ b/src/helpers/formatTime.test.js
@@ -4,4 +4,8 @@ describe("formatTime", () => {
   it("returns the formatted time", () => {
     expect(formatTime("2020-04-05T10:10:10")).toEqual("10:10am");
   });
+
+  it("returns the formatted time with time format provided", () => {
+    expect(formatTime("2020-04-05T17:10:10", "HH:mm")).toEqual("17:10");
+  });
 });


### PR DESCRIPTION
# What

- Update our formatting time helpers to take in a time format
- Update NHS staff member pages to use 24 hours time format

# Why

We received feedback around this with a preference for 24 hours.

# Screenshots

🕐 

# Notes

N/A