### PR TITLE
Add usecase for retrieving ward visit totals

### DIFF
--- a/src/usecases/retrieveWardVisitTotals.js
+++ b/src/usecases/retrieveWardVisitTotals.js
@@ -1,0 +1,22 @@
+const calculateTotalNumberOfVisits = (visitsByWard) =>
+  visitsByWard.reduce((total, { visits }) => total + visits, 0);
+
+const getVisitsByWard = async (db) => {
+  const queryResult = await db.any(
+    "SELECT wards.hospital_name, wards.name, SUM(totals.total) AS total_visits FROM ward_visit_totals AS totals JOIN wards ON wards.id = totals.ward_id GROUP BY(wards.name)"
+  );
+
+  return queryResult.map(({ hospital_name, total_visits, name }) => ({
+    hospitalName: hospital_name,
+    name,
+    visits: parseInt(total_visits),
+  }));
+};
+
+export default ({ getDb }) => async () => {
+  const db = await getDb();
+  const visitTotals = await getVisitsByWard(db);
+  const overallTotal = calculateTotalNumberOfVisits(visitTotals);
+
+  return { total: overallTotal, byWard: visitTotals };
+};

--- a/src/usecases/retrieveWardVisitTotals.test.js
+++ b/src/usecases/retrieveWardVisitTotals.test.js
@@ -1,0 +1,46 @@
+import retrieveWardVisitTotals from "./retrieveWardVisitTotals";
+
+describe("retrieveWardVisitTotals", () => {
+  describe("Given no visits", () => {
+    it("Returns 0 overall total", async () => {
+      const anySpy = jest.fn(async () => []);
+
+      const container = {
+        getDb: async () => ({
+          any: anySpy,
+        }),
+      };
+
+      const response = await retrieveWardVisitTotals(container)();
+
+      expect(anySpy).toHaveBeenCalled();
+      expect(response).toEqual({ total: 0, byWard: [] });
+    });
+  });
+
+  describe("Given some visits", () => {
+    it("Returns the totals per ward and the overall total", async () => {
+      const anySpy = jest.fn(async () => [
+        { hospital_name: "Hospital One", name: "Ward One", total_visits: "10" },
+        { hospital_name: "Hospital One", name: "Ward Two", total_visits: "20" },
+      ]);
+
+      const container = {
+        getDb: async () => ({
+          any: anySpy,
+        }),
+      };
+
+      let res = await retrieveWardVisitTotals(container)();
+
+      expect(anySpy).toHaveBeenCalled();
+      expect(res).toEqual({
+        total: 30,
+        byWard: [
+          { hospitalName: "Hospital One", name: "Ward One", visits: 10 },
+          { hospitalName: "Hospital One", name: "Ward Two", visits: 20 },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
# What

Adds use case to get ward visit totals out of the database, grouped by ward name

# Why

# Screenshots

# Notes
