### PR TITLE
Add trust name to to heading and page title of admin page

### DIFF
--- a/pageTests/admin.test.js
+++ b/pageTests/admin.test.js
@@ -18,6 +18,21 @@ describe("admin", () => {
     },
   };
 
+  const wards = [
+    {
+      id: 1,
+      name: "Defoe Ward",
+      hospital_name: "Test Hospital",
+      code: "test_code",
+    },
+    {
+      id: 2,
+      name: "Willem Ward",
+      hospital_name: "Test Hospital 2",
+      code: "test_code_2",
+    },
+  ];
+
   let res;
 
   beforeEach(() => {
@@ -37,29 +52,101 @@ describe("admin", () => {
 
     it("retrieves wards", async () => {
       const getRetrieveWardsSpy = jest.fn(async () => ({
-        wards: [
-          {
-            id: 1,
-            name: "Defoe Ward",
-            hospital_name: "Test Hospital",
-            code: "test_code",
-          },
-          {
-            id: 2,
-            name: "Willem Ward",
-            hospital_name: "Test Hospital 2",
-            code: "test_code_2",
-          },
-        ],
+        wards: wards,
+        error: null,
+      }));
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: { name: "Doggo Trust" },
         error: null,
       }));
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
       };
 
-      await getServerSideProps({ req: authenticatedReq, res, container });
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
 
       expect(getRetrieveWardsSpy).toHaveBeenCalledWith(1);
+      expect(props.wards).toEqual(wards);
+      expect(props.wardError).toBeNull();
+    });
+
+    it("sets an error in props if ward error", async () => {
+      const getRetrieveWardsSpy = jest.fn(async () => ({
+        wards: null,
+        error: "Error!",
+      }));
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: { name: "Doggo Trust" },
+        error: null,
+      }));
+      const container = {
+        getRetrieveWards: () => getRetrieveWardsSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.wardError).toEqual("Error!");
+    });
+
+    it("retrieves the trust of the admin", async () => {
+      const trustId = 1;
+      const getRetrieveWardsSpy = jest.fn(async () => ({
+        error: null,
+      }));
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: {
+          id: trustId,
+          name: "Doggo Trust",
+        },
+        error: null,
+      }));
+      const container = {
+        getRetrieveWards: () => getRetrieveWardsSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveTrustByIdSpy).toHaveBeenCalledWith(trustId);
+      expect(props.trust).toEqual({ name: "Doggo Trust" });
+      expect(props.wardError).toBeNull();
+    });
+
+    it("sets an error in props if trust error", async () => {
+      const getRetrieveWardsSpy = jest.fn(async () => ({
+        wards: wards,
+        error: null,
+      }));
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: null,
+        error: "Error!",
+      }));
+      const container = {
+        getRetrieveWards: () => getRetrieveWardsSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.trustError).toEqual("Error!");
     });
   });
 });

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -52,12 +52,12 @@ export const getServerSideProps = propsWithContainer(
         authenticationToken.trustId
       );
 
-      const trustName = trustResponse.trust ? trustResponse.trust.name : null;
+      // const trustName = trustResponse.trust ? trustResponse.trust.name : null;
 
       return {
         props: {
           wards: wardsResponse.wards,
-          trust: { name: trustName },
+          trust: { name: trustResponse.trust?.name },
           wardError: wardsResponse.error,
           trustError: trustResponse.error,
         },

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -10,16 +10,25 @@ import Heading from "../src/components/Heading";
 import ActionLink from "../src/components/ActionLink";
 import Text from "../src/components/Text";
 
-const Admin = ({ error, wards }) => {
-  if (error) {
+const Admin = ({ wardError, trustError, wards, trust }) => {
+  if (wardError || trustError) {
     return <Error />;
   }
 
   return (
-    <Layout title="Admin" renderLogout={true}>
+    <Layout
+      title={`Ward admininistration for ${trust.name}`}
+      renderLogout={true}
+    >
       <GridRow>
         <GridColumn width="full">
-          <Heading>Ward Administration</Heading>
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            Ward admininistration
+          </Heading>
           <ActionLink href={`/admin/add-a-ward`}>Add a ward</ActionLink>
 
           {wards.length > 0 ? (
@@ -36,12 +45,22 @@ const Admin = ({ error, wards }) => {
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(
     async ({ container, authenticationToken }) => {
-      const { wards, error } = await container.getRetrieveWards()(
+      const wardsResponse = await container.getRetrieveWards()(
+        authenticationToken.trustId
+      );
+      const trustResponse = await container.getRetrieveTrustById()(
         authenticationToken.trustId
       );
 
+      const trustName = trustResponse.trust ? trustResponse.trust.name : null;
+
       return {
-        props: { wards: wards, error: error },
+        props: {
+          wards: wardsResponse.wards,
+          trust: { name: trustName },
+          wardError: wardsResponse.error,
+          trustError: trustResponse.error,
+        },
       };
     },
     {

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -18,6 +18,7 @@ import retrieveWardVisitTotals from "../usecases/retrieveWardVisitTotals";
 import updateWard from "../usecases/updateWard";
 import createHospital from "../usecases/createHospital";
 import retrieveHospitalsByTrustId from "../usecases/retrieveHospitalsByTrustId";
+import retrieveTrustById from "../usecases/retrieveTrustById";
 
 class AppContainer {
   getDb = () => {
@@ -98,6 +99,10 @@ class AppContainer {
 
   getRetrieveHospitalsByTrustId = () => {
     return retrieveHospitalsByTrustId(this);
+  };
+
+  getRetrieveTrustById = () => {
+    return retrieveTrustById(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -73,4 +73,8 @@ describe("AppContainer", () => {
   it("returns getRetrieveHospitalsByTrustId", () => {
     expect(container.getRetrieveHospitalsByTrustId()).toBeDefined();
   });
+
+  it("returns getRetrieveTrustById", () => {
+    expect(container.getRetrieveTrustById()).toBeDefined();
+  });
 });

--- a/src/usecases/retrieveTrustById.js
+++ b/src/usecases/retrieveTrustById.js
@@ -1,0 +1,26 @@
+const retrieveTrustById = ({ getDb }) => async (trustId) => {
+  const db = await getDb();
+  console.log("Retrieving trust for  ", trustId);
+  try {
+    const trust = await db.oneOrNone(
+      "SELECT * FROM trusts WHERE id = $1 LIMIT 1",
+      trustId
+    );
+
+    return {
+      trust: {
+        id: trust.id,
+        name: trust.name,
+      },
+      error: null,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      trust: null,
+      error: error.toString(),
+    };
+  }
+};
+
+export default retrieveTrustById;

--- a/src/usecases/retrieveTrustById.test.js
+++ b/src/usecases/retrieveTrustById.test.js
@@ -1,0 +1,42 @@
+import retrieveTrustById from "./retrieveTrustById";
+
+describe("retrieveTrustById", () => {
+  it("returns an object containing the trust", async () => {
+    const container = {
+      async getDb() {
+        return {
+          oneOrNone: jest.fn().mockReturnValue({
+            id: 1,
+            name: "Doggo Trust",
+          }),
+        };
+      },
+    };
+    const trustId = 1;
+
+    const { trust, error } = await retrieveTrustById(container)(trustId);
+
+    expect(error).toBeNull();
+    expect(trust).toEqual({
+      id: 1,
+      name: "Doggo Trust",
+    });
+  });
+
+  it("returns an error object on db exception", async () => {
+    const container = {
+      async getDb() {
+        return {
+          oneOrNone: jest.fn(() => {
+            throw new Error("DB Error!");
+          }),
+        };
+      },
+    };
+    const trustId = 1;
+
+    const { error } = await retrieveTrustById(container)(trustId);
+    expect(error).toBeDefined();
+    expect(error).toEqual("Error: DB Error!");
+  });
+});


### PR DESCRIPTION
# What

Add trust name to to heading and page title of admin page.

# Why

We don't make it clear to the user what trust they are currently managing.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/81933446-525b8380-95e5-11ea-9ca8-336e03ccee6f.png)

# Notes

N/A