### PR TITLE
Use APP_ENV for Sentry environment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,7 +55,7 @@ module.exports = withNextEnv(
           SENTRY_ORG &&
           SENTRY_PROJECT &&
           SENTRY_AUTH_TOKEN &&
-          (NODE_ENV === "production" || NODE_ENV === "staging")
+          NODE_ENV === "production"
         ) {
           config.plugins.push(
             new SentryWebpackPlugin({

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,7 +5,7 @@ import Head from "next/head";
 
 Sentry.init({
   enabled: process.env.ENABLE_SENTRY === "yes",
-  environment: process.env.NODE_ENV,
+  environment: process.env.APP_ENV || process.env.NODE_ENV,
   dsn: process.env.SENTRY_DSN,
 });
 


### PR DESCRIPTION
# What
Uses an APP_ENV env variable to distinguish staging from production (falls back to NODE_ENV if APP_ENV isn't present)

# Why
Separates our errors by the correct environment in Sentry

# Screenshots

# Notes
