### PR TITLE
Use app container for token provider

### DIFF
--- a/pageTests/wards/visit-start.test.js
+++ b/pageTests/wards/visit-start.test.js
@@ -16,7 +16,17 @@ describe("visit-start", () => {
 
   describe("getServerSideProps", () => {
     it("redirects to login page if not authenticated", async () => {
-      await getServerSideProps({ req: anonymousReq, res });
+      const authenticationToken = {
+        foo: true,
+      };
+      const tokenProvider = {
+        validate: jest.fn(() => authenticationToken),
+      };
+      const container = {
+        getTokenProvider: () => tokenProvider,
+      };
+      console.log(container);
+      await getServerSideProps({ req: anonymousReq, res, container });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
         Location: "/wards/login",

--- a/pageTests/wards/visit-start.test.js
+++ b/pageTests/wards/visit-start.test.js
@@ -25,7 +25,7 @@ describe("visit-start", () => {
       const container = {
         getTokenProvider: () => tokenProvider,
       };
-      console.log(container);
+
       await getServerSideProps({ req: anonymousReq, res, container });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -2,7 +2,6 @@ import React from "react";
 import Error from "next/error";
 import Layout from "../src/components/Layout";
 import propsWithContainer from "../src/middleware/propsWithContainer";
-import TokenProvider from "../src/providers/TokenProvider";
 import verifyAdminToken from "../src/usecases/verifyAdminToken";
 import WardsTable from "../src/components/WardsTable";
 import { GridRow, GridColumn } from "../src/components/Grid";
@@ -44,30 +43,25 @@ const Admin = ({ wardError, trustError, wards, trust }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container, authenticationToken }) => {
-      const wardsResponse = await container.getRetrieveWards()(
-        authenticationToken.trustId
-      );
-      const trustResponse = await container.getRetrieveTrustById()(
-        authenticationToken.trustId
-      );
+  verifyAdminToken(async ({ container, authenticationToken }) => {
+    const wardsResponse = await container.getRetrieveWards()(
+      authenticationToken.trustId
+    );
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
 
-      // const trustName = trustResponse.trust ? trustResponse.trust.name : null;
+    // const trustName = trustResponse.trust ? trustResponse.trust.name : null;
 
-      return {
-        props: {
-          wards: wardsResponse.wards,
-          trust: { name: trustResponse.trust?.name },
-          wardError: wardsResponse.error,
-          trustError: trustResponse.error,
-        },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+    return {
+      props: {
+        wards: wardsResponse.wards,
+        trust: { name: trustResponse.trust?.name },
+        wardError: wardsResponse.error,
+        trustError: trustResponse.error,
+      },
+    };
+  })
 );
 
 export default Admin;

--- a/pages/admin/add-a-hospital-success.js
+++ b/pages/admin/add-a-hospital-success.js
@@ -3,7 +3,6 @@ import Error from "next/error";
 import Layout from "../../src/components/Layout";
 import AnchorLink from "../../src/components/AnchorLink";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
-import TokenProvider from "../../src/providers/TokenProvider";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
 import ActionLink from "../../src/components/ActionLink";
 
@@ -38,29 +37,24 @@ const AddAHospitalSuccess = ({ error, name }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container, query, authenticationToken }) => {
-      const getRetrieveHospitalById = container.getRetrieveHospitalById();
-      const { hospital, error } = await getRetrieveHospitalById(
-        query.hospitalId,
-        authenticationToken.trustId
-      );
+  verifyAdminToken(async ({ container, query, authenticationToken }) => {
+    const getRetrieveHospitalById = container.getRetrieveHospitalById();
+    const { hospital, error } = await getRetrieveHospitalById(
+      query.hospitalId,
+      authenticationToken.trustId
+    );
 
-      if (error) {
-        return { props: { error: error } };
-      } else {
-        return {
-          props: {
-            error: error,
-            name: hospital.name,
-          },
-        };
-      }
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
+    if (error) {
+      return { props: { error: error } };
+    } else {
+      return {
+        props: {
+          error: error,
+          name: hospital.name,
+        },
+      };
     }
-  )
+  })
 );
 
 export default AddAHospitalSuccess;

--- a/pages/admin/add-a-hospital.js
+++ b/pages/admin/add-a-hospital.js
@@ -3,7 +3,7 @@ import ErrorSummary from "../../src/components/ErrorSummary";
 import { GridRow, GridColumn } from "../../src/components/Grid";
 import Layout from "../../src/components/Layout";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
-import TokenProvider from "../../src/providers/TokenProvider";
+
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import Error from "next/error";
 import FormGroup from "../../src/components/FormGroup";
@@ -124,19 +124,14 @@ const AddAHospital = ({ error, trustId }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ authenticationToken }) => {
-      const trustId = authenticationToken.trustId;
-      return {
-        props: {
-          trustId,
-        },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+  verifyAdminToken(async ({ authenticationToken }) => {
+    const trustId = authenticationToken.trustId;
+    return {
+      props: {
+        trustId,
+      },
+    };
+  })
 );
 
 export default AddAHospital;

--- a/pages/admin/add-a-ward-success.js
+++ b/pages/admin/add-a-ward-success.js
@@ -3,7 +3,6 @@ import Error from "next/error";
 import Layout from "../../src/components/Layout";
 import AnchorLink from "../../src/components/AnchorLink";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
-import TokenProvider from "../../src/providers/TokenProvider";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
 import ActionLink from "../../src/components/ActionLink";
 
@@ -38,25 +37,20 @@ const AddAWardSuccess = ({ error, name, hospitalName }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container, query, authenticationToken }) => {
-      const getRetrieveWardById = container.getRetrieveWardById();
-      const { ward, error } = await getRetrieveWardById(
-        query.wardId,
-        authenticationToken.trustId
-      );
-      return {
-        props: {
-          error: error,
-          name: ward.name,
-          hospitalName: ward.hospitalName,
-        },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+  verifyAdminToken(async ({ container, query, authenticationToken }) => {
+    const getRetrieveWardById = container.getRetrieveWardById();
+    const { ward, error } = await getRetrieveWardById(
+      query.wardId,
+      authenticationToken.trustId
+    );
+    return {
+      props: {
+        error: error,
+        name: ward.name,
+        hospitalName: ward.hospitalName,
+      },
+    };
+  })
 );
 
 export default AddAWardSuccess;

--- a/pages/admin/add-a-ward.js
+++ b/pages/admin/add-a-ward.js
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { GridRow, GridColumn } from "../../src/components/Grid";
 import Layout from "../../src/components/Layout";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import AddWardForm from "../../src/components/AddWardForm";
 import Error from "next/error";
@@ -33,23 +32,18 @@ const AddAWard = ({ hospitals, error }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container, authenticationToken }) => {
-      const retrieveHospitalsByTrustId = container.getRetrieveHospitalsByTrustId();
-      const { hospitals, error } = await retrieveHospitalsByTrustId(
-        authenticationToken.trustId
-      );
-      return {
-        props: {
-          error,
-          hospitals,
-        },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+  verifyAdminToken(async ({ container, authenticationToken }) => {
+    const retrieveHospitalsByTrustId = container.getRetrieveHospitalsByTrustId();
+    const { hospitals, error } = await retrieveHospitalsByTrustId(
+      authenticationToken.trustId
+    );
+    return {
+      props: {
+        error,
+        hospitals,
+      },
+    };
+  })
 );
 
 export default AddAWard;

--- a/pages/admin/edit-a-ward-success.js
+++ b/pages/admin/edit-a-ward-success.js
@@ -3,7 +3,6 @@ import Error from "next/error";
 import Layout from "../../src/components/Layout";
 import AnchorLink from "../../src/components/AnchorLink";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
-import TokenProvider from "../../src/providers/TokenProvider";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
 import ActionLink from "../../src/components/ActionLink";
 
@@ -38,26 +37,21 @@ const EditAWardSuccess = ({ error, name, hospitalName }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container, query, authenticationToken }) => {
-      const getRetrieveWardById = container.getRetrieveWardById();
-      const { ward, error } = await getRetrieveWardById(
-        query.wardId,
-        authenticationToken.trustId
-      );
+  verifyAdminToken(async ({ container, query, authenticationToken }) => {
+    const getRetrieveWardById = container.getRetrieveWardById();
+    const { ward, error } = await getRetrieveWardById(
+      query.wardId,
+      authenticationToken.trustId
+    );
 
-      return {
-        props: {
-          error: error,
-          name: ward.name,
-          hospitalName: ward.hospitalName,
-        },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+    return {
+      props: {
+        error: error,
+        name: ward.name,
+        hospitalName: ward.hospitalName,
+      },
+    };
+  })
 );
 
 export default EditAWardSuccess;

--- a/pages/admin/edit-a-ward.js
+++ b/pages/admin/edit-a-ward.js
@@ -3,7 +3,6 @@ import Error from "next/error";
 import { GridRow, GridColumn } from "../../src/components/Grid";
 import Layout from "../../src/components/Layout";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import EditWardForm from "../../src/components/EditWardForm";
 
@@ -37,41 +36,36 @@ const EditAWard = ({ error, id, name, hospitalId, hospitals }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container, query, authenticationToken }) => {
-      const getRetrieveWardById = container.getRetrieveWardById();
+  verifyAdminToken(async ({ container, query, authenticationToken }) => {
+    const getRetrieveWardById = container.getRetrieveWardById();
 
-      let error = null;
-      const getRetrieveWardByIdResponse = await getRetrieveWardById(
-        query.wardId,
-        authenticationToken.trustId
-      );
-      error = error || getRetrieveWardByIdResponse.error;
+    let error = null;
+    const getRetrieveWardByIdResponse = await getRetrieveWardById(
+      query.wardId,
+      authenticationToken.trustId
+    );
+    error = error || getRetrieveWardByIdResponse.error;
 
-      const retrieveHospitalsByTrustId = container.getRetrieveHospitalsByTrustId();
-      const retrieveHospitalsResponse = await retrieveHospitalsByTrustId(
-        authenticationToken.trustId
-      );
+    const retrieveHospitalsByTrustId = container.getRetrieveHospitalsByTrustId();
+    const retrieveHospitalsResponse = await retrieveHospitalsByTrustId(
+      authenticationToken.trustId
+    );
 
-      error = error || retrieveHospitalsResponse.error;
-      if (error) {
-        return { props: { error: error } };
-      } else {
-        return {
-          props: {
-            error: error,
-            id: getRetrieveWardByIdResponse.ward.id,
-            name: getRetrieveWardByIdResponse.ward.name,
-            hospitalId: getRetrieveWardByIdResponse.ward.hospitalId,
-            hospitals: retrieveHospitalsResponse.hospitals,
-          },
-        };
-      }
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
+    error = error || retrieveHospitalsResponse.error;
+    if (error) {
+      return { props: { error: error } };
+    } else {
+      return {
+        props: {
+          error: error,
+          id: getRetrieveWardByIdResponse.ward.id,
+          name: getRetrieveWardByIdResponse.ward.name,
+          hospitalId: getRetrieveWardByIdResponse.ward.hospitalId,
+          hospitals: retrieveHospitalsResponse.hospitals,
+        },
+      };
     }
-  )
+  })
 );
 
 export default EditAWard;

--- a/pages/performance.js
+++ b/pages/performance.js
@@ -1,6 +1,5 @@
 import React from "react";
 import verifyAdminToken from "../src/usecases/verifyAdminToken";
-import TokenProvider from "../src/providers/TokenProvider";
 import propsWithContainer from "../src/middleware/propsWithContainer";
 import Layout from "../src/components/Layout";
 import { GridRow, GridColumn } from "../src/components/Grid";
@@ -19,19 +18,14 @@ const Performance = ({ visitsScheduled }) => (
 );
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(
-    async ({ container }) => {
-      const retrieveWardVisitTotals = container.getRetrieveWardVisitTotals();
-      const wardVisitTotals = await retrieveWardVisitTotals();
+  verifyAdminToken(async ({ container }) => {
+    const retrieveWardVisitTotals = container.getRetrieveWardVisitTotals();
+    const wardVisitTotals = await retrieveWardVisitTotals();
 
-      return {
-        props: { visitsScheduled: wardVisitTotals.total },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+    return {
+      props: { visitsScheduled: wardVisitTotals.total },
+    };
+  })
 );
 
 export default Performance;

--- a/pages/wards/book-a-visit-confirmation.js
+++ b/pages/wards/book-a-visit-confirmation.js
@@ -8,8 +8,8 @@ import fetch from "isomorphic-unfetch";
 import moment from "moment";
 import Router from "next/router";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import VisitSummaryList from "../../src/components/VisitSummaryList";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
 
 const ScheduleConfirmation = ({
   patientName,
@@ -93,8 +93,8 @@ const ScheduleConfirmation = ({
   );
 };
 
-export const getServerSideProps = verifyToken(
-  ({ query }) => {
+export const getServerSideProps = propsWithContainer(
+  verifyToken(({ query }) => {
     const {
       patientName,
       contactName,
@@ -115,10 +115,7 @@ export const getServerSideProps = verifyToken(
         callTime,
       },
     };
-  },
-  {
-    tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-  }
+  })
 );
 
 export default ScheduleConfirmation;

--- a/pages/wards/book-a-visit-success.js
+++ b/pages/wards/book-a-visit-success.js
@@ -6,7 +6,7 @@ import Text from "../../src/components/Text";
 import Heading from "../../src/components/Heading";
 import Layout from "../../src/components/Layout";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
 
 const Success = () => {
   return (
@@ -33,13 +33,10 @@ const Success = () => {
   );
 };
 
-export const getServerSideProps = verifyToken(
-  () => {
+export const getServerSideProps = propsWithContainer(
+  verifyToken(() => {
     return { props: {} };
-  },
-  {
-    tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-  }
+  })
 );
 
 export default Success;

--- a/pages/wards/book-a-visit.js
+++ b/pages/wards/book-a-visit.js
@@ -10,7 +10,6 @@ import Layout from "../../src/components/Layout";
 import ErrorSummary from "../../src/components/ErrorSummary";
 import validateMobileNumber from "../../src/helpers/validateMobileNumber";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import Label from "../../src/components/Label";
 import Router from "next/router";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
@@ -230,46 +229,41 @@ const queryContainsInitialData = (query) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyToken(
-    async ({ query, container }) => {
-      let props = {};
-      if (queryContainsInitialData(query)) {
-        const {
-          patientName,
-          contactName,
-          contactNumber,
-          day,
-          month,
-          year,
-          hour,
-          minute,
-        } = query;
-        const callDateTime = { day, month, year, hour, minute };
+  verifyToken(async ({ query, container }) => {
+    let props = {};
+    if (queryContainsInitialData(query)) {
+      const {
+        patientName,
+        contactName,
+        contactNumber,
+        day,
+        month,
+        year,
+        hour,
+        minute,
+      } = query;
+      const callDateTime = { day, month, year, hour, minute };
 
-        props = {
-          ...props,
-          initialPatientName: patientName,
-          initialContactName: contactName,
-          initialContactNumber: contactNumber,
-          initialCallDateTime: callDateTime,
-        };
-      } else if (query.rebookCallId) {
-        const { scheduledCall } = await retrieveVisitByCallId(container)(
-          query.rebookCallId
-        );
-        props = {
-          ...props,
-          initialPatientName: scheduledCall.patientName,
-          initialContactName: scheduledCall.recipientName,
-          initialContactNumber: scheduledCall.recipientNumber,
-        };
-      }
-      return { props };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
+      props = {
+        ...props,
+        initialPatientName: patientName,
+        initialContactName: contactName,
+        initialContactNumber: contactNumber,
+        initialCallDateTime: callDateTime,
+      };
+    } else if (query.rebookCallId) {
+      const { scheduledCall } = await retrieveVisitByCallId(container)(
+        query.rebookCallId
+      );
+      props = {
+        ...props,
+        initialPatientName: scheduledCall.patientName,
+        initialContactName: scheduledCall.recipientName,
+        initialContactNumber: scheduledCall.recipientNumber,
+      };
     }
-  )
+    return { props };
+  })
 );
 
 export default Home;

--- a/pages/wards/cancel-visit-confirmation.js
+++ b/pages/wards/cancel-visit-confirmation.js
@@ -5,7 +5,6 @@ import Heading from "../../src/components/Heading";
 import Layout from "../../src/components/Layout";
 import Router from "next/router";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import retrieveVisitByCallId from "../../src/usecases/retrieveVisitByCallId";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import Error from "next/error";
@@ -67,37 +66,32 @@ const deleteVisitConfirmation = ({
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyToken(
-    async ({ query, container }) => {
-      const { callId } = query;
+  verifyToken(async ({ query, container }) => {
+    const { callId } = query;
 
-      let { scheduledCall, error } = await retrieveVisitByCallId(container)(
-        callId
-      );
-      if (error && !scheduledCall) {
-        scheduledCall = {
-          patientName: "",
-          recipientName: "",
-          recipientNumber: "",
-          callTime: "",
-        };
-      }
-
-      return {
-        props: {
-          patientName: scheduledCall.patientName,
-          contactName: scheduledCall.recipientName,
-          contactNumber: scheduledCall.recipientNumber,
-          callDateAndTime: scheduledCall.callTime,
-          callId,
-          error,
-        },
+    let { scheduledCall, error } = await retrieveVisitByCallId(container)(
+      callId
+    );
+    if (error && !scheduledCall) {
+      scheduledCall = {
+        patientName: "",
+        recipientName: "",
+        recipientNumber: "",
+        callTime: "",
       };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
     }
-  )
+
+    return {
+      props: {
+        patientName: scheduledCall.patientName,
+        contactName: scheduledCall.recipientName,
+        contactNumber: scheduledCall.recipientNumber,
+        callDateAndTime: scheduledCall.callTime,
+        callId,
+        error,
+      },
+    };
+  })
 );
 
 export default deleteVisitConfirmation;

--- a/pages/wards/cancel-visit-success.js
+++ b/pages/wards/cancel-visit-success.js
@@ -5,7 +5,6 @@ import Heading from "../../src/components/Heading";
 import Layout from "../../src/components/Layout";
 import Router from "next/router";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import retrieveVisitByCallId from "../../src/usecases/retrieveVisitByCallId";
 import deleteVisitByCallId from "../../src/usecases/deleteVisitByCallId";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
@@ -53,37 +52,32 @@ const deleteVisitSuccess = ({
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyToken(
-    async ({ query, container }) => {
-      const { callId } = query;
-      let { scheduledCall, error } = await retrieveVisitByCallId(container)(
-        callId
-      );
-      if (error && !scheduledCall) {
-        scheduledCall = {
-          patientName: "",
-          recipientName: "",
-          recipientNumber: "",
-          callTime: "",
-        };
-      }
-
-      let { error: deleteError } = await deleteVisitByCallId(container)(callId);
-      return {
-        props: {
-          patientName: scheduledCall.patientName,
-          contactName: scheduledCall.recipientName,
-          contactNumber: scheduledCall.recipientNumber,
-          callDateAndTime: scheduledCall.callTime,
-          error,
-          deleteError,
-        },
+  verifyToken(async ({ query, container }) => {
+    const { callId } = query;
+    let { scheduledCall, error } = await retrieveVisitByCallId(container)(
+      callId
+    );
+    if (error && !scheduledCall) {
+      scheduledCall = {
+        patientName: "",
+        recipientName: "",
+        recipientNumber: "",
+        callTime: "",
       };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
     }
-  )
+
+    let { error: deleteError } = await deleteVisitByCallId(container)(callId);
+    return {
+      props: {
+        patientName: scheduledCall.patientName,
+        contactName: scheduledCall.recipientName,
+        contactNumber: scheduledCall.recipientNumber,
+        callDateAndTime: scheduledCall.callTime,
+        error,
+        deleteError,
+      },
+    };
+  })
 );
 
 export default deleteVisitSuccess;

--- a/pages/wards/visit-start.js
+++ b/pages/wards/visit-start.js
@@ -10,7 +10,6 @@ import Error from "next/error";
 import formatDate from "../../src/helpers/formatDate";
 import formatTime from "../../src/helpers/formatTime";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 
 const VisitStart = ({
   patientName,
@@ -93,34 +92,29 @@ const VisitStart = ({
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyToken(
-    async ({ query, container }) => {
-      const { callId } = query;
+  verifyToken(async ({ query, container }) => {
+    const { callId } = query;
 
-      const { scheduledCall, error } = await retrieveVisitByCallId(container)(
-        callId
-      );
+    const { scheduledCall, error } = await retrieveVisitByCallId(container)(
+      callId
+    );
 
-      const callTime = formatTime(scheduledCall.callTime, "HH:mm");
-      const callDate = formatDate(scheduledCall.callTime);
+    const callTime = formatTime(scheduledCall.callTime, "HH:mm");
+    const callDate = formatDate(scheduledCall.callTime);
 
-      return {
-        props: {
-          patientName: scheduledCall.patientName,
-          contactName: scheduledCall.recipientName,
-          contactNumber: scheduledCall.recipientNumber,
-          callTime,
-          callDate,
-          callId,
-          error,
-          callPassword: scheduledCall.callPassword,
-        },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+    return {
+      props: {
+        patientName: scheduledCall.patientName,
+        contactName: scheduledCall.recipientName,
+        contactNumber: scheduledCall.recipientNumber,
+        callTime,
+        callDate,
+        callId,
+        error,
+        callPassword: scheduledCall.callPassword,
+      },
+    };
+  })
 );
 
 export default VisitStart;

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -8,7 +8,6 @@ import VisitsTable from "../../src/components/VisitsTable";
 import Error from "next/error";
 import Text from "../../src/components/Text";
 import verifyToken from "../../src/usecases/verifyToken";
-import TokenProvider from "../../src/providers/TokenProvider";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 
 export default function WardVisits({
@@ -64,25 +63,17 @@ export default function WardVisits({
 }
 
 export const getServerSideProps = propsWithContainer(
-  verifyToken(
-    async ({ authenticationToken, container, query }) => {
-      const { wardId, trustId } = authenticationToken;
-      let { scheduledCalls, error } = await container.getRetrieveVisits()({
-        wardId,
-      });
-      let ward;
-      ({ ward, error } = await container.getRetrieveWardById()(
-        wardId,
-        trustId
-      ));
-      const showAccordion = Boolean(query.showAccordion);
+  verifyToken(async ({ authenticationToken, container, query }) => {
+    const { wardId, trustId } = authenticationToken;
+    let { scheduledCalls, error } = await container.getRetrieveVisits()({
+      wardId,
+    });
+    let ward;
+    ({ ward, error } = await container.getRetrieveWardById()(wardId, trustId));
+    const showAccordion = Boolean(query.showAccordion);
 
-      return {
-        props: { scheduledCalls, ward, error, showAccordion: showAccordion },
-      };
-    },
-    {
-      tokens: new TokenProvider(process.env.JWT_SIGNING_KEY),
-    }
-  )
+    return {
+      props: { scheduledCalls, ward, error, showAccordion: showAccordion },
+    };
+  })
 );

--- a/src/usecases/sendTextMessage.js
+++ b/src/usecases/sendTextMessage.js
@@ -14,6 +14,7 @@ const sendTextMessage = ({ getNotifyClient }) => async (
 
     return { success: true, error: null };
   } catch (error) {
+    console.log(error);
     return {
       success: false,
       error: `GovNotify error occurred: ${error?.error?.errors[0]?.message}`,

--- a/src/usecases/sendTextMessage.js
+++ b/src/usecases/sendTextMessage.js
@@ -14,7 +14,6 @@ const sendTextMessage = ({ getNotifyClient }) => async (
 
     return { success: true, error: null };
   } catch (error) {
-    console.log(error);
     return {
       success: false,
       error: `GovNotify error occurred: ${error?.error?.errors[0]?.message}`,

--- a/src/usecases/verifyAdminToken.js
+++ b/src/usecases/verifyAdminToken.js
@@ -1,12 +1,12 @@
 import adminIsAuthenticated from "./adminIsAuthenticated";
 
-export default function (callback, container) {
+export default function (callback) {
   return function (context) {
-    const { req, res } = context;
+    const { req, res, container } = context;
 
-    const authenticationToken = adminIsAuthenticated({
-      getTokenProvider: () => container.tokens,
-    })(req.headers.cookie);
+    const authenticationToken = adminIsAuthenticated(container)(
+      req.headers.cookie
+    );
 
     if (authenticationToken) {
       return callback({ ...context, authenticationToken }) ?? { props: {} };

--- a/src/usecases/verifyAdminToken.test.js
+++ b/src/usecases/verifyAdminToken.test.js
@@ -18,26 +18,33 @@ describe("verifyAdminToken", () => {
     const authenticationToken = {
       admin: true,
     };
+    const tokenProvider = {
+      validate: jest.fn(() => authenticationToken),
+    };
     const container = {
-      tokens: {
-        validate: jest.fn(() => authenticationToken),
-      },
+      getTokenProvider: () => tokenProvider,
     };
 
-    const result = verifyAdminToken(callback, container)({ req, res });
-    expect(callback).toHaveBeenCalledWith({ req, res, authenticationToken });
+    const result = verifyAdminToken(callback)({ req, res, container });
+    expect(callback).toHaveBeenCalledWith({
+      req,
+      res,
+      container,
+      authenticationToken,
+    });
     expect(result).toBe(expectedProps);
   });
 
   it("redirects if the token is not valid", async () => {
     const callback = jest.fn();
+    const tokenProvider = {
+      validate: jest.fn(() => false),
+    };
     const container = {
-      tokens: {
-        validate: jest.fn(() => false),
-      },
+      getTokenProvider: () => tokenProvider,
     };
 
-    verifyAdminToken(callback, container)({ req, res });
+    verifyAdminToken(callback)({ req, res, container });
     expect(res.writeHead).toHaveBeenCalledWith(302, {
       Location: "/wards/login",
     });
@@ -45,14 +52,15 @@ describe("verifyAdminToken", () => {
 
   it("redirects if there are no cookies", async () => {
     const callback = jest.fn();
+    const tokenProvider = {
+      validate: jest.fn(() => false),
+    };
     const container = {
-      tokens: {
-        validate: jest.fn(() => false),
-      },
+      getTokenProvider: () => tokenProvider,
     };
     req.headers.cookie = "";
 
-    verifyAdminToken(callback, container)({ req, res });
+    verifyAdminToken(callback)({ req, res, container });
     expect(res.writeHead).toHaveBeenCalledWith(302, {
       Location: "/wards/login",
     });

--- a/src/usecases/verifyToken.js
+++ b/src/usecases/verifyToken.js
@@ -1,12 +1,12 @@
 import userIsAuthenticated from "./userIsAuthenticated";
 
-export default function (callback, container) {
+export default function (callback) {
   return function (context) {
-    const { req, res } = context;
+    const { req, res, container } = context;
 
-    const authenticationToken = userIsAuthenticated({
-      getTokenProvider: () => container.tokens,
-    })(req.headers.cookie);
+    const authenticationToken = userIsAuthenticated(container)(
+      req.headers.cookie
+    );
 
     if (authenticationToken) {
       return callback({ ...context, authenticationToken }) ?? { props: {} };

--- a/src/usecases/verifyToken.test.js
+++ b/src/usecases/verifyToken.test.js
@@ -18,26 +18,33 @@ describe("verifyToken", () => {
     const authenticationToken = {
       foo: true,
     };
+    const tokenProvider = {
+      validate: jest.fn(() => authenticationToken),
+    };
     const container = {
-      tokens: {
-        validate: jest.fn(() => authenticationToken),
-      },
+      getTokenProvider: () => tokenProvider,
     };
 
-    const result = verifyToken(callback, container)({ req, res });
-    expect(callback).toHaveBeenCalledWith({ req, res, authenticationToken });
+    const result = verifyToken(callback)({ req, res, container });
+    expect(callback).toHaveBeenCalledWith({
+      req,
+      res,
+      container,
+      authenticationToken,
+    });
     expect(result).toBe(expectedProps);
   });
 
   it("redirects if the token is not valid", async () => {
     const callback = jest.fn();
+    const tokenProvider = {
+      validate: jest.fn(() => false),
+    };
     const container = {
-      tokens: {
-        validate: jest.fn(() => false),
-      },
+      getTokenProvider: () => tokenProvider,
     };
 
-    verifyToken(callback, container)({ req, res });
+    verifyToken(callback)({ req, res, container });
     expect(res.writeHead).toHaveBeenCalledWith(302, {
       Location: "/wards/login",
     });
@@ -45,14 +52,15 @@ describe("verifyToken", () => {
 
   it("redirects if there are no cookies", async () => {
     const callback = jest.fn();
+    const tokenProvider = {
+      validate: jest.fn(() => false),
+    };
     const container = {
-      tokens: {
-        validate: jest.fn(() => false),
-      },
+      getTokenProvider: () => tokenProvider,
     };
     req.headers.cookie = "";
 
-    verifyToken(callback, container)({ req, res });
+    verifyToken(callback)({ req, res, container });
     expect(res.writeHead).toHaveBeenCalledWith(302, {
       Location: "/wards/login",
     });


### PR DESCRIPTION
# What

Previously a custom container was used to pass in token provider, now we use the app container.

# Why

Consistency
To support the work to ensure login is not possible with tokens from archived wards.

# Screenshots

# Notes
