### PR TITLE
Seed dev database after running migrations

### DIFF
--- a/bin/setup_dev_db.sh
+++ b/bin/setup_dev_db.sh
@@ -3,3 +3,4 @@
 dropdb nhs-virtual-visit-dev
 createdb nhs-virtual-visit-dev
 npm run dbmigrate up
+cat db/seeds.sql | psql nhs-virtual-visit-dev

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -6,4 +6,4 @@ INSERT INTO hospitals (name, trust_id) VALUES ('Test 2 Hospital', (SELECT id FRO
 INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward One', (SELECT id FROM hospitals WHERE name='Test Hospital'), 'TEST1', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward Two', (SELECT id FROM hospitals WHERE name='Test Hospital 2'), 'TEST2', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test 2 Ward One', (SELECT id FROM hospitals WHERE name='Test 2 Hospital'), 'TEST22', (SELECT id FROM trusts WHERE name='Test 2 Trust'));
-INSERT INTO wards (name, hospital_name, code, trust_id, archived_at) VALUES ('Archived Ward', 'Test Hospital', 'TESTARC', (SELECT id FROM trusts WHERE name='Test Trust'), CURRENT_TIMESTAMP);
+INSERT INTO wards (name, hospital_id, code, trust_id, archived_at) VALUES ('Archived Ward',  (SELECT id FROM hospitals WHERE name='Test Hospital'), 'TESTARC', (SELECT id FROM trusts WHERE name='Test Trust'), CURRENT_TIMESTAMP);


### PR DESCRIPTION
# What
Seeds the development database after running migrations

# Why
Quickly populates the dev database so that you can get up and running faster

# Screenshots

# Notes
