### PR TITLE
Add updateWardById usecase

### DIFF
--- a/src/usecases/updateWard.js
+++ b/src/usecases/updateWard.js
@@ -1,0 +1,25 @@
+export default ({ getDb }) => async (ward) => {
+  const db = await getDb();
+  try {
+    const updatedWard = await db.one(
+      `UPDATE wards
+      SET name = $1,
+          hospital_name = $2
+      WHERE
+          id = $3
+      RETURNING id
+          `,
+      [ward.name, ward.hospitalName, ward.id]
+    );
+    return {
+      wardId: updatedWard.id,
+      error: null,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      wardId: null,
+      error: error.toString(),
+    };
+  }
+};

--- a/src/usecases/updateWard.test.js
+++ b/src/usecases/updateWard.test.js
@@ -1,0 +1,41 @@
+import updateWard from "./updateWard";
+
+describe("updateWard", () => {
+  it("updates a ward in the db when valid", async () => {
+    const oneSpy = jest.fn().mockReturnValue({ id: 10 });
+    const container = {
+      async getDb() {
+        return {
+          one: oneSpy,
+        };
+      },
+    };
+    const request = {
+      id: 10,
+      name: "Defoe Ward",
+      hospitalName: "Test Hospital",
+    };
+    const { wardId, error } = await updateWard(container)(request);
+    expect(wardId).toEqual(10);
+    expect(error).toBeNull();
+    expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
+      request.name,
+      request.hospitalName,
+      request.id,
+    ]);
+  });
+  it("returns an error object on db exception", async () => {
+    const container = {
+      async getDb() {
+        return {
+          one: jest.fn(() => {
+            throw new Error("DB Error!");
+          }),
+        };
+      },
+    };
+    const { wardId, error } = await updateWard(container)("rubbishRequest");
+    expect(error).toEqual("Error: DB Error!");
+    expect(wardId).toEqual(null);
+  });
+});


### PR DESCRIPTION
# What

Add a `updateWard` usecase.

# Why

To enable editing a ward. This usecase will be called by a new `/api/admin/update-ward` endpoint which will be created in the next PR.

# Screenshots

N/A

# Notes

N/A