### PR TITLE
Store ward id in token

### DIFF
--- a/pageTests/api/session.test.js
+++ b/pageTests/api/session.test.js
@@ -55,10 +55,13 @@ describe("api/session", () => {
 
         const verifyWardCodeSpy = jest.fn(async () => ({
           validWardCode: true,
+          ward: { id: 10, code: "MEOW" },
         }));
+        const tokenGeneratorSpy = jest.fn(() => "generatedToken");
+
         const container = {
           getTokenProvider: jest.fn(() => ({
-            generate: jest.fn(() => "generatedToken"),
+            generate: tokenGeneratorSpy,
           })),
           getVerifyWardCode: () => verifyWardCodeSpy,
         };
@@ -66,6 +69,10 @@ describe("api/session", () => {
         await session(validRequest, response, { container });
 
         expect(verifyWardCodeSpy).toHaveBeenCalledWith("MEOW");
+        expect(tokenGeneratorSpy).toHaveBeenCalledWith({
+          wardId: 10,
+          wardCode: "MEOW",
+        });
         expect(response.writeHead).toHaveBeenCalledWith(
           201,
           expect.objectContaining({

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -13,7 +13,8 @@ export default withContainer(
       }
 
       const tokens = container.getTokenProvider();
-      const token = tokens.generate(code);
+      const { ward } = verifyWardCodeResponse;
+      const token = tokens.generate({ wardId: ward.id, wardCode: ward.code });
       const expiryHours = 2;
       let expiry = new Date();
       expiry.setTime(expiry.getTime() + expiryHours * 60 * 60 * 1000);

--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -5,8 +5,10 @@ class TokenProvider {
     this.signingKey = signingKey;
   }
 
-  generate(ward) {
-    return jwt.sign({ ward }, this.signingKey, { algorithm: "HS256" });
+  generate({ wardId, wardCode }) {
+    return jwt.sign({ wardId, ward: wardCode }, this.signingKey, {
+      algorithm: "HS256",
+    });
   }
 
   validate(token) {

--- a/src/usecases/verifyWardCode.js
+++ b/src/usecases/verifyWardCode.js
@@ -8,7 +8,13 @@ const verifyWardCode = ({ getDb }) => async (wardCode) => {
     );
 
     if (dbResponse.length > 0) {
-      return { validWardCode: true, error: null };
+      let [ward] = dbResponse;
+
+      return {
+        validWardCode: true,
+        ward: { id: ward.id, code: ward.code },
+        error: null,
+      };
     } else {
       return { validWardCode: false, error: null };
     }

--- a/src/usecases/verifyWardCode.test.js
+++ b/src/usecases/verifyWardCode.test.js
@@ -2,7 +2,7 @@ import verifyWardCode from "./verifyWardCode";
 
 describe("verifyWardCode", () => {
   describe("Given a matching ward code", () => {
-    it("Returns true", async () => {
+    it("Returns true with the matching ward ID", async () => {
       const container = {
         getDb: async () => ({
           any: jest.fn(async () => [
@@ -10,7 +10,7 @@ describe("verifyWardCode", () => {
               id: 1,
               name: "Ward name",
               hospital_name: "London Meowdical Hospital",
-              ward_code: "MEOW",
+              code: "MEOW",
             },
           ]),
         }),
@@ -18,6 +18,10 @@ describe("verifyWardCode", () => {
 
       let response = await verifyWardCode(container)("MEOW");
       expect(response.validWardCode).toEqual(true);
+      expect(response.ward).toEqual({
+        id: 1,
+        code: "MEOW",
+      });
     });
   });
 


### PR DESCRIPTION
# What

Stores the ward id along side the code (currently `ward`) in the token

# Why

So that we can begin to use it elsewhere

# Screenshots

# Notes
