### PR TITLE
Ensure that an admin can only edit wards in their current trust

### DIFF
--- a/pageTests/admin/add-a-ward-success.test.js
+++ b/pageTests/admin/add-a-ward-success.test.js
@@ -47,7 +47,7 @@ describe("/admin/add-a-ward-success", () => {
         });
 
         const container = {
-          getWardById: () => retrieveWardByIdSpy,
+          getRetrieveWardById: () => retrieveWardByIdSpy,
         };
 
         await getServerSideProps({
@@ -73,7 +73,7 @@ describe("/admin/add-a-ward-success", () => {
         });
 
         const container = {
-          getWardById: () => retrieveWardByIdSpy,
+          getRetrieveWardById: () => retrieveWardByIdSpy,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/admin/add-a-ward-success.test.js
+++ b/pageTests/admin/add-a-ward-success.test.js
@@ -2,7 +2,7 @@ import { getServerSideProps } from "../../pages/admin/add-a-ward-success";
 
 // TODO: This needs to be moved once the verifyToken logic is in the container..
 jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
+  token && { admin: true, trustId: 1 }
 );
 
 const authenticatedReq = {
@@ -59,7 +59,7 @@ describe("/admin/add-a-ward-success", () => {
           container,
         });
 
-        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID");
+        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID", 1);
       });
 
       it("set a ward prop based on the retrieved ward", async () => {

--- a/pageTests/admin/edit-a-ward-success.test.js
+++ b/pageTests/admin/edit-a-ward-success.test.js
@@ -47,7 +47,7 @@ describe("/admin/edit-a-ward-success", () => {
         });
 
         const container = {
-          getWardById: () => retrieveWardByIdSpy,
+          getRetrieveWardById: () => retrieveWardByIdSpy,
         };
 
         await getServerSideProps({
@@ -73,7 +73,7 @@ describe("/admin/edit-a-ward-success", () => {
         });
 
         const container = {
-          getWardById: () => retrieveWardByIdSpy,
+          getRetrieveWardById: () => retrieveWardByIdSpy,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/admin/edit-a-ward-success.test.js
+++ b/pageTests/admin/edit-a-ward-success.test.js
@@ -2,7 +2,7 @@ import { getServerSideProps } from "../../pages/admin/edit-a-ward-success";
 
 // TODO: This needs to be moved once the verifyToken logic is in the container..
 jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
+  token && { admin: true, trustId: 1 }
 );
 
 const authenticatedReq = {
@@ -59,7 +59,7 @@ describe("/admin/edit-a-ward-success", () => {
           container,
         });
 
-        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID");
+        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID", 1);
       });
 
       it("set a ward prop based on the retrieved ward", async () => {

--- a/pageTests/admin/edit-a-ward.test.js
+++ b/pageTests/admin/edit-a-ward.test.js
@@ -2,7 +2,7 @@ import { getServerSideProps } from "../../pages/admin/edit-a-ward";
 
 // TODO: This needs to be moved once the verifyToken logic is in the container..
 jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
+  token && { admin: true, trustId: 1 }
 );
 
 const authenticatedReq = {
@@ -59,7 +59,7 @@ describe("/admin/edit-a-ward", () => {
           container,
         });
 
-        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID");
+        expect(retrieveWardByIdSpy).toHaveBeenCalledWith("ward ID", 1);
       });
 
       it("set a ward prop based on the retrieved ward", async () => {

--- a/pageTests/admin/edit-a-ward.test.js
+++ b/pageTests/admin/edit-a-ward.test.js
@@ -47,7 +47,7 @@ describe("/admin/edit-a-ward", () => {
         });
 
         const container = {
-          getWardById: () => retrieveWardByIdSpy,
+          getRetrieveWardById: () => retrieveWardByIdSpy,
         };
 
         await getServerSideProps({
@@ -73,7 +73,7 @@ describe("/admin/edit-a-ward", () => {
         });
 
         const container = {
-          getWardById: () => retrieveWardByIdSpy,
+          getRetrieveWardById: () => retrieveWardByIdSpy,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/api/book-a-visit.test.js
+++ b/pageTests/api/book-a-visit.test.js
@@ -22,7 +22,7 @@ describe("/api/book-a-visit", () => {
     success: true,
   }));
 
-  const getWardByIdSpy = jest.fn(() => ({
+  const getRetrieveWardByIdSpy = jest.fn(() => ({
     ward: {
       id: 10,
       name: "Fake Ward",
@@ -53,7 +53,7 @@ describe("/api/book-a-visit", () => {
     };
     container = {
       getCreateVisit: jest.fn().mockReturnValue(() => {}),
-      getWardById: () => getWardByIdSpy,
+      getRetrieveWardById: () => getRetrieveWardByIdSpy,
       getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
       getDb: jest.fn().mockResolvedValue(() => {}),
       getSendTextMessage: () => () => ({ success: true, error: null }),
@@ -220,7 +220,7 @@ describe("/api/book-a-visit", () => {
       });
 
       expect(response.status).toHaveBeenCalledWith(201);
-      expect(getWardByIdSpy).toHaveBeenCalledWith(10);
+      expect(getRetrieveWardByIdSpy).toHaveBeenCalledWith(10);
       expect(createVisitSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           patientName: "Bob Smith",

--- a/pageTests/api/send-visit-ready-notification.test.js
+++ b/pageTests/api/send-visit-ready-notification.test.js
@@ -15,7 +15,7 @@ describe("send-visit-ready-notification", () => {
     container = {
       getUserIsAuthenticated: () => () => "token",
       getSendTextMessage: () => sendTextMessageSpy,
-      getWardById: jest.fn().mockReturnValue(() => ({
+      getRetrieveWardById: jest.fn().mockReturnValue(() => ({
         ward: {
           id: 1,
           name: "Defoe Ward",

--- a/pageTests/api/session.test.js
+++ b/pageTests/api/session.test.js
@@ -59,7 +59,7 @@ describe("api/session", () => {
 
         const verifyWardCodeSpy = jest.fn(async () => ({
           validWardCode: true,
-          ward: { id: 10, code: "MEOW" },
+          ward: { id: 10, code: "MEOW", trustId: 1 },
         }));
         const verifyTrustAdminCodeSpy = jest.fn(async () => ({
           validTrustAdminCode: false,
@@ -81,6 +81,7 @@ describe("api/session", () => {
           wardId: 10,
           wardCode: "MEOW",
           admin: false,
+          trustId: 1,
         });
         expect(response.writeHead).toHaveBeenCalledWith(
           201,

--- a/pageTests/api/update-a-ward.test.js
+++ b/pageTests/api/update-a-ward.test.js
@@ -36,7 +36,7 @@ describe("update-a-ward", () => {
       getAdminIsAuthenticated: jest
         .fn()
         .mockReturnValue((cookie) => cookie === "token=valid.token.value"),
-      getWardById: jest.fn().mockReturnValue(() => {
+      getRetrieveWardById: jest.fn().mockReturnValue(() => {
         return { error: null };
       }),
     };
@@ -282,7 +282,7 @@ describe("update-a-ward", () => {
     await updateAWard(validRequest, response, {
       container: {
         ...container,
-        getWardById: jest.fn().mockReturnValue(() => {
+        getRetrieveWardById: jest.fn().mockReturnValue(() => {
           return { error: "Error!" };
         }),
       },

--- a/pageTests/wards/visits.test.js
+++ b/pageTests/wards/visits.test.js
@@ -2,7 +2,7 @@ import { getServerSideProps } from "../../pages/wards/visits";
 
 // TODO: This needs to be moved once the verifyToken logic is in the container..
 jest.mock("../../src/usecases/userIsAuthenticated", () => () => (token) =>
-  token && { ward: "123", wardId: 1 }
+  token && { ward: "123", wardId: 1, trustId: 1 }
 );
 
 describe("ward/visits", () => {
@@ -40,12 +40,12 @@ describe("ward/visits", () => {
         error: null,
       }));
       const wardSpy = jest.fn(async () => ({
-        ward: { id: 1 },
+        ward: { id: 1, trustId: 1 },
         error: null,
       }));
       const container = {
         getRetrieveVisits: () => visitsSpy,
-        getWardById: () => wardSpy,
+        getRetrieveWardById: () => wardSpy,
       };
 
       const { props } = await getServerSideProps({
@@ -57,7 +57,7 @@ describe("ward/visits", () => {
       expect(res.writeHead).not.toHaveBeenCalled();
 
       expect(visitsSpy).toHaveBeenCalledWith({ wardId: 1 });
-      expect(wardSpy).toHaveBeenCalledWith(1);
+      expect(wardSpy).toHaveBeenCalledWith(1, 1);
       expect(props.error).toBeNull();
       expect(props.scheduledCalls).toHaveLength(2);
       expect(props.scheduledCalls[0]).toMatchObject({
@@ -77,13 +77,13 @@ describe("ward/visits", () => {
         scheduledCalls: null,
         error: "Error",
       });
-      const getWardByIdStub = async () => ({
+      const getRetrieveWardByIdStub = async () => ({
         ward: null,
         error: "Error",
       });
       const container = {
         getRetrieveVisits: () => retrieveVisitsStub,
-        getWardById: () => getWardByIdStub,
+        getRetrieveWardById: () => getRetrieveWardByIdStub,
       };
 
       const { props } = await getServerSideProps({

--- a/pages/admin/add-a-ward-success.js
+++ b/pages/admin/add-a-ward-success.js
@@ -41,8 +41,8 @@ const AddAWardSuccess = ({ error, name, hospitalName }) => {
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
     async ({ container, query, authenticationToken }) => {
-      const getWardById = container.getWardById();
-      const { ward, error } = await getWardById(
+      const getRetrieveWardById = container.getRetrieveWardById();
+      const { ward, error } = await getRetrieveWardById(
         query.wardId,
         authenticationToken.trustId
       );

--- a/pages/admin/add-a-ward-success.js
+++ b/pages/admin/add-a-ward-success.js
@@ -40,9 +40,12 @@ const AddAWardSuccess = ({ error, name, hospitalName }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
-    async ({ container, query }) => {
+    async ({ container, query, authenticationToken }) => {
       const getWardById = container.getWardById();
-      const { ward, error } = await getWardById(query.wardId);
+      const { ward, error } = await getWardById(
+        query.wardId,
+        authenticationToken.trustId
+      );
 
       return {
         props: {

--- a/pages/admin/edit-a-ward-success.js
+++ b/pages/admin/edit-a-ward-success.js
@@ -41,8 +41,8 @@ const EditAWardSuccess = ({ error, name, hospitalName }) => {
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
     async ({ container, query, authenticationToken }) => {
-      const getWardById = container.getWardById();
-      const { ward, error } = await getWardById(
+      const getRetrieveWardById = container.getRetrieveWardById();
+      const { ward, error } = await getRetrieveWardById(
         query.wardId,
         authenticationToken.trustId
       );

--- a/pages/admin/edit-a-ward-success.js
+++ b/pages/admin/edit-a-ward-success.js
@@ -40,9 +40,12 @@ const EditAWardSuccess = ({ error, name, hospitalName }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
-    async ({ container, query }) => {
+    async ({ container, query, authenticationToken }) => {
       const getWardById = container.getWardById();
-      const { ward, error } = await getWardById(query.wardId);
+      const { ward, error } = await getWardById(
+        query.wardId,
+        authenticationToken.trustId
+      );
 
       return {
         props: {

--- a/pages/admin/edit-a-ward.js
+++ b/pages/admin/edit-a-ward.js
@@ -38,8 +38,8 @@ const EditAWard = ({ error, id, name, hospitalName }) => {
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
     async ({ container, query, authenticationToken }) => {
-      const getWardById = container.getWardById();
-      const { ward, error } = await getWardById(
+      const getRetrieveWardById = container.getRetrieveWardById();
+      const { ward, error } = await getRetrieveWardById(
         query.wardId,
         authenticationToken.trustId
       );

--- a/pages/admin/edit-a-ward.js
+++ b/pages/admin/edit-a-ward.js
@@ -37,9 +37,12 @@ const EditAWard = ({ error, id, name, hospitalName }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
-    async ({ container, query }) => {
+    async ({ container, query, authenticationToken }) => {
       const getWardById = container.getWardById();
-      const { ward, error } = await getWardById(query.wardId);
+      const { ward, error } = await getWardById(
+        query.wardId,
+        authenticationToken.trustId
+      );
 
       return {
         props: {

--- a/pages/api/book-a-visit.js
+++ b/pages/api/book-a-visit.js
@@ -96,7 +96,7 @@ export default withContainer(
       const createVisit = container.getCreateVisit();
       const updateWardVisitTotals = container.getUpdateWardVisitTotals();
 
-      const { ward, error } = await container.getWardById()(wardId);
+      const { ward, error } = await container.getRetrieveWardById()(wardId);
       if (error) {
         throw error;
       }

--- a/pages/api/send-visit-ready-notification.js
+++ b/pages/api/send-visit-ready-notification.js
@@ -36,7 +36,7 @@ export default withContainer(async (req, res, { container }) => {
   const templateId = TemplateStore.secondText.templateId;
 
   try {
-    const { ward, error } = await container.getWardById()(
+    const { ward, error } = await container.getRetrieveWardById()(
       authenticationToken.wardId
     );
     if (error) {

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -33,6 +33,7 @@ export default withContainer(
           wardId: ward.id,
           wardCode: ward.code,
           admin: false,
+          trustId: ward.trustId,
         });
       }
 

--- a/pages/api/update-a-ward.js
+++ b/pages/api/update-a-ward.js
@@ -44,7 +44,7 @@ export default withContainer(
       return;
     }
 
-    const retrieveWardById = container.getWardById();
+    const retrieveWardById = container.getRetrieveWardById();
 
     const existingWard = await retrieveWardById(body.id, adminToken.trustId);
 

--- a/pages/api/update-a-ward.js
+++ b/pages/api/update-a-ward.js
@@ -10,7 +10,9 @@ export default withContainer(
 
     const adminIsAuthenticated = container.getAdminIsAuthenticated();
 
-    if (!adminIsAuthenticated(headers.cookie)) {
+    const adminToken = adminIsAuthenticated(headers.cookie);
+
+    if (!adminToken) {
       res.status(401);
       res.end();
       return;
@@ -39,6 +41,16 @@ export default withContainer(
     if (!body.hospitalName) {
       res.status(400);
       res.end(JSON.stringify({ err: "hospital name must be present" }));
+      return;
+    }
+
+    const retrieveWardById = container.getWardById();
+
+    const existingWard = await retrieveWardById(body.id, adminToken.trustId);
+
+    if (existingWard.error) {
+      res.status(400);
+      res.end(JSON.stringify({ err: "ward does not exist in current trust" }));
       return;
     }
 

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -54,12 +54,15 @@ export default function WardVisits({ scheduledCalls, ward, error }) {
 export const getServerSideProps = propsWithContainer(
   verifyToken(
     async ({ authenticationToken, container }) => {
-      const { wardId } = authenticationToken;
+      const { wardId, trustId } = authenticationToken;
       let { scheduledCalls, error } = await container.getRetrieveVisits()({
         wardId,
       });
       let ward;
-      ({ ward, error } = await container.getWardById()(wardId));
+      ({ ward, error } = await container.getRetrieveWardById()(
+        wardId,
+        trustId
+      ));
       return {
         props: { scheduledCalls, ward, error },
       };

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -31,7 +31,7 @@ class AppContainer {
     return createWard(this);
   };
 
-  getWardById = () => {
+  getRetrieveWardById = () => {
     return retrieveWardById(this);
   };
 

--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -13,9 +13,9 @@ class TokenProvider {
       {
         wardId,
         ward: wardCode,
-        admin: admin,
-        trustId: trustId,
-        version: version,
+        admin,
+        trustId,
+        version,
       },
       this.signingKey,
       {

--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -1,5 +1,7 @@
 import jwt from "jsonwebtoken";
 
+const version = 1;
+
 class TokenProvider {
   constructor(signingKey) {
     this.signingKey = signingKey;
@@ -7,7 +9,14 @@ class TokenProvider {
 
   generate({ wardId, wardCode, admin, trustId }) {
     return jwt.sign(
-      { wardId, ward: wardCode, admin: admin, trustId: trustId },
+      // If updating the token structure, update the version
+      {
+        wardId,
+        ward: wardCode,
+        admin: admin,
+        trustId: trustId,
+        version: version,
+      },
       this.signingKey,
       {
         algorithm: "HS256",
@@ -16,7 +25,15 @@ class TokenProvider {
   }
 
   validate(token) {
-    return jwt.verify(token, this.signingKey, { algorithms: ["HS256"] });
+    const decryptedToken = jwt.verify(token, this.signingKey, {
+      algorithms: ["HS256"],
+    });
+
+    if (decryptedToken.version != version) {
+      throw new Error("Invalid token version");
+    }
+
+    return decryptedToken;
   }
 }
 

--- a/src/providers/TokenProvider.test.js
+++ b/src/providers/TokenProvider.test.js
@@ -1,0 +1,63 @@
+import jwt from "jsonwebtoken";
+import TokenProvider from "./TokenProvider";
+
+describe("TokenProvider", () => {
+  it("should verify a valid token", () => {
+    jwt.verify = jest.fn().mockReturnValue({
+      version: 1,
+      wardId: 1,
+      ward: "123",
+      admin: false,
+      trustId: 2,
+    });
+
+    const tokenProvider = new TokenProvider();
+
+    const token = tokenProvider.validate("token");
+
+    expect(token.version).toEqual(1);
+  });
+
+  it("should reject a token with an invalid version", () => {
+    jwt.verify = jest.fn().mockReturnValue({
+      version: 2,
+      wardId: 1,
+      ward: "123",
+      admin: false,
+      trustId: 2,
+    });
+
+    const tokenProvider = new TokenProvider();
+
+    expect(() => {
+      tokenProvider.validate("token");
+    }).toThrowError("Invalid token version");
+  });
+
+  it("should reject an invalid token", () => {
+    jwt.verify = jest.fn().mockImplementation(() => {
+      throw new Error("Error!");
+    });
+
+    const tokenProvider = new TokenProvider();
+
+    expect(() => {
+      tokenProvider.validate("token");
+    }).toThrowError();
+  });
+
+  it("should reject a token without a version", () => {
+    jwt.verify = jest.fn().mockReturnValue({
+      wardId: 1,
+      ward: "123",
+      admin: false,
+      trustId: 2,
+    });
+
+    const tokenProvider = new TokenProvider();
+
+    expect(() => {
+      tokenProvider.validate("token");
+    }).toThrowError("Invalid token version");
+  });
+});

--- a/src/usecases/retrieveWardById.js
+++ b/src/usecases/retrieveWardById.js
@@ -1,10 +1,10 @@
-const retrieveWardById = ({ getDb }) => async (wardId) => {
+const retrieveWardById = ({ getDb }) => async (wardId, trustId) => {
   const db = await getDb();
   console.log("Retrieving ward for  ", wardId);
   try {
     const ward = await db.oneOrNone(
-      "SELECT * FROM wards WHERE id = $1 LIMIT 1",
-      wardId
+      "SELECT * FROM wards WHERE id = $1 AND trust_id = $2 LIMIT 1",
+      [wardId, trustId]
     );
 
     return {

--- a/src/usecases/retrieveWardById.test.js
+++ b/src/usecases/retrieveWardById.test.js
@@ -14,11 +14,14 @@ describe("retrieveWardById", () => {
       },
     };
 
-    const { ward, error } = await retrieveWardById(container)(1);
+    const wardId = 1;
+    const trustId = 1;
+
+    const { ward, error } = await retrieveWardById(container)(wardId, trustId);
 
     expect(error).toBeNull();
     expect(ward).toEqual({
-      id: 1,
+      id: wardId,
       name: "Defoe Ward",
       hospitalName: "Test Hospital",
     });

--- a/src/usecases/verifyWardCode.js
+++ b/src/usecases/verifyWardCode.js
@@ -3,7 +3,7 @@ const verifyWardCode = ({ getDb }) => async (wardCode) => {
 
   try {
     const dbResponse = await db.any(
-      `SELECT id, code FROM wards WHERE code = $1 LIMIT 1`,
+      `SELECT id, code, trust_id FROM wards WHERE code = $1 LIMIT 1`,
       [wardCode]
     );
 
@@ -12,7 +12,7 @@ const verifyWardCode = ({ getDb }) => async (wardCode) => {
 
       return {
         validWardCode: true,
-        ward: { id: ward.id, code: ward.code },
+        ward: { id: ward.id, code: ward.code, trustId: ward.trust_id },
         error: null,
       };
     } else {

--- a/src/usecases/verifyWardCode.test.js
+++ b/src/usecases/verifyWardCode.test.js
@@ -11,6 +11,7 @@ describe("verifyWardCode", () => {
               name: "Ward name",
               hospital_name: "London Meowdical Hospital",
               code: "MEOW",
+              trust_id: 1,
             },
           ]),
         }),
@@ -21,6 +22,7 @@ describe("verifyWardCode", () => {
       expect(response.ward).toEqual({
         id: 1,
         code: "MEOW",
+        trustId: 1,
       });
     });
   });


### PR DESCRIPTION
# What

Ensure that an admin can only edit wards in their current trust.

# Why

🔒 

# Screenshots

# Notes
