### PR TITLE
Add an edit a ward success page

### DIFF
--- a/pageTests/admin/edit-a-ward-success.test.js
+++ b/pageTests/admin/edit-a-ward-success.test.js
@@ -1,0 +1,93 @@
+import { getServerSideProps } from "../../pages/admin/edit-a-ward-success";
+
+// TODO: This needs to be moved once the verifyToken logic is in the container..
+jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
+  token && { admin: true }
+);
+
+const authenticatedReq = {
+  headers: {
+    cookie: "token=123",
+  },
+};
+
+describe("/admin/edit-a-ward-success", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+
+    describe("with wardId parameter", () => {
+      it("retrieves a ward by the wardId parameter", async () => {
+        const retrieveWardByIdSpy = jest.fn().mockReturnValue({
+          ward: {
+            id: 1,
+            name: "Defoe Ward",
+            hospitalName: "Northwick Park Hospital",
+          },
+          error: null,
+        });
+
+        const container = {
+          getWardById: () => retrieveWardByIdSpy,
+        };
+
+        await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query: {
+            wardId: "ward ID",
+          },
+          container,
+        });
+
+        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID");
+      });
+
+      it("set a ward prop based on the retrieved ward", async () => {
+        const retrieveWardByIdSpy = jest.fn().mockReturnValue({
+          ward: {
+            id: 1,
+            name: "Defoe Ward",
+            hospitalName: "Northwick Park Hospital",
+          },
+          error: null,
+        });
+
+        const container = {
+          getWardById: () => retrieveWardByIdSpy,
+        };
+
+        const { props } = await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query: {
+            wardId: "1",
+          },
+          container,
+        });
+
+        expect(props.name).toEqual("Defoe Ward");
+        expect(props.hospitalName).toEqual("Northwick Park Hospital");
+      });
+    });
+  });
+});

--- a/pages/admin/add-a-ward-success.js
+++ b/pages/admin/add-a-ward-success.js
@@ -43,7 +43,6 @@ export const getServerSideProps = propsWithContainer(
     async ({ container, query }) => {
       const getWardById = container.getWardById();
       const { ward, error } = await getWardById(query.wardId);
-      console.log(ward);
 
       return {
         props: {

--- a/pages/admin/edit-a-ward-success.js
+++ b/pages/admin/edit-a-ward-success.js
@@ -1,0 +1,61 @@
+import React from "react";
+import Error from "next/error";
+import Layout from "../../src/components/Layout";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+import TokenProvider from "../../src/providers/TokenProvider";
+import verifyAdminToken from "../../src/usecases/verifyAdminToken";
+import ActionLink from "../../src/components/ActionLink";
+
+const EditAWardSuccess = ({ error, name, hospitalName }) => {
+  if (error) {
+    return <Error />;
+  }
+
+  return (
+    <Layout title={`${name} has been updated`} renderLogout={true}>
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-two-thirds">
+          <div
+            className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+            style={{ textAlign: "center" }}
+          >
+            <h1 className="nhsuk-panel__title">{name} has been updated</h1>
+
+            <div className="nhsuk-panel__body">for {hospitalName}</div>
+          </div>
+          <h2>What happens next</h2>
+
+          <ActionLink href={`/admin/add-a-ward`}>Add a ward</ActionLink>
+
+          <p>
+            <a href={`/admin`} className="nhsuk-link">
+              Return to ward administration
+            </a>
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyAdminToken(
+    async ({ container, query }) => {
+      const getWardById = container.getWardById();
+      const { ward, error } = await getWardById(query.wardId);
+
+      return {
+        props: {
+          error: error,
+          name: ward.name,
+          hospitalName: ward.hospitalName,
+        },
+      };
+    },
+    {
+      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
+    }
+  )
+);
+
+export default EditAWardSuccess;


### PR DESCRIPTION
# What

Add a basic edit a ward success page.

# Why

To confirm to the user that they've successfully updated a ward.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/81665830-200d2300-9439-11ea-94ed-52c57f395de4.png)

# Notes

N/A