### PR TITLE
Only show the wards of a trust on the ward admin page

### DIFF
--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,4 +1,6 @@
 INSERT INTO trusts (name, admin_code) VALUES ('Test Trust', 'admin');
+INSERT INTO trusts (name, admin_code) VALUES ('Test 2 Trust', 'admin2');
 INSERT INTO wards (name, hospital_name, code, trust_id) VALUES ('Test Ward One', 'Test Hospital', 'TEST1', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO wards (name, hospital_name, code, trust_id) VALUES ('Test Ward Two', 'Test Hospital', 'TEST2', (SELECT id FROM trusts WHERE name='Test Trust'));
+INSERT INTO wards (name, hospital_name, code, trust_id) VALUES ('Test 2 Ward One', 'Test 2 Hospital', 'TEST22', (SELECT id FROM trusts WHERE name='Test 2 Trust'));
 INSERT INTO hospitals (name, trust_id) VALUES ('Test Hospital', (SELECT id FROM trusts WHERE name='Test Trust'));

--- a/pageTests/admin.test.js
+++ b/pageTests/admin.test.js
@@ -2,13 +2,19 @@ import { getServerSideProps } from "../pages/admin";
 
 // TODO: This needs to be moved once the verifyToken logic is in the container..
 jest.mock("../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
+  token && { admin: true, trustId: 1 }
 );
 
 describe("admin", () => {
   const anonymousReq = {
     headers: {
       cookie: "",
+    },
+  };
+
+  const authenticatedReq = {
+    headers: {
+      cookie: "token=123",
     },
   };
 
@@ -27,6 +33,33 @@ describe("admin", () => {
       expect(res.writeHead).toHaveBeenCalledWith(302, {
         Location: "/wards/login",
       });
+    });
+
+    it("retrieves wards", async () => {
+      const getRetrieveWardsSpy = jest.fn(async () => ({
+        wards: [
+          {
+            id: 1,
+            name: "Defoe Ward",
+            hospital_name: "Test Hospital",
+            code: "test_code",
+          },
+          {
+            id: 2,
+            name: "Willem Ward",
+            hospital_name: "Test Hospital 2",
+            code: "test_code_2",
+          },
+        ],
+        error: null,
+      }));
+      const container = {
+        getRetrieveWards: () => getRetrieveWardsSpy,
+      };
+
+      await getServerSideProps({ req: authenticatedReq, res, container });
+
+      expect(getRetrieveWardsSpy).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -35,8 +35,10 @@ const Admin = ({ error, wards }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
-    async ({ container }) => {
-      const { wards, error } = await container.getRetrieveWards()();
+    async ({ container, authenticationToken }) => {
+      const { wards, error } = await container.getRetrieveWards()(
+        authenticationToken.trustId
+      );
 
       return {
         props: { wards: wards, error: error },

--- a/src/usecases/retrieveWards.js
+++ b/src/usecases/retrieveWards.js
@@ -1,8 +1,9 @@
-const retrieveWards = ({ getDb }) => async () => {
+const retrieveWards = ({ getDb }) => async (trustId) => {
   const db = await getDb();
   try {
     const wards = await db.any(
-      `SELECT * FROM wards ORDER BY hospital_name ASC, name ASC`
+      `SELECT * FROM wards WHERE trust_id = $1 ORDER BY hospital_name ASC, name ASC`,
+      [trustId]
     );
 
     return {

--- a/src/usecases/retrieveWards.test.js
+++ b/src/usecases/retrieveWards.test.js
@@ -25,10 +25,17 @@ describe("retrieveWards", () => {
       },
     };
 
-    const { wards, error } = await retrieveWards(container)();
+    const trustId = 3;
+
+    const { wards, error } = await retrieveWards(container)(trustId);
 
     expect(error).toBeNull();
-    expect(anySpy).toHaveBeenCalledWith(expect.anything());
+    expect(
+      anySpy
+    ).toHaveBeenCalledWith(
+      "SELECT * FROM wards WHERE trust_id = $1 ORDER BY hospital_name ASC, name ASC",
+      [trustId]
+    );
     expect(wards).toHaveLength(2);
     expect(wards[0]).toEqual({
       id: 1,


### PR DESCRIPTION
# What

Update ward admin page to only show wards of the trust.

# Why

Part of enabling multiple trusts.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/81813186-11993700-951f-11ea-944c-30f033dd2522.png)

![image](https://user-images.githubusercontent.com/42817036/81813240-1eb62600-951f-11ea-8cf4-22d2eaa561f4.png)

# Notes

Next steps are to:

1. Associate all current wards to the "London North West University Healthcare" trust on all environments
2. Only allow admins to change wards that are part of their trust
