### PR TITLE
Add skip to main content link

### DIFF
--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -19,6 +19,9 @@ const Layout = ({
         {isBookService ? "Book" : "Attend"} a virtual visit | LNWH
       </title>
     </Head>
+    <a className="nhsuk-skip-link" href="#maincontent">
+      Skip to main content
+    </a>
     <header className="nhsuk-header" role="banner">
       <div className="nhsuk-width-container nhsuk-header__container">
         <div className="nhsuk-header__logo nhsuk-header__logo--only">


### PR DESCRIPTION
# What

Add a skip to main content link.

# Why

For accessibility reasons - this allows keyboard-only users skip to the main content of a web page and navigate using the tab key to select links and form elements.

# Screenshots

![Screenshot 2020-05-07 at 08 45 36](https://user-images.githubusercontent.com/42817036/81267950-2e290100-903f-11ea-9f4e-f3fa213a7507.png)

# Notes

https://service-manual.nhs.uk/design-system/components/skip-link