### PR TITLE
Add a VisitSummaryList component

### DIFF
--- a/pageTests/wards/cancel-visit-confirmation.test.js
+++ b/pageTests/wards/cancel-visit-confirmation.test.js
@@ -64,7 +64,7 @@ describe("ward/cancel-visit-confirmation", () => {
                   patient_name: "Fred Bloggs",
                   recipient_name: "John Doe",
                   recipient_number: "07700900900",
-                  call_time: new Date("2020-04-20 17:20:00"),
+                  call_time: new Date("2020-04-15T23:00:00.000Z"),
                   call_id: "Test-Call-Id",
                   provider: "Test",
                 },
@@ -81,13 +81,11 @@ describe("ward/cancel-visit-confirmation", () => {
           container,
         });
         expect(res.writeHead).not.toHaveBeenCalled();
-        expect(props.callDate).toEqual("20 April 2020");
         expect(props.callId).toEqual("Test-Call-Id");
         expect(props.patientName).toEqual("Fred Bloggs");
         expect(props.contactName).toEqual("John Doe");
         expect(props.contactNumber).toEqual("07700900900");
-        expect(props.callDate).toEqual("20 April 2020");
-        expect(props.callTime).toEqual("17:20");
+        expect(props.callDateAndTime).toEqual("2020-04-15T23:00:00.000Z");
       });
     });
   });

--- a/pageTests/wards/cancel-visit-success.test.js
+++ b/pageTests/wards/cancel-visit-success.test.js
@@ -64,7 +64,7 @@ describe("ward/cancel-visit-success", () => {
                   patient_name: "Fred Bloggs",
                   recipient_name: "John Doe",
                   recipient_number: "07700900900",
-                  call_time: new Date("2020-04-20 17:20:00"),
+                  call_time: new Date("2020-04-15T23:00:00.000Z"),
                   call_id: "Test-Call-Id",
                   provider: "Test",
                 },
@@ -81,12 +81,10 @@ describe("ward/cancel-visit-success", () => {
           container,
         });
         expect(res.writeHead).not.toHaveBeenCalled();
-        expect(props.callDate).toEqual("20 April 2020");
         expect(props.patientName).toEqual("Fred Bloggs");
         expect(props.contactName).toEqual("John Doe");
         expect(props.contactNumber).toEqual("07700900900");
-        expect(props.callDate).toEqual("20 April 2020");
-        expect(props.callTime).toEqual("17:20");
+        expect(props.callDateAndTime).toEqual("2020-04-15T23:00:00.000Z");
       });
     });
   });

--- a/pages/wards/book-a-visit-confirmation.js
+++ b/pages/wards/book-a-visit-confirmation.js
@@ -7,10 +7,9 @@ import Layout from "../../src/components/Layout";
 import fetch from "isomorphic-unfetch";
 import moment from "moment";
 import Router from "next/router";
-import formatDate from "../../src/helpers/formatDate";
-import formatTime from "../../src/helpers/formatTime";
 import verifyToken from "../../src/usecases/verifyToken";
 import TokenProvider from "../../src/providers/TokenProvider";
+import VisitSummaryList from "../../src/components/VisitSummaryList";
 
 const ScheduleConfirmation = ({
   patientName,
@@ -68,85 +67,16 @@ const ScheduleConfirmation = ({
         <GridColumn width="two-thirds">
           <form onSubmit={onSubmit}>
             <Heading>Check your answers before booking a virtual visit</Heading>
-            <dl className="nhsuk-summary-list">
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Patient name</dt>
-                <dd className="nhsuk-summary-list__value">{patientName}</dd>
-                <dd className="nhsuk-summary-list__actions">
-                  <a href="#" onClick={changeLink}>
-                    Change
-                    <span className="nhsuk-u-visually-hidden">
-                      {" "}
-                      patient name
-                    </span>
-                  </a>
-                </dd>
-              </div>
 
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">
-                  Key contact&apos;s name
-                </dt>
-                <dd className="nhsuk-summary-list__value">{contactName}</dd>
-                <dd className="nhsuk-summary-list__actions">
-                  <a href="#" onClick={changeLink}>
-                    Change
-                    <span className="nhsuk-u-visually-hidden">
-                      {" "}
-                      key contact&apos;s name
-                    </span>
-                  </a>
-                </dd>
-              </div>
+            <VisitSummaryList
+              patientName={patientName}
+              visitorName={contactName}
+              visitorMobileNumber={contactNumber}
+              visitDateAndTime={callTime}
+              withActions={true}
+              actionLinkOnClick={changeLink}
+            ></VisitSummaryList>
 
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">
-                  Key contact&apos;s mobile number
-                </dt>
-                <dd className="nhsuk-summary-list__value">{contactNumber}</dd>
-                <dd className="nhsuk-summary-list__actions">
-                  <a href="#" onClick={changeLink}>
-                    Change
-                    <span className="nhsuk-u-visually-hidden">
-                      {" "}
-                      key contact&apos;s mobile number
-                    </span>
-                  </a>
-                </dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Date of call</dt>
-                <dd className="nhsuk-summary-list__value">
-                  {formatDate(callTime)}
-                </dd>
-                <dd className="nhsuk-summary-list__actions">
-                  <a href="#" onClick={changeLink}>
-                    Change
-                    <span className="nhsuk-u-visually-hidden">
-                      {" "}
-                      date of call
-                    </span>
-                  </a>
-                </dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Time of call</dt>
-                <dd className="nhsuk-summary-list__value">
-                  {formatTime(callTime, "HH:mm")}
-                </dd>
-                <dd className="nhsuk-summary-list__actions">
-                  <a href="#" onClick={changeLink}>
-                    Change
-                    <span className="nhsuk-u-visually-hidden">
-                      {" "}
-                      time of call
-                    </span>
-                  </a>
-                </dd>
-              </div>
-            </dl>
             <h2 className="nhsuk-heading-l">
               Key contact&apos;s mobile number
             </h2>

--- a/pages/wards/cancel-visit-confirmation.js
+++ b/pages/wards/cancel-visit-confirmation.js
@@ -9,17 +9,15 @@ import TokenProvider from "../../src/providers/TokenProvider";
 import retrieveVisitByCallId from "../../src/usecases/retrieveVisitByCallId";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import Error from "next/error";
-
-import formatDate from "../../src/helpers/formatDate";
-import formatTime from "../../src/helpers/formatTime";
+import VisitSummaryList from "../../src/components/VisitSummaryList";
+import BackLink from "../../src/components/BackLink";
 
 const deleteVisitConfirmation = ({
   callId,
   patientName,
   contactName,
   contactNumber,
-  callTime,
-  callDate,
+  callDateAndTime,
   error,
 }) => {
   const onSubmit = useCallback(async (event) => {
@@ -35,38 +33,19 @@ const deleteVisitConfirmation = ({
     <Layout title="Confirm cancellation of virtual visit" renderLogout={true}>
       <GridRow>
         <GridColumn width="full">
+          <Heading>Confirm cancellation of virtual visit</Heading>
+        </GridColumn>
+      </GridRow>
+      <GridRow>
+        <GridColumn width="two-thirds">
           <form onSubmit={onSubmit}>
-            <Heading>Confirm cancellation of virtual visit</Heading>
-            <dl className="nhsuk-summary-list">
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Patient&apos;s name</dt>
-                <dd className="nhsuk-summary-list__value">{patientName}</dd>
-              </div>
+            <VisitSummaryList
+              patientName={patientName}
+              visitorName={contactName}
+              visitorMobileNumber={contactNumber}
+              visitDateAndTime={callDateAndTime}
+            ></VisitSummaryList>
 
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">
-                  Key contact&apos;s name
-                </dt>
-                <dd className="nhsuk-summary-list__value">{contactName}</dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">
-                  Key contact&apos;s mobile number
-                </dt>
-                <dd className="nhsuk-summary-list__value">{contactNumber}</dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Date of call</dt>
-                <dd className="nhsuk-summary-list__value">{callDate}</dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Time of call</dt>
-                <dd className="nhsuk-summary-list__value">{callTime}</dd>
-              </div>
-            </dl>
             <div className="nhsuk-warning-callout">
               <h3 className="nhsuk-warning-callout__label">
                 Inform key contact
@@ -76,20 +55,10 @@ const deleteVisitConfirmation = ({
                 visit is being cancelled.
               </p>
             </div>
+
             <Button>Confirm cancellation</Button>
-            <div className="nhsuk-back-link">
-              <a className="nhsuk-back-link__link" href={`/wards/visits`}>
-                <svg
-                  className="nhsuk-icon nhsuk-icon__chevron-left"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-                </svg>
-                Return to virtual visits
-              </a>
-            </div>
+
+            <BackLink href="/wards/visits">Back to virtual visits</BackLink>
           </form>
         </GridColumn>
       </GridRow>
@@ -114,16 +83,12 @@ export const getServerSideProps = propsWithContainer(
         };
       }
 
-      const callTime = formatTime(scheduledCall.callTime, "HH:mm");
-      const callDate = formatDate(scheduledCall.callTime);
-
       return {
         props: {
           patientName: scheduledCall.patientName,
           contactName: scheduledCall.recipientName,
           contactNumber: scheduledCall.recipientNumber,
-          callTime,
-          callDate,
+          callDateAndTime: scheduledCall.callTime,
           callId,
           error,
         },

--- a/pages/wards/cancel-visit-success.js
+++ b/pages/wards/cancel-visit-success.js
@@ -10,15 +10,13 @@ import retrieveVisitByCallId from "../../src/usecases/retrieveVisitByCallId";
 import deleteVisitByCallId from "../../src/usecases/deleteVisitByCallId";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import Error from "next/error";
-import formatDate from "../../src/helpers/formatDate";
-import formatTime from "../../src/helpers/formatTime";
+import VisitSummaryList from "../../src/components/VisitSummaryList";
 
 const deleteVisitSuccess = ({
   patientName,
   contactName,
   contactNumber,
-  callTime,
-  callDate,
+  callDateAndTime,
   error,
   deleteError,
 }) => {
@@ -38,36 +36,14 @@ const deleteVisitSuccess = ({
           <form onSubmit={onSubmit}>
             <Heading>Virtual visit has been cancelled</Heading>
             <p>The following virtual visit has been successfully cancelled.</p>
-            <dl className="nhsuk-summary-list">
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Patient&apos;s name</dt>
-                <dd className="nhsuk-summary-list__value">{patientName}</dd>
-              </div>
 
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">
-                  Key contact&apos;s name
-                </dt>
-                <dd className="nhsuk-summary-list__value">{contactName}</dd>
-              </div>
+            <VisitSummaryList
+              patientName={patientName}
+              visitorName={contactName}
+              visitorMobileNumber={contactNumber}
+              visitDateAndTime={callDateAndTime}
+            ></VisitSummaryList>
 
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">
-                  Key contact&apos;s mobile number
-                </dt>
-                <dd className="nhsuk-summary-list__value">{contactNumber}</dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Date of call</dt>
-                <dd className="nhsuk-summary-list__value">{callDate}</dd>
-              </div>
-
-              <div className="nhsuk-summary-list__row">
-                <dt className="nhsuk-summary-list__key">Time of call</dt>
-                <dd className="nhsuk-summary-list__value">{callTime}</dd>
-              </div>
-            </dl>
             <Button>Return to virtual visits</Button>
           </form>
         </GridColumn>
@@ -92,17 +68,13 @@ export const getServerSideProps = propsWithContainer(
         };
       }
 
-      const callTime = formatTime(scheduledCall.callTime, "HH:mm");
-      const callDate = formatDate(scheduledCall.callTime);
-
       let { error: deleteError } = await deleteVisitByCallId(container)(callId);
       return {
         props: {
           patientName: scheduledCall.patientName,
           contactName: scheduledCall.recipientName,
           contactNumber: scheduledCall.recipientNumber,
-          callTime,
-          callDate,
+          callDateAndTime: scheduledCall.callTime,
           error,
           deleteError,
         },

--- a/src/components/SummaryList/index.js
+++ b/src/components/SummaryList/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+const SummaryList = ({ list, withActions }) => (
+  <dl className="nhsuk-summary-list">
+    {list.map((row) => (
+      <div className="nhsuk-summary-list__row" key={row.key}>
+        <dt className="nhsuk-summary-list__key">{row.key}</dt>
+        <dd className="nhsuk-summary-list__value">{row.value}</dd>
+        {withActions && (
+          <dd className="nhsuk-summary-list__actions">
+            <a
+              href={row.actionLink || "#"}
+              onClick={row.actionLinkOnClick || null}
+            >
+              Change
+              <span className="nhsuk-u-visually-hidden">
+                {` ${row.hiddenActionText}`}
+              </span>
+            </a>
+          </dd>
+        )}
+      </div>
+    ))}
+  </dl>
+);
+
+export default SummaryList;

--- a/src/components/VisitSummaryList/index.js
+++ b/src/components/VisitSummaryList/index.js
@@ -1,0 +1,50 @@
+import React from "react";
+import SummaryList from "../SummaryList";
+import formatDate from "../../../src/helpers/formatDate";
+import formatTime from "../../../src/helpers/formatTime";
+
+const VisitSummaryList = ({
+  patientName,
+  visitorName,
+  visitorMobileNumber,
+  visitDateAndTime,
+  withActions = false,
+  actionLinkOnClick = null,
+}) => {
+  const visit = [
+    {
+      key: "Patient name",
+      value: patientName,
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "patient name",
+    },
+    {
+      key: "Key contact name",
+      value: visitorName,
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "key contact name",
+    },
+    {
+      key: "Key contact mobile number",
+      value: visitorMobileNumber,
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "key contact mobile number",
+    },
+    {
+      key: "Date of visit",
+      value: formatDate(visitDateAndTime),
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "date of visit",
+    },
+    {
+      key: "Time of visit",
+      value: formatTime(visitDateAndTime, "HH:mm"),
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "time of visit",
+    },
+  ];
+
+  return <SummaryList list={visit} withActions={withActions} />;
+};
+
+export default VisitSummaryList;


### PR DESCRIPTION
# What

- Add a generic `SummaryList` component
- Add a `VisitSummaryList` component for displaying the details of a visit
- Update places using the plain summary list HTML to use component

# Why

So we are consistent with our summary list for displaying a visit and removes duplication.

# Screenshots

![screencapture-localhost-3000-wards-cancel-visit-confirmation-2020-05-12-08_47_29](https://user-images.githubusercontent.com/42817036/81655529-3497ee00-942e-11ea-9dc0-905dd06e5464.png)

# Notes

N/A