### PR TITLE
Book visit confirmation now uses new interface for retrieveWardById

### DIFF
--- a/pageTests/api/book-a-visit.test.js
+++ b/pageTests/api/book-a-visit.test.js
@@ -16,6 +16,7 @@ describe("/api/book-a-visit", () => {
   const validUserIsAuthenticatedSpy = jest.fn(() => ({
     wardId: 10,
     ward: "MEOW",
+    trustId: 1,
   }));
 
   const updateWardVisitTotalsSpy = jest.fn(() => ({
@@ -220,7 +221,7 @@ describe("/api/book-a-visit", () => {
       });
 
       expect(response.status).toHaveBeenCalledWith(201);
-      expect(getRetrieveWardByIdSpy).toHaveBeenCalledWith(10);
+      expect(getRetrieveWardByIdSpy).toHaveBeenCalledWith(10, 1);
       expect(createVisitSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           patientName: "Bob Smith",

--- a/pages/api/book-a-visit.js
+++ b/pages/api/book-a-visit.js
@@ -86,7 +86,7 @@ export default withContainer(
 
     try {
       let callId = ids.generate();
-      let { wardId } = userIsAuthenticatedResponse;
+      let { wardId, trustId } = userIsAuthenticatedResponse;
       let callPassword = ids.generate();
 
       if (process.env.ENABLE_WHEREBY == "yes") {
@@ -96,7 +96,7 @@ export default withContainer(
       const createVisit = container.getCreateVisit();
       const updateWardVisitTotals = container.getUpdateWardVisitTotals();
 
-      const { ward, error } = await container.getRetrieveWardById()(wardId);
+      const { ward, error } = await container.getRetrieveWardById()(wardId, trustId);
       if (error) {
         throw error;
       }

--- a/pages/api/book-a-visit.js
+++ b/pages/api/book-a-visit.js
@@ -96,7 +96,10 @@ export default withContainer(
       const createVisit = container.getCreateVisit();
       const updateWardVisitTotals = container.getUpdateWardVisitTotals();
 
-      const { ward, error } = await container.getRetrieveWardById()(wardId, trustId);
+      const { ward, error } = await container.getRetrieveWardById()(
+        wardId,
+        trustId
+      );
       if (error) {
         throw error;
       }

--- a/src/usecases/retrieveWardById.test.js
+++ b/src/usecases/retrieveWardById.test.js
@@ -38,7 +38,7 @@ describe("retrieveWardById", () => {
       },
     };
 
-    const { error } = await retrieveWardById(container)(1);
+    const { error } = await retrieveWardById(container)(1, 1);
     expect(error).toBeDefined();
     expect(error).toEqual("Error: DB Error!");
   });


### PR DESCRIPTION
Co-authored-by: Wen Ting Wang <chubberlisk@outlook.com>

# What

Fixes problem in book visit confirmation, it would fail as wasn't using new interface for retrieveWardById

# Why

# Screenshots

# Notes
