### PR TITLE
add test:coverage command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format:check": "prettier --check '{pages,pageTests,src}/**/*.{js,css,md,yml}'",
     "lint": "eslint . --ext .js",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:contract": "jest --config ./jest.contract.config.js",
     "test:contract:watch": "npm run test:contract -- --watch",
     "test:watch": "jest --watch",


### PR DESCRIPTION
# What
Add test:coverage command to package.json
# Why
So devs can easily run coverage report
# Screenshots

# Notes
