### PR TITLE
Add warning around node 14 and db-migrate to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following video chat capabilities are currently supported:
 Requirements:
 
 - PostgreSQL 12
-- Node LTS
+- Node LTS (Currently Node 12. There is a known issue with db-migrate and Node 14)
 - GovNotify API keys
 
 ## Environment Setup


### PR DESCRIPTION
# What
Add warning to readme not to use node 14 as there is an iddue with db-migrate

# Why

# Screenshots

# Notes
