### PR TITLE
Use DATABASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ In order to run this app locally you will need to add these variables to your `.
 API_KEY=
 # Postgres Connection String
 DATABASE_URL=
-URI=
 # GovNotify Initial Template ID
 SMS_INITIAL_TEMPLATE_ID=
 # GovNotify Join Template ID
@@ -105,11 +104,10 @@ Restart your PostgreSQL server and SSL will connections will be enabled
    ```bash
    cat db/schema.sql | psql nhs-virtual-visit-dev
    ```
-3. Add the database URI as an environment variable in `.env`. On Linux you may need to provide a username and password.
+3. Add the database URL as an environment variable in `.env`. On Linux you may need to provide a username and password.
    ```bash
-   cat <<<EOF > .env
-   DATABASE_URI=postgresql://localhost/nhs-virtual-visit-dev
-   URI=postgresql://localhost/nhs-virtual-visit-dev
+   cat <<<EOF >> .env
+   DATABASE_URL=postgresql://localhost/nhs-virtual-visit-dev
    EOF
    ```
 

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -3,7 +3,7 @@ async function getDb() {
   dotenv.config();
 
   const pgp = require("pg-promise")({});
-  const connectionURL = process.env.URI;
+  const connectionURL = process.env.DATABASE_URL;
   return pgp({
     connectionString: connectionURL,
     ssl: { rejectUnauthorized: false },

--- a/src/gateways/Database/index.js
+++ b/src/gateways/Database/index.js
@@ -7,7 +7,7 @@ export default (() => {
         const { default: pgp } = await import("pg-promise");
 
         instance = pgp()({
-          connectionString: process.env.URI,
+          connectionString: process.env.DATABASE_URL,
           ssl: {
             rejectUnauthorized: false,
           },


### PR DESCRIPTION
# What
Update the env var to use the correct DB connection string.

# Why
DATABASE_URL is automatically updated by Heroku and will always contain the correct value to connect to the right database.

It is likely that heroku will automatically refresh the credentials in the future, this would cause the service to fail.

# Screenshots

# Notes
