### PR TITLE
Allow an admin to edit a ward

### DIFF
--- a/pageTests/admin/edit-a-ward.test.js
+++ b/pageTests/admin/edit-a-ward.test.js
@@ -85,6 +85,7 @@ describe("/admin/edit-a-ward", () => {
           container,
         });
 
+        expect(props.id).toEqual(1);
         expect(props.name).toEqual("Defoe Ward");
         expect(props.hospitalName).toEqual("Northwick Park Hospital");
       });

--- a/pages/admin/edit-a-ward.js
+++ b/pages/admin/edit-a-ward.js
@@ -7,7 +7,7 @@ import TokenProvider from "../../src/providers/TokenProvider";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import EditWardForm from "../../src/components/EditWardForm";
 
-const EditAWard = ({ error, name, hospitalName }) => {
+const EditAWard = ({ error, id, name, hospitalName }) => {
   if (error) {
     return <Error />;
   }
@@ -25,6 +25,7 @@ const EditAWard = ({ error, name, hospitalName }) => {
           <EditWardForm
             errors={errors}
             setErrors={setErrors}
+            id={id}
             initialName={name}
             initialHospitalName={hospitalName}
           />
@@ -43,6 +44,7 @@ export const getServerSideProps = propsWithContainer(
       return {
         props: {
           error: error,
+          id: ward.id,
           name: ward.name,
           hospitalName: ward.hospitalName,
         },

--- a/src/components/WardsTable/index.js
+++ b/src/components/WardsTable/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Router from "next/router";
 
 const WardsTable = ({ wards }) => (
   <div className="nhsuk-table-responsive">
@@ -15,6 +16,7 @@ const WardsTable = ({ wards }) => (
           <th className="nhsuk-table__header" scope="col">
             Ward code
           </th>
+          <th className="nhsuk-table__header" scope="col"></th>
         </tr>
       </thead>
       <tbody className="nhsuk-table__body">
@@ -23,6 +25,20 @@ const WardsTable = ({ wards }) => (
             <td className="nhsuk-table__cell">{ward.hospitalName}</td>
             <td className="nhsuk-table__cell">{ward.name}</td>
             <td className="nhsuk-table__cell">{ward.code}</td>
+            <td className="nhsuk-table__cell">
+              <button
+                className="nhsuk-button"
+                onClick={() => {
+                  const wardId = ward.id;
+                  Router.push({
+                    pathname: `/admin/edit-a-ward`,
+                    query: { wardId },
+                  });
+                }}
+              >
+                Edit
+              </button>
+            </td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
# What

- Updated the `EditWardForm` to submit the form using the `/api/update-a-ward` API endpoint and redirect to edit a ward success page
- Added an edit button on the "Ward Administration" page

# Why

In previous PRs we created all the individual pieces to allow an admin to edit a ward, now we must connect them and make the functionality visible to the user. 🎉 

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/81672575-3d92ba80-9442-11ea-8de4-faa3e56b8646.png)

# Notes

Related PRs:

- https://github.com/madetech/nhs-virtual-visit/pull/246
- https://github.com/madetech/nhs-virtual-visit/pull/247
- https://github.com/madetech/nhs-virtual-visit/pull/249
- https://github.com/madetech/nhs-virtual-visit/pull/251