### PR TITLE
Add an admin flag to the API token if an admin code is used

### DIFF
--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -55,7 +55,7 @@ export const getServerSideProps = propsWithContainer(
   verifyToken(
     async ({ authenticationToken, container }) => {
       const { wardId } = authenticationToken;
-      console.log(authenticationToken);
+
       const { scheduledCalls, error } = await container.getRetrieveVisits()({
         wardId,
       });

--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -5,8 +5,8 @@ class TokenProvider {
     this.signingKey = signingKey;
   }
 
-  generate({ wardId, wardCode }) {
-    return jwt.sign({ wardId, ward: wardCode }, this.signingKey, {
+  generate({ wardId, wardCode, admin }) {
+    return jwt.sign({ wardId, ward: wardCode, admin: admin }, this.signingKey, {
       algorithm: "HS256",
     });
   }

--- a/src/usecases/userIsAuthenticated.js
+++ b/src/usecases/userIsAuthenticated.js
@@ -6,7 +6,13 @@ export default ({ getTokenProvider }) => (requestCookie) => {
   try {
     const { token } = cookie.parse(requestCookie);
 
-    return token && tokenProvider.validate(token);
+    const validatedToken = tokenProvider.validate(token);
+
+    if (token && validatedToken.admin) {
+      return false;
+    }
+
+    return token && validatedToken;
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
# What
Add an admin flag to the API token if an admin code is used

# Why
Allows us to eventually support admin users

# Screenshots

# Notes
Requires an ADMIN_AUTH_CODES env variable