### PR TITLE
Split visits by today, upcoming and past

### DIFF
--- a/pageTests/wards/visits.test.js
+++ b/pageTests/wards/visits.test.js
@@ -56,7 +56,7 @@ describe("ward/visits", () => {
       });
       expect(res.writeHead).not.toHaveBeenCalled();
 
-      expect(visitsSpy).toHaveBeenCalledWith({ wardId: 1 });
+      expect(visitsSpy).toHaveBeenCalledWith({ wardId: 1, withInterval: true });
       expect(wardSpy).toHaveBeenCalledWith(1, 1);
       expect(props.error).toBeNull();
       expect(props.scheduledCalls).toHaveLength(2);

--- a/pageTests/wards/visits.test.js
+++ b/pageTests/wards/visits.test.js
@@ -99,8 +99,9 @@ describe("ward/visits", () => {
     });
 
     it("passes a feature flag query param to the props", async () => {
+      const retrieveSpy = jest.fn().mockReturnValue({});
       const container = {
-        getRetrieveVisits: () => jest.fn().mockReturnValue({}),
+        getRetrieveVisits: () => retrieveSpy,
         getRetrieveWardById: () => jest.fn().mockReturnValue({}),
       };
 
@@ -112,6 +113,10 @@ describe("ward/visits", () => {
       });
 
       expect(props.showAccordion).toEqual(true);
+      expect(retrieveSpy).toHaveBeenCalledWith({
+        wardId: 1,
+        withInterval: false,
+      });
     });
   });
 });

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -11,6 +11,7 @@ import verifyToken from "../../src/usecases/verifyToken";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import filterTodaysVisits from "../../src/helpers/filterTodaysVisits";
 import filterUpcomingVisits from "../../src/helpers/filterUpcomingVisits";
+import filterPastVisits from "../../src/helpers/filterPastVisits";
 
 export default function WardVisits({
   scheduledCalls,
@@ -31,7 +32,11 @@ export default function WardVisits({
     <div className="nhsuk-grid-row">
       <div className="nhsuk-grid-column-one-quarter">
         <ul className="nhsuk-list">
-          <li>
+          <li
+            className={
+              visitsPanelListTitle == "Today" ? "nhsuk-u-font-weight-bold" : ""
+            }
+          >
             <a
               href="#"
               onClick={() => {
@@ -51,6 +56,17 @@ export default function WardVisits({
               }}
             >
               Upcoming
+            </a>
+          </li>
+          <li>
+            <a
+              href="#"
+              onClick={() => {
+                setDisplayedVisits(filterPastVisits(scheduledCalls));
+                setVisitsPanelListTitle("Past");
+              }}
+            >
+              Past
             </a>
           </li>
         </ul>

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -65,13 +65,15 @@ export default function WardVisits({
 export const getServerSideProps = propsWithContainer(
   verifyToken(async ({ authenticationToken, container, query }) => {
     const { wardId, trustId } = authenticationToken;
+    const showAccordion = Boolean(query.showAccordion);
+    const withInterval = !showAccordion;
+
     let { scheduledCalls, error } = await container.getRetrieveVisits()({
       wardId,
-      withInterval: true,
+      withInterval: withInterval,
     });
     let ward;
     ({ ward, error } = await container.getRetrieveWardById()(wardId, trustId));
-    const showAccordion = Boolean(query.showAccordion);
 
     return {
       props: { scheduledCalls, ward, error, showAccordion: showAccordion },

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -67,6 +67,7 @@ export const getServerSideProps = propsWithContainer(
     const { wardId, trustId } = authenticationToken;
     let { scheduledCalls, error } = await container.getRetrieveVisits()({
       wardId,
+      withInterval: true,
     });
     let ward;
     ({ ward, error } = await container.getRetrieveWardById()(wardId, trustId));

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -1,17 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 import Layout from "../../src/components/Layout";
 import Heading from "../../src/components/Heading";
 import ActionLink from "../../src/components/ActionLink";
 import { GridRow, GridColumn } from "../../src/components/Grid";
-import VisitsPanelList from "../../src/components/VisitsPanelList";
 import VisitsTable from "../../src/components/VisitsTable";
 import Error from "next/error";
 import Text from "../../src/components/Text";
 import verifyToken from "../../src/usecases/verifyToken";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
-import filterTodaysVisits from "../../src/helpers/filterTodaysVisits";
-import filterUpcomingVisits from "../../src/helpers/filterUpcomingVisits";
-import filterPastVisits from "../../src/helpers/filterPastVisits";
+import AccordionVisits from "../../src/components/AccordionVisits";
 
 export default function WardVisits({
   scheduledCalls,
@@ -23,62 +20,8 @@ export default function WardVisits({
     return <Error />;
   }
 
-  const [displayedVisits, setDisplayedVisits] = useState(
-    filterTodaysVisits(scheduledCalls)
-  );
-  const [visitsPanelListTitle, setVisitsPanelListTitle] = useState("Today");
-
   const tableContainer = showAccordion ? (
-    <div className="nhsuk-grid-row">
-      <div className="nhsuk-grid-column-one-quarter">
-        <ul className="nhsuk-list">
-          <li
-            className={
-              visitsPanelListTitle == "Today" ? "nhsuk-u-font-weight-bold" : ""
-            }
-          >
-            <a
-              href="#"
-              onClick={() => {
-                setDisplayedVisits(filterTodaysVisits(scheduledCalls));
-                setVisitsPanelListTitle("Today");
-              }}
-            >
-              Today
-            </a>
-          </li>
-          <li>
-            <a
-              href="#"
-              onClick={() => {
-                setDisplayedVisits(filterUpcomingVisits(scheduledCalls));
-                setVisitsPanelListTitle("Upcoming");
-              }}
-            >
-              Upcoming
-            </a>
-          </li>
-          <li>
-            <a
-              href="#"
-              onClick={() => {
-                setDisplayedVisits(filterPastVisits(scheduledCalls));
-                setVisitsPanelListTitle("Past");
-              }}
-            >
-              Past
-            </a>
-          </li>
-        </ul>
-      </div>
-
-      <div className="nhsuk-grid-column-three-quarters">
-        <VisitsPanelList
-          visits={displayedVisits}
-          title={visitsPanelListTitle}
-        />
-      </div>
-    </div>
+    <AccordionVisits visits={scheduledCalls} />
   ) : (
     <VisitsTable visits={scheduledCalls} />
   );

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -10,6 +10,7 @@ import Text from "../../src/components/Text";
 import verifyToken from "../../src/usecases/verifyToken";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import filterTodaysVisits from "../../src/helpers/filterTodaysVisits";
+import filterUpcomingVisits from "../../src/helpers/filterUpcomingVisits";
 
 export default function WardVisits({
   scheduledCalls,
@@ -21,10 +22,47 @@ export default function WardVisits({
     return <Error />;
   }
 
-  const [displayedVisits] = useState(filterTodaysVisits(scheduledCalls));
+  const [displayedVisits, setDisplayedVisits] = useState(
+    filterTodaysVisits(scheduledCalls)
+  );
+  const [visitsPanelListTitle, setVisitsPanelListTitle] = useState("Today");
 
   const tableContainer = showAccordion ? (
-    <VisitsPanelList visits={displayedVisits} title="Today" />
+    <div className="nhsuk-grid-row">
+      <div className="nhsuk-grid-column-one-quarter">
+        <ul className="nhsuk-list">
+          <li>
+            <a
+              href="#"
+              onClick={() => {
+                setDisplayedVisits(filterTodaysVisits(scheduledCalls));
+                setVisitsPanelListTitle("Today");
+              }}
+            >
+              Today
+            </a>
+          </li>
+          <li>
+            <a
+              href="#"
+              onClick={() => {
+                setDisplayedVisits(filterUpcomingVisits(scheduledCalls));
+                setVisitsPanelListTitle("Upcoming");
+              }}
+            >
+              Upcoming
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div className="nhsuk-grid-column-three-quarters">
+        <VisitsPanelList
+          visits={displayedVisits}
+          title={visitsPanelListTitle}
+        />
+      </div>
+    </div>
   ) : (
     <VisitsTable visits={scheduledCalls} />
   );

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Layout from "../../src/components/Layout";
 import Heading from "../../src/components/Heading";
 import ActionLink from "../../src/components/ActionLink";
@@ -9,6 +9,7 @@ import Error from "next/error";
 import Text from "../../src/components/Text";
 import verifyToken from "../../src/usecases/verifyToken";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
+import filterTodaysVisits from "../../src/helpers/filterTodaysVisits";
 
 export default function WardVisits({
   scheduledCalls,
@@ -20,8 +21,10 @@ export default function WardVisits({
     return <Error />;
   }
 
+  const [displayedVisits] = useState(filterTodaysVisits(scheduledCalls));
+
   const tableContainer = showAccordion ? (
-    <VisitsPanelList visits={scheduledCalls} />
+    <VisitsPanelList visits={displayedVisits} title="Today" />
   ) : (
     <VisitsTable visits={scheduledCalls} />
   );

--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import filterTodaysVisits from "../../helpers/filterTodaysVisits";
+import filterUpcomingVisits from "../../helpers/filterUpcomingVisits";
+import filterPastVisits from "../../helpers/filterPastVisits";
+import VisitsPanelList from "../VisitsPanelList";
+
+const AccordionVisits = ({ visits }) => {
+  const [displayedVisits, setDisplayedVisits] = useState(
+    filterTodaysVisits(visits)
+  );
+  const [visitsPanelListTitle, setVisitsPanelListTitle] = useState("Today");
+
+  return (
+    <div className="nhsuk-grid-row">
+      <div className="nhsuk-grid-column-one-quarter">
+        <ul className="nhsuk-list">
+          <li
+            className={
+              visitsPanelListTitle == "Today" ? "nhsuk-u-font-weight-bold" : ""
+            }
+          >
+            <a
+              href="#"
+              onClick={() => {
+                setDisplayedVisits(filterTodaysVisits(visits));
+                setVisitsPanelListTitle("Today");
+              }}
+            >
+              Today
+            </a>
+          </li>
+          <li>
+            <a
+              href="#"
+              onClick={() => {
+                setDisplayedVisits(filterUpcomingVisits(visits));
+                setVisitsPanelListTitle("Upcoming");
+              }}
+            >
+              Upcoming
+            </a>
+          </li>
+          <li>
+            <a
+              href="#"
+              onClick={() => {
+                setDisplayedVisits(filterPastVisits(visits));
+                setVisitsPanelListTitle("Past");
+              }}
+            >
+              Past
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div className="nhsuk-grid-column-three-quarters">
+        <VisitsPanelList
+          visits={displayedVisits}
+          title={visitsPanelListTitle}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AccordionVisits;

--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -10,6 +10,7 @@ const AccordionVisits = ({ visits }) => {
     filterTodaysVisits(visits)
   );
   const [visitsPanelListTitle, setVisitsPanelListTitle] = useState("Today");
+  const [showButtons, setShowButtons] = useState(true);
 
   return (
     <div className="nhsuk-grid-row">
@@ -25,6 +26,7 @@ const AccordionVisits = ({ visits }) => {
               onClick={() => {
                 setDisplayedVisits(filterTodaysVisits(visits));
                 setVisitsPanelListTitle("Today");
+                setShowButtons(true);
               }}
             >
               Today
@@ -42,6 +44,7 @@ const AccordionVisits = ({ visits }) => {
               onClick={() => {
                 setDisplayedVisits(filterUpcomingVisits(visits));
                 setVisitsPanelListTitle("Upcoming");
+                setShowButtons(true);
               }}
             >
               Upcoming
@@ -57,6 +60,7 @@ const AccordionVisits = ({ visits }) => {
               onClick={() => {
                 setDisplayedVisits(filterPastVisits(visits));
                 setVisitsPanelListTitle("Past");
+                setShowButtons(false);
               }}
             >
               Past
@@ -69,6 +73,7 @@ const AccordionVisits = ({ visits }) => {
         <VisitsPanelList
           visits={displayedVisits}
           title={visitsPanelListTitle}
+          showButtons={showButtons}
         />
       </div>
     </div>

--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -30,7 +30,13 @@ const AccordionVisits = ({ visits }) => {
               Today
             </a>
           </li>
-          <li>
+          <li
+            className={
+              visitsPanelListTitle == "Upcoming"
+                ? "nhsuk-u-font-weight-bold"
+                : ""
+            }
+          >
             <a
               href="#"
               onClick={() => {
@@ -41,7 +47,11 @@ const AccordionVisits = ({ visits }) => {
               Upcoming
             </a>
           </li>
-          <li>
+          <li
+            className={
+              visitsPanelListTitle == "Past" ? "nhsuk-u-font-weight-bold" : ""
+            }
+          >
             <a
               href="#"
               onClick={() => {

--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -3,6 +3,7 @@ import filterTodaysVisits from "../../helpers/filterTodaysVisits";
 import filterUpcomingVisits from "../../helpers/filterUpcomingVisits";
 import filterPastVisits from "../../helpers/filterPastVisits";
 import VisitsPanelList from "../VisitsPanelList";
+import "./styles.scss";
 
 const AccordionVisits = ({ visits }) => {
   const [displayedVisits, setDisplayedVisits] = useState(

--- a/src/components/AccordionVisits/styles.scss
+++ b/src/components/AccordionVisits/styles.scss
@@ -1,0 +1,5 @@
+@import "node_modules/nhsuk-frontend/packages/nhsuk";
+
+a:visited {
+  color: $color_nhsuk-blue;
+}

--- a/src/components/AccordionVisits/styles.scss
+++ b/src/components/AccordionVisits/styles.scss
@@ -1,4 +1,4 @@
-@import "node_modules/nhsuk-frontend/packages/nhsuk";
+@import "node_modules/nhsuk-frontend/packages/core/settings/colours";
 
 a:visited {
   color: $color_nhsuk-blue;

--- a/src/components/VisitsPanelList/index.js
+++ b/src/components/VisitsPanelList/index.js
@@ -7,7 +7,7 @@ import { GridRow, GridColumn } from "../Grid";
 import TimeFromNow from "../TimeFromNow";
 import Text from "../Text";
 
-const VisitsPanelList = ({ visits, title }) => {
+const VisitsPanelList = ({ visits, title, showButtons }) => {
   if (visits.length != 0) {
     return (
       <div className="nhsuk-list-panel nhsuk-u-margin-0">
@@ -57,32 +57,36 @@ const VisitsPanelList = ({ visits, title }) => {
                         </GridColumn>
                       </GridRow>
 
-                      <button
-                        className="nhsuk-button nhsuk-u-margin-right-5 nhsuk-u-margin-bottom-4"
-                        type="submit"
-                        onClick={() => {
-                          const callId = visit.callId;
-                          Router.push({
-                            pathname: `/wards/visit-start`,
-                            query: { callId },
-                          });
-                        }}
-                      >
-                        Start
-                      </button>
+                      {showButtons && (
+                        <>
+                          <button
+                            className="nhsuk-button nhsuk-u-margin-right-5 nhsuk-u-margin-bottom-4"
+                            type="submit"
+                            onClick={() => {
+                              const callId = visit.callId;
+                              Router.push({
+                                pathname: `/wards/visit-start`,
+                                query: { callId },
+                              });
+                            }}
+                          >
+                            Start
+                          </button>
 
-                      <button
-                        className="nhsuk-button nhsuk-button--secondary"
-                        onClick={() => {
-                          const callId = visit.callId;
-                          Router.push({
-                            pathname: `/wards/cancel-visit-confirmation`,
-                            query: { callId },
-                          });
-                        }}
-                      >
-                        Cancel
-                      </button>
+                          <button
+                            className="nhsuk-button nhsuk-button--secondary"
+                            onClick={() => {
+                              const callId = visit.callId;
+                              Router.push({
+                                pathname: `/wards/cancel-visit-confirmation`,
+                                query: { callId },
+                              });
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      )}
                     </div>
                   </details>
                 </div>

--- a/src/components/VisitsPanelList/index.js
+++ b/src/components/VisitsPanelList/index.js
@@ -4,11 +4,9 @@ import Router from "next/router";
 import formatDateAndTime from "../../helpers/formatDateAndTime";
 import VisitSummaryList from "../VisitSummaryList";
 import { GridRow, GridColumn } from "../Grid";
-import filterTodaysVisits from "../../helpers/filterTodaysVisits";
-import filterUpcomingVisits from "../../helpers/filterUpcomingVisits";
 import TimeFromNow from "../TimeFromNow";
 
-const VisitPanelList = ({ visits, title }) => {
+const VisitsPanelList = ({ visits, title }) => {
   if (visits.length != 0) {
     return (
       <div className="nhsuk-list-panel nhsuk-u-margin-0">
@@ -103,19 +101,6 @@ const VisitPanelList = ({ visits, title }) => {
   } else {
     return null;
   }
-};
-
-const VisitsPanelList = ({ visits }) => {
-  const today = filterTodaysVisits(visits);
-  const upcoming = filterUpcomingVisits(visits);
-
-  return (
-    <>
-      <VisitPanelList visits={today} title="Today" />
-      <br />
-      <VisitPanelList visits={upcoming} title="Upcoming" />
-    </>
-  );
 };
 
 export default VisitsPanelList;

--- a/src/components/VisitsPanelList/index.js
+++ b/src/components/VisitsPanelList/index.js
@@ -5,6 +5,7 @@ import formatDateAndTime from "../../helpers/formatDateAndTime";
 import VisitSummaryList from "../VisitSummaryList";
 import { GridRow, GridColumn } from "../Grid";
 import TimeFromNow from "../TimeFromNow";
+import Text from "../Text";
 
 const VisitsPanelList = ({ visits, title }) => {
   if (visits.length != 0) {
@@ -99,7 +100,28 @@ const VisitsPanelList = ({ visits, title }) => {
       </div>
     );
   } else {
-    return null;
+    return (
+      <div className="nhsuk-list-panel nhsuk-u-margin-0">
+        <h3
+          className="nhsuk-list-panel__label"
+          style={{ fontSize: "1.5rem" }}
+          id="A"
+        >
+          {title}
+        </h3>
+        <ul className="nhsuk-list-panel__list nhsuk-list-panel__list--with-label">
+          <li className="nhsuk-list-panel__item">
+            <div className="app-visit-card">
+              <div className="app-visit-card-body">
+                <Text className="nhsuk-u-margin-bottom-0">
+                  There are no virtual visits.
+                </Text>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    );
   }
 };
 

--- a/src/helpers/filterPastVisits.js
+++ b/src/helpers/filterPastVisits.js
@@ -1,0 +1,7 @@
+import moment from "moment";
+
+export default function filterPastVisits(visits) {
+  return visits.filter((visit) =>
+    moment(visit.callTime).isBefore(moment().startOf("day"))
+  );
+}

--- a/src/helpers/filterPastVisits.test.js
+++ b/src/helpers/filterPastVisits.test.js
@@ -1,0 +1,27 @@
+import MockDate from "mockdate";
+import filterPastVisits from "./filterPastVisits";
+
+describe("filterPastVisits", () => {
+  beforeEach(() => {
+    MockDate.set(new Date("2020-05-18"));
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  it("returns visits that were scheduled in the past", () => {
+    const visits = [
+      { callTime: "2020-05-17 13:00:00" },
+      { callTime: "2020-05-17 23:59:59" },
+      { callTime: "2020-05-18 00:00:00" },
+      { callTime: "2020-05-18 00:00:01" },
+      { callTime: "2020-05-18 13:00:00" },
+    ];
+
+    expect(filterPastVisits(visits)).toEqual([
+      { callTime: "2020-05-17 13:00:00" },
+      { callTime: "2020-05-17 23:59:59" },
+    ]);
+  });
+});

--- a/src/usecases/retrieveVisits.js
+++ b/src/usecases/retrieveVisits.js
@@ -1,10 +1,12 @@
-const retrieveVisits = ({ getDb }) => async ({ wardId }) => {
+const retrieveVisits = ({ getDb }) => async ({ wardId, withInterval }) => {
   const db = await getDb();
   try {
-    const scheduledCalls = await db.any(
-      `SELECT * FROM scheduled_calls_table WHERE call_time > NOW() - INTERVAL '12 hours' AND ward_id = $1 ORDER BY call_time ASC`,
-      [wardId]
-    );
+    let query = `SELECT * FROM scheduled_calls_table WHERE ward_id = $1 ORDER BY call_time ASC`;
+    if (withInterval) {
+      query = `SELECT * FROM scheduled_calls_table WHERE call_time > NOW() - INTERVAL '12 hours' AND ward_id = $1 ORDER BY call_time ASC`;
+    }
+
+    const scheduledCalls = await db.any(query, [wardId]);
 
     return {
       scheduledCalls: scheduledCalls.map((scheduledCall) => ({

--- a/src/usecases/retrieveVisits.test.js
+++ b/src/usecases/retrieveVisits.test.js
@@ -58,6 +58,54 @@ describe("retrieveVisits", () => {
     });
   });
 
+  it("returns a query with a 12 hour interval when withInterval is true", async () => {
+    const anySpy = jest.fn(() => []);
+
+    const container = {
+      async getDb() {
+        return {
+          any: anySpy,
+        };
+      },
+    };
+
+    await retrieveVisits(container)({
+      wardId: 1,
+      withInterval: true,
+    });
+
+    expect(
+      anySpy
+    ).toHaveBeenCalledWith(
+      "SELECT * FROM scheduled_calls_table WHERE call_time > NOW() - INTERVAL '12 hours' AND ward_id = $1 ORDER BY call_time ASC",
+      [1]
+    );
+  });
+
+  it("returns a query with a 12 hour interval when withInterval is false", async () => {
+    const anySpy = jest.fn(() => []);
+
+    const container = {
+      async getDb() {
+        return {
+          any: anySpy,
+        };
+      },
+    };
+
+    await retrieveVisits(container)({
+      wardId: 1,
+      withInterval: false,
+    });
+
+    expect(
+      anySpy
+    ).toHaveBeenCalledWith(
+      "SELECT * FROM scheduled_calls_table WHERE ward_id = $1 ORDER BY call_time ASC",
+      [1]
+    );
+  });
+
   it("returns an error object on db exception", async () => {
     const container = {
       async getDb() {


### PR DESCRIPTION
# What
Split the virtual visits by todays visits, upcoming visits, and visits in the past

# Why
This makes the visits page less noisy and more user friendly for ward staff

# Screenshots
Old
![old](https://user-images.githubusercontent.com/7527178/82453375-5b969580-9aa8-11ea-8a7d-ffb3e3edb20d.png)

New 
![new past](https://user-images.githubusercontent.com/7527178/82453380-5df8ef80-9aa8-11ea-9241-f77505d06e7d.png)
![new today](https://user-images.githubusercontent.com/7527178/82453383-5e918600-9aa8-11ea-9198-b1122f3c5a9e.png)

# Notes
