### PR TITLE
Update visits page to show the current time

### DIFF
--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Layout from "../../src/components/Layout";
-import Heading from "../../src/components/Heading";
+import HeadingWithTime from "../../src/components/HeadingWithTime";
 import ActionLink from "../../src/components/ActionLink";
 import { GridRow, GridColumn } from "../../src/components/Grid";
 import VisitsTable from "../../src/components/VisitsTable";
@@ -30,13 +30,13 @@ export default function WardVisits({
     <Layout title="Virtual visits" renderLogout={true}>
       <GridRow>
         <GridColumn width="full">
-          <Heading>
+          <HeadingWithTime>
             <span className="nhsuk-caption-l">
               Ward: {ward.name}
               <span className="nhsuk-u-visually-hidden">-</span>
             </span>
             Virtual visits
-          </Heading>
+          </HeadingWithTime>
 
           <h2 className="nhsuk-heading-l">Book a virtual visit</h2>
 

--- a/src/components/HeadingWithTime/index.js
+++ b/src/components/HeadingWithTime/index.js
@@ -1,0 +1,17 @@
+import React from "react";
+import Heading from "../Heading";
+import TimeNow from "../TimeNow";
+import "./styles.scss";
+
+const HeadingWithTime = ({ children }) => (
+  <div className="app-heading-with-time">
+    <div className="app-heading-with-time-text">
+      <Heading>{children}</Heading>
+    </div>
+    <div className="app-heading-with-time-beside">
+      <TimeNow />
+    </div>
+  </div>
+);
+
+export default HeadingWithTime;

--- a/src/components/HeadingWithTime/styles.scss
+++ b/src/components/HeadingWithTime/styles.scss
@@ -1,0 +1,30 @@
+@import "node_modules/nhsuk-frontend/packages/nhsuk";
+
+.app-heading-with-time {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap-reverse;
+
+  .app-heading-with-time-text {
+    width: 50%;
+  }
+
+  .app-heading-with-time-beside {
+    @include nhsuk-typography-responsive(32);
+    font-weight: $nhsuk-font-bold;
+    text-align: right;
+    width: 50%;
+  }
+
+  @media screen and (max-width: 641px) {
+    .app-heading-with-time-text {
+      width: 100%;
+    }
+
+    .app-heading-with-time-beside {
+      @include nhsuk-responsive-margin(4, "bottom");
+      text-align: left;
+      width: 100%;
+    }
+  }
+}

--- a/src/components/TimeNow/index.js
+++ b/src/components/TimeNow/index.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+import moment from "moment";
+
+const oneSecond = 1000;
+
+const TimeNow = () => {
+  const [timeNow, setTimeNow] = useState(moment().format("HH:mm"));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimeNow(moment().format("HH:mm"));
+    }, oneSecond);
+    return () => clearInterval(interval);
+  }, []);
+
+  return timeNow;
+};
+
+export default TimeNow;


### PR DESCRIPTION
# What

Update visits page to show the current time.

# Why

On a tablet the current time is potentially quite small so we hope to aid ward staff when making decisions around the time of visits.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/82466974-fc8d4c80-9ab8-11ea-9911-83b22467899c.png)

# Notes

Should this be feature flagged?