### PR TITLE
Add usecase for updating ward visit totals

### DIFF
--- a/src/usecases/updateWardVisitTotals.js
+++ b/src/usecases/updateWardVisitTotals.js
@@ -1,0 +1,27 @@
+export default ({ getDb }) => async ({ wardId, date }) => {
+  try {
+    const db = await getDb();
+    const res = await db.any(
+      "SELECT id, ward_id, total FROM ward_visit_totals WHERE ward_id = $1 AND total_date = $2",
+      [wardId, date.toISOString()]
+    );
+
+    const [existingTotal] = res;
+
+    if (existingTotal) {
+      await db.none("UPDATE ward_visit_totals SET total = $2 WHERE id = $1", [
+        existingTotal.id,
+        existingTotal.total + 1,
+      ]);
+    } else {
+      await db.one(
+        "INSERT INTO ward_visit_totals (ward_id, total_date, total) VALUES ($1, $2, $3)",
+        [wardId, date.toISOString(), 1]
+      );
+    }
+
+    return { success: true, error: undefined };
+  } catch (error) {
+    return { success: false, error };
+  }
+};

--- a/src/usecases/updateWardVisitTotals.test.js
+++ b/src/usecases/updateWardVisitTotals.test.js
@@ -1,0 +1,95 @@
+import updateWardVisitTotals from "./updateWardVisitTotals";
+
+describe("updateWardVisitTotals", () => {
+  const dateToInsert = new Date();
+
+  describe("given no value currently exists for the ward", () => {
+    it("inserts a new value for the ward and date", async () => {
+      const anySpy = jest.fn(async () => []);
+      const oneSpy = jest.fn(async () => 10);
+
+      const container = {
+        getDb: async () => {
+          return {
+            any: anySpy,
+            one: oneSpy,
+          };
+        },
+      };
+
+      let response = await updateWardVisitTotals(container)({
+        wardId: 1,
+        date: dateToInsert,
+      });
+
+      expect(anySpy).toHaveBeenCalledWith(expect.stringContaining("SELECT"), [
+        1,
+        dateToInsert.toISOString(),
+      ]);
+
+      expect(oneSpy).toHaveBeenCalledWith(expect.stringContaining("INSERT"), [
+        1,
+        dateToInsert.toISOString(),
+        1,
+      ]);
+
+      expect(response.success).toEqual(true);
+    });
+  });
+
+  describe("given a value currently exists for the ward", () => {
+    it("updates the existing value for the ward", async () => {
+      const anySpy = jest.fn(async () => [{ id: 10, wardId: 1, total: 1 }]);
+      const noneSpy = jest.fn(async () => {});
+
+      const container = {
+        getDb: async () => {
+          return {
+            any: anySpy,
+            none: noneSpy,
+          };
+        },
+      };
+
+      let response = await updateWardVisitTotals(container)({
+        wardId: 1,
+        date: dateToInsert,
+      });
+
+      expect(anySpy).toHaveBeenCalled();
+      expect(anySpy).toHaveBeenCalledWith(expect.stringContaining("SELECT"), [
+        1,
+        dateToInsert.toISOString(),
+      ]);
+
+      expect(noneSpy).toHaveBeenCalledWith(expect.stringContaining("UPDATE"), [
+        10,
+        2,
+      ]);
+      expect(response.success).toEqual(true);
+    });
+  });
+
+  describe("DB Errors", () => {
+    it("Returns success false", async () => {
+      const anySpy = jest.fn(async () => {
+        throw "DB Error";
+      });
+
+      const container = {
+        getDb: async () => {
+          return {
+            any: anySpy,
+          };
+        },
+      };
+      let response = await updateWardVisitTotals(container)({
+        wardId: 1,
+        date: dateToInsert,
+      });
+
+      expect(response.success).toEqual(false);
+      expect(response.error).toEqual("DB Error");
+    });
+  });
+});


### PR DESCRIPTION
# What

Inserts/Updates into the ward visit totals table

# Why

So that we can begin to track total number of scheduled visits per ward

# Screenshots

# Notes
