### PR TITLE
Add an edit a ward page

### DIFF
--- a/pageTests/admin/edit-a-ward.test.js
+++ b/pageTests/admin/edit-a-ward.test.js
@@ -1,0 +1,93 @@
+import { getServerSideProps } from "../../pages/admin/edit-a-ward";
+
+// TODO: This needs to be moved once the verifyToken logic is in the container..
+jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
+  token && { admin: true }
+);
+
+const authenticatedReq = {
+  headers: {
+    cookie: "token=123",
+  },
+};
+
+describe("/admin/edit-a-ward", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+
+    describe("with wardId parameter", () => {
+      it("retrieves a ward by the wardId parameter", async () => {
+        const retrieveWardByIdSpy = jest.fn().mockReturnValue({
+          ward: {
+            id: 1,
+            name: "Defoe Ward",
+            hospitalName: "Northwick Park Hospital",
+          },
+          error: null,
+        });
+
+        const container = {
+          getWardById: () => retrieveWardByIdSpy,
+        };
+
+        await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query: {
+            wardId: "ward ID",
+          },
+          container,
+        });
+
+        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID");
+      });
+
+      it("set a ward prop based on the retrieved ward", async () => {
+        const retrieveWardByIdSpy = jest.fn().mockReturnValue({
+          ward: {
+            id: 1,
+            name: "Defoe Ward",
+            hospitalName: "Northwick Park Hospital",
+          },
+          error: null,
+        });
+
+        const container = {
+          getWardById: () => retrieveWardByIdSpy,
+        };
+
+        const { props } = await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query: {
+            wardId: "1",
+          },
+          container,
+        });
+
+        expect(props.name).toEqual("Defoe Ward");
+        expect(props.hospitalName).toEqual("Northwick Park Hospital");
+      });
+    });
+  });
+});

--- a/pages/admin/add-a-ward.js
+++ b/pages/admin/add-a-ward.js
@@ -4,7 +4,7 @@ import Layout from "../../src/components/Layout";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
 import TokenProvider from "../../src/providers/TokenProvider";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
-import WardForm from "../../src/components/WardForm";
+import AddWardForm from "../../src/components/AddWardForm";
 
 const AddAWard = () => {
   const [errors, setErrors] = useState([]);
@@ -17,7 +17,7 @@ const AddAWard = () => {
     >
       <GridRow>
         <GridColumn width="two-thirds">
-          <WardForm errors={errors} setErrors={setErrors} />
+          <AddWardForm errors={errors} setErrors={setErrors} />
         </GridColumn>
       </GridRow>
     </Layout>

--- a/pages/admin/edit-a-ward.js
+++ b/pages/admin/edit-a-ward.js
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import Error from "next/error";
+import { GridRow, GridColumn } from "../../src/components/Grid";
+import Layout from "../../src/components/Layout";
+import verifyAdminToken from "../../src/usecases/verifyAdminToken";
+import TokenProvider from "../../src/providers/TokenProvider";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+import EditWardForm from "../../src/components/EditWardForm";
+
+const EditAWard = ({ error, name, hospitalName }) => {
+  if (error) {
+    return <Error />;
+  }
+
+  const [errors, setErrors] = useState([]);
+
+  return (
+    <Layout
+      title="Edit a ward"
+      hasErrors={errors.length != 0}
+      renderLogout={true}
+    >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <EditWardForm
+            errors={errors}
+            setErrors={setErrors}
+            initialName={name}
+            initialHospitalName={hospitalName}
+          />
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyAdminToken(
+    async ({ container, query }) => {
+      const getWardById = container.getWardById();
+      const { ward, error } = await getWardById(query.wardId);
+
+      return {
+        props: {
+          error: error,
+          name: ward.name,
+          hospitalName: ward.hospitalName,
+        },
+      };
+    },
+    {
+      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
+    }
+  )
+);
+
+export default EditAWard;

--- a/src/components/AddWardForm/index.js
+++ b/src/components/AddWardForm/index.js
@@ -13,7 +13,7 @@ const isPresent = (input) => {
   }
 };
 
-const WardForm = ({ errors, setErrors }) => {
+const AddWardForm = ({ errors, setErrors }) => {
   const [hospitalName, setHospitalName] = useState("");
   const [wardName, setWardName] = useState("");
   const [wardCode, setWardCode] = useState("");
@@ -205,4 +205,4 @@ const WardForm = ({ errors, setErrors }) => {
   );
 };
 
-export default WardForm;
+export default AddWardForm;

--- a/src/components/EditWardForm/index.js
+++ b/src/components/EditWardForm/index.js
@@ -1,0 +1,108 @@
+import React, { useCallback, useState } from "react";
+import Button from "../Button";
+import FormGroup from "../FormGroup";
+import Heading from "../Heading";
+import Input from "../Input";
+import ErrorSummary from "../ErrorSummary";
+import Label from "../Label";
+
+const isPresent = (input) => {
+  if (input.length !== 0) {
+    return input;
+  }
+};
+
+const EditWardForm = ({
+  errors,
+  setErrors,
+  initialName,
+  initialHospitalName,
+}) => {
+  const [hospitalName, setHospitalName] = useState(initialName);
+  const [wardName, setWardName] = useState(initialHospitalName);
+
+  const hasError = (field) =>
+    errors.find((error) => error.id === `${field}-error`);
+
+  const errorMessage = (field) => {
+    const error = errors.filter((err) => err.id === `${field}-error`);
+    return error.length === 1 ? error[0].message : "";
+  };
+
+  const onSubmit = useCallback(async (event) => {
+    event.preventDefault();
+    const onSubmitErrors = [];
+
+    const setWardNameError = (errors) => {
+      errors.push({
+        id: "ward-name-error",
+        message: "Enter a ward name",
+      });
+    };
+
+    const setHospitalNameError = (errors) => {
+      errors.push({
+        id: "hospital-name-error",
+        message: "Enter a hospital name",
+      });
+    };
+
+    if (!isPresent(wardName)) {
+      setWardNameError(onSubmitErrors);
+    }
+    if (!isPresent(hospitalName)) {
+      setHospitalNameError(onSubmitErrors);
+    }
+
+    if (onSubmitErrors.length === 0) {
+      console.log("Edit a ward");
+    }
+
+    setErrors(onSubmitErrors);
+  });
+  return (
+    <>
+      <ErrorSummary errors={errors} />
+      <form onSubmit={onSubmit}>
+        <Heading>Edit a ward</Heading>
+        <FormGroup>
+          <Label htmlFor="ward-name" className="nhsuk-label--l">
+            What is the ward name?
+          </Label>
+          <Input
+            id="ward-name"
+            type="text"
+            hasError={hasError("ward-name")}
+            errorMessage={errorMessage("ward-name")}
+            className="nhsuk-u-font-size-32 nhsuk-input--width-10 nhsuk-u-margin-bottom-5"
+            style={{ padding: "16px!important", height: "64px" }}
+            onChange={(event) => setWardName(event.target.value)}
+            name="ward-name"
+            autoComplete="off"
+            value={wardName || ""}
+          />
+
+          <Label htmlFor="hospital-name" className="nhsuk-label--l">
+            What is the hospital name?
+          </Label>
+          <Input
+            id="hospital-name"
+            type="text"
+            hasError={hasError("hospital-name")}
+            errorMessage={errorMessage("hospital-name")}
+            className="nhsuk-u-font-size-32 nhsuk-input--width-10 nhsuk-u-margin-bottom-5"
+            style={{ padding: "16px!important", height: "64px" }}
+            onChange={(event) => setHospitalName(event.target.value)}
+            name="hospital-name"
+            autoComplete="off"
+            value={hospitalName || ""}
+          />
+          <br></br>
+          <Button className="nhsuk-u-margin-top-5">Edit ward</Button>
+        </FormGroup>
+      </form>
+    </>
+  );
+};
+
+export default EditWardForm;


### PR DESCRIPTION
# What

- Rename `WardForm` to `AddWardForm` component
- Add an `EditWardForm` component
- Add an edit a ward page

# Why

We want to allow an admin to edit a ward name and hospital name.

This is a second slice of allowing editing a ward. Next steps are to:

- create an `editWardById` usecase
- create an `/api/admin/update-ward` API endpoint
- call the endpoint when submitting the edit a ward form
- add edit a success page
- add a link from the ward administration table to edit

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/81570827-04524000-9399-11ea-9a01-46eed6ff8d37.png)

# Notes

N/A