### PR TITLE
Refactor token user type

### DIFF
--- a/pageTests/admin.test.js
+++ b/pageTests/admin.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../pages/admin";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true, trustId: 1 }
-);
-
 describe("admin", () => {
   const anonymousReq = {
     headers: {
@@ -35,6 +30,10 @@ describe("admin", () => {
 
   let res;
 
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId: 1 })),
+  };
+
   beforeEach(() => {
     res = {
       writeHead: jest.fn().mockReturnValue({ end: () => {} }),
@@ -62,6 +61,7 @@ describe("admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
       };
 
       const { props } = await getServerSideProps({
@@ -87,6 +87,7 @@ describe("admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
       };
 
       const { props } = await getServerSideProps({
@@ -113,6 +114,7 @@ describe("admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
       };
 
       const { props } = await getServerSideProps({
@@ -138,6 +140,7 @@ describe("admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
       };
 
       const { props } = await getServerSideProps({

--- a/pageTests/admin/add-a-hospital-success.test.js
+++ b/pageTests/admin/add-a-hospital-success.test.js
@@ -1,14 +1,13 @@
 import { getServerSideProps } from "../../pages/admin/add-a-hospital-success";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true, trustId: 1 }
-);
-
 const authenticatedReq = {
   headers: {
     cookie: "token=123",
   },
+};
+
+const tokenProvider = {
+  validate: jest.fn(() => ({ type: "trustAdmin", trustId: 1 })),
 };
 
 describe("/admin/add-a-hospital-success", () => {
@@ -47,6 +46,7 @@ describe("/admin/add-a-hospital-success", () => {
 
         const container = {
           getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
+          getTokenProvider: () => tokenProvider,
         };
 
         await getServerSideProps({
@@ -72,6 +72,7 @@ describe("/admin/add-a-hospital-success", () => {
 
         const container = {
           getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
+          getTokenProvider: () => tokenProvider,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/admin/add-a-hospital.test.js
+++ b/pageTests/admin/add-a-hospital.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/add-a-hospital";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true, trustId: 1 }
-);
-
 describe("/admin/add-a-hospital", () => {
   const anonymousReq = {
     headers: {

--- a/pageTests/admin/add-a-ward-success.test.js
+++ b/pageTests/admin/add-a-ward-success.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/add-a-ward-success";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true, trustId: 1 }
-);
-
 const authenticatedReq = {
   headers: {
     cookie: "token=123",
@@ -19,6 +14,10 @@ describe("/admin/add-a-ward-success", () => {
   };
 
   let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId: 1 })),
+  };
 
   beforeEach(() => {
     res = {
@@ -48,6 +47,7 @@ describe("/admin/add-a-ward-success", () => {
 
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
+          getTokenProvider: () => tokenProvider,
         };
 
         await getServerSideProps({
@@ -74,6 +74,7 @@ describe("/admin/add-a-ward-success", () => {
 
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
+          getTokenProvider: () => tokenProvider,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/admin/add-a-ward.test.js
+++ b/pageTests/admin/add-a-ward.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/add-a-ward";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
-);
-
 describe("/admin/add-a-ward", () => {
   const anonymousReq = {
     headers: {

--- a/pageTests/admin/archive-a-ward-confirmation.test.js
+++ b/pageTests/admin/archive-a-ward-confirmation.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/archive-a-ward-confirmation";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
-);
-
 describe("/admin/archive-a-ward-confirmation", () => {
   const anonymousReq = {
     headers: {

--- a/pageTests/admin/archive-a-ward-success.test.js
+++ b/pageTests/admin/archive-a-ward-success.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/archive-a-ward-success";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
-);
-
 describe("/admin/archive-a-ward-success", () => {
   const anonymousReq = {
     headers: {

--- a/pageTests/admin/edit-a-ward-success.test.js
+++ b/pageTests/admin/edit-a-ward-success.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/edit-a-ward-success";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true, trustId: 1 }
-);
-
 const authenticatedReq = {
   headers: {
     cookie: "token=123",
@@ -19,6 +14,10 @@ describe("/admin/edit-a-ward-success", () => {
   };
 
   let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId: 1 })),
+  };
 
   beforeEach(() => {
     res = {
@@ -48,6 +47,7 @@ describe("/admin/edit-a-ward-success", () => {
 
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
+          getTokenProvider: () => tokenProvider,
         };
 
         await getServerSideProps({
@@ -74,6 +74,7 @@ describe("/admin/edit-a-ward-success", () => {
 
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
+          getTokenProvider: () => tokenProvider,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/admin/edit-a-ward.test.js
+++ b/pageTests/admin/edit-a-ward.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/admin/edit-a-ward";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true, trustId: 10 }
-);
-
 const authenticatedReq = {
   headers: {
     cookie: "token=123",
@@ -19,6 +14,10 @@ describe("/admin/edit-a-ward", () => {
   };
 
   let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId: 10 })),
+  };
 
   beforeEach(() => {
     res = {
@@ -53,6 +52,7 @@ describe("/admin/edit-a-ward", () => {
               hospitals: [],
               error: null,
             }),
+          getTokenProvider: () => tokenProvider,
         };
 
         await getServerSideProps({
@@ -84,6 +84,7 @@ describe("/admin/edit-a-ward", () => {
               hospitals: [],
               error: null,
             }),
+          getTokenProvider: () => tokenProvider,
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/api/session.test.js
+++ b/pageTests/api/session.test.js
@@ -82,6 +82,7 @@ describe("api/session", () => {
           wardCode: "MEOW",
           admin: false,
           trustId: 1,
+          type: "wardStaff",
         });
         expect(response.writeHead).toHaveBeenCalledWith(
           201,
@@ -135,6 +136,7 @@ describe("api/session", () => {
           wardCode: undefined,
           admin: true,
           trustId: 1,
+          type: "trustAdmin",
         });
         expect(response.writeHead).toHaveBeenCalledWith(
           201,

--- a/pageTests/api/session.test.js
+++ b/pageTests/api/session.test.js
@@ -80,7 +80,6 @@ describe("api/session", () => {
         expect(tokenGeneratorSpy).toHaveBeenCalledWith({
           wardId: 10,
           wardCode: "MEOW",
-          admin: false,
           trustId: 1,
           type: "wardStaff",
         });
@@ -134,7 +133,6 @@ describe("api/session", () => {
         expect(tokenGeneratorSpy).toHaveBeenCalledWith({
           wardId: undefined,
           wardCode: undefined,
-          admin: true,
           trustId: 1,
           type: "trustAdmin",
         });

--- a/pageTests/performance.test.js
+++ b/pageTests/performance.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../pages/performance";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../src/usecases/adminIsAuthenticated", () => () => (token) =>
-  token && { admin: true }
-);
-
 describe("/performance", () => {
   const anonymousReq = {
     headers: {
@@ -37,8 +32,12 @@ describe("/performance", () => {
 
     it("Provides the current visit totals as props", async () => {
       const wardVisitTotalSpy = jest.fn(() => ({ total: 30 }));
+      const tokenProvider = {
+        validate: jest.fn(() => ({ type: "trustAdmin" })),
+      };
       const container = {
         getRetrieveWardVisitTotals: () => wardVisitTotalSpy,
+        getTokenProvider: () => tokenProvider,
       };
       const { props } = await getServerSideProps({
         req: authenticatedReq,

--- a/pageTests/wards/book-a-visit-confirmation.test.js
+++ b/pageTests/wards/book-a-visit-confirmation.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/wards/book-a-visit-confirmation";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/userIsAuthenticated", () => () => (token) =>
-  token && { ward: "123" }
-);
-
 describe("/wards/book-a-visit-confirmation", () => {
   describe("getServerSideProps", () => {
     const anonymousReq = {

--- a/pageTests/wards/book-a-visit-success.test.js
+++ b/pageTests/wards/book-a-visit-success.test.js
@@ -1,9 +1,4 @@
 import { getServerSideProps } from "../../pages/wards/book-a-visit-success";
-//
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/userIsAuthenticated", () => () => (token) =>
-  token && { ward: "123" }
-);
 
 describe("wards/book-a-visit-success", () => {
   const anonymousReq = {
@@ -19,6 +14,10 @@ describe("wards/book-a-visit-success", () => {
   };
 
   let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "wardStaff", wardId: 123, trustId: 10 })),
+  };
 
   beforeEach(() => {
     res = {
@@ -36,13 +35,22 @@ describe("wards/book-a-visit-success", () => {
     });
 
     it("retrieves the ward id from the authentication token", async () => {
+      const getRetrieveWardByIdSpy = jest.fn().mockReturnValue({});
+
+      const container = {
+        getRetrieveWardById: () => getRetrieveWardByIdSpy,
+        getTokenProvider: () => tokenProvider,
+      };
+
       const { props } = await getServerSideProps({
         req: authenticatedReq,
         res,
         query: {},
+        container: container,
       });
 
       expect(props).toBeDefined();
+      expect(getRetrieveWardByIdSpy).toBeCalledWith(123, 10);
     });
   });
 });

--- a/pageTests/wards/cancel-visit-confirmation.test.js
+++ b/pageTests/wards/cancel-visit-confirmation.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/wards/cancel-visit-confirmation";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/userIsAuthenticated", () => () => (token) =>
-  token && { ward: "123" }
-);
-
 describe("ward/cancel-visit-confirmation", () => {
   const anonymousReq = {
     headers: {
@@ -18,6 +13,10 @@ describe("ward/cancel-visit-confirmation", () => {
     },
   };
   let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "wardStaff", wardId: 123 })),
+  };
 
   beforeEach(() => {
     res = {
@@ -41,6 +40,8 @@ describe("ward/cancel-visit-confirmation", () => {
               throw new Error("Some DB Error");
             },
           }),
+        getTokenProvider: () => tokenProvider,
+        getRetrieveWardById: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({
@@ -70,6 +71,8 @@ describe("ward/cancel-visit-confirmation", () => {
                 },
               ],
             }),
+          getTokenProvider: () => tokenProvider,
+          getRetrieveWardById: () => jest.fn().mockReturnValue({}),
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/wards/cancel-visit-success.test.js
+++ b/pageTests/wards/cancel-visit-success.test.js
@@ -1,10 +1,5 @@
 import { getServerSideProps } from "../../pages/wards/cancel-visit-success";
 
-// TODO: This needs to be moved once the verifyToken logic is in the container..
-jest.mock("../../src/usecases/userIsAuthenticated", () => () => (token) =>
-  token && { ward: "123" }
-);
-
 describe("ward/cancel-visit-success", () => {
   const anonymousReq = {
     headers: {
@@ -18,6 +13,10 @@ describe("ward/cancel-visit-success", () => {
     },
   };
   let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "wardStaff", wardId: 123 })),
+  };
 
   beforeEach(() => {
     res = {
@@ -41,6 +40,8 @@ describe("ward/cancel-visit-success", () => {
               throw new Error("Some DB Error");
             },
           }),
+        getTokenProvider: () => tokenProvider,
+        getRetrieveWardById: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({
@@ -70,6 +71,8 @@ describe("ward/cancel-visit-success", () => {
                 },
               ],
             }),
+          getTokenProvider: () => tokenProvider,
+          getRetrieveWardById: () => jest.fn().mockReturnValue({}),
         };
 
         const { props } = await getServerSideProps({

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -26,6 +26,7 @@ export default withContainer(
           wardCode: undefined,
           admin: true,
           trustId: verifyTrustAdminCodeResponse.trust.id,
+          type: "trustAdmin",
         });
       } else {
         const { ward } = verifyWardCodeResponse;
@@ -34,6 +35,7 @@ export default withContainer(
           wardCode: ward.code,
           admin: false,
           trustId: ward.trustId,
+          type: "wardStaff",
         });
       }
 

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -1,4 +1,5 @@
 import withContainer from "../../src/middleware/withContainer";
+const { WARD_STAFF, TRUST_ADMIN } = require("../../src/helpers/tokenTypes");
 
 export default withContainer(
   async ({ body: { code }, method }, res, { container }) => {
@@ -25,7 +26,7 @@ export default withContainer(
           wardId: undefined,
           wardCode: undefined,
           trustId: verifyTrustAdminCodeResponse.trust.id,
-          type: "trustAdmin",
+          type: TRUST_ADMIN,
         });
       } else {
         const { ward } = verifyWardCodeResponse;
@@ -33,7 +34,7 @@ export default withContainer(
           wardId: ward.id,
           wardCode: ward.code,
           trustId: ward.trustId,
-          type: "wardStaff",
+          type: WARD_STAFF,
         });
       }
 

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -24,7 +24,6 @@ export default withContainer(
         token = tokens.generate({
           wardId: undefined,
           wardCode: undefined,
-          admin: true,
           trustId: verifyTrustAdminCodeResponse.trust.id,
           type: "trustAdmin",
         });
@@ -33,7 +32,6 @@ export default withContainer(
         token = tokens.generate({
           wardId: ward.id,
           wardCode: ward.code,
-          admin: false,
           trustId: ward.trustId,
           type: "wardStaff",
         });

--- a/pages/wards/login.js
+++ b/pages/wards/login.js
@@ -94,7 +94,7 @@ export const getServerSideProps = propsWithContainer(
     const adminIsAuthenticated = container.getAdminIsAuthenticated();
     const adminToken = adminIsAuthenticated(headers.cookie);
 
-    if (adminToken && adminToken.admin) {
+    if (adminToken) {
       res.writeHead(307, { Location: `/admin` }).end();
     } else if (userToken && userToken.ward) {
       res.writeHead(307, { Location: `/wards/visits` }).end();

--- a/src/helpers/tokenTypes.js
+++ b/src/helpers/tokenTypes.js
@@ -1,0 +1,7 @@
+const WARD_STAFF = "wardStaff";
+const TRUST_ADMIN = "trustAdmin";
+
+module.exports = {
+  WARD_STAFF,
+  TRUST_ADMIN,
+};

--- a/src/helpers/tokenTypes.test.js
+++ b/src/helpers/tokenTypes.test.js
@@ -1,0 +1,11 @@
+import tokenTypes from "./tokenTypes";
+
+describe("tokenTypes", () => {
+  it("returns the wardStaff token type", () => {
+    expect(tokenTypes.WARD_STAFF).toEqual("wardStaff");
+  });
+
+  it("returns the trustAdmin token type", () => {
+    expect(tokenTypes.TRUST_ADMIN).toEqual("trustAdmin");
+  });
+});

--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -7,13 +7,12 @@ class TokenProvider {
     this.signingKey = signingKey;
   }
 
-  generate({ wardId, wardCode, admin, trustId, type }) {
+  generate({ wardId, wardCode, trustId, type }) {
     return jwt.sign(
       // If updating the token structure, update the version
       {
         wardId,
         ward: wardCode,
-        admin,
         trustId,
         version,
         type,

--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -1,13 +1,13 @@
 import jwt from "jsonwebtoken";
 
-const version = "2";
+const version = "3";
 
 class TokenProvider {
   constructor(signingKey) {
     this.signingKey = signingKey;
   }
 
-  generate({ wardId, wardCode, admin, trustId }) {
+  generate({ wardId, wardCode, admin, trustId, type }) {
     return jwt.sign(
       // If updating the token structure, update the version
       {
@@ -16,6 +16,7 @@ class TokenProvider {
         admin,
         trustId,
         version,
+        type,
       },
       this.signingKey,
       {

--- a/src/providers/TokenProvider.test.js
+++ b/src/providers/TokenProvider.test.js
@@ -4,18 +4,19 @@ import TokenProvider from "./TokenProvider";
 describe("TokenProvider", () => {
   it("should verify a valid token", () => {
     jwt.verify = jest.fn().mockReturnValue({
-      version: "2",
+      version: "3",
       wardId: 1,
       ward: "123",
       admin: false,
       trustId: 2,
+      type: "wardStaff",
     });
 
     const tokenProvider = new TokenProvider();
 
     const token = tokenProvider.validate("token");
 
-    expect(token.version).toEqual("2");
+    expect(token.version).toEqual("3");
   });
 
   it("should reject a token with an invalid version", () => {

--- a/src/usecases/adminIsAuthenticated.js
+++ b/src/usecases/adminIsAuthenticated.js
@@ -8,7 +8,7 @@ export default ({ getTokenProvider }) => (requestCookie) => {
 
     const validatedToken = tokenProvider.validate(token);
 
-    if (token && !validatedToken.admin) {
+    if (token && validatedToken.type !== "trustAdmin") {
       return false;
     }
 

--- a/src/usecases/adminIsAuthenticated.js
+++ b/src/usecases/adminIsAuthenticated.js
@@ -1,5 +1,7 @@
 import cookie from "cookie";
 
+const { TRUST_ADMIN } = require("../helpers/tokenTypes");
+
 export default ({ getTokenProvider }) => (requestCookie) => {
   const tokenProvider = getTokenProvider();
 
@@ -8,7 +10,7 @@ export default ({ getTokenProvider }) => (requestCookie) => {
 
     const validatedToken = tokenProvider.validate(token);
 
-    if (token && validatedToken.type !== "trustAdmin") {
+    if (token && validatedToken.type !== TRUST_ADMIN) {
       return false;
     }
 

--- a/src/usecases/adminIsAuthenticated.test.js
+++ b/src/usecases/adminIsAuthenticated.test.js
@@ -7,7 +7,7 @@ describe("adminIsAuthenticated", () => {
   describe("valid admin token", () => {
     beforeEach(() => {
       tokenProvider = {
-        validate: jest.fn(() => ({ admin: true })),
+        validate: jest.fn(() => ({ type: "trustAdmin" })),
       };
       container = {
         getTokenProvider: () => tokenProvider,
@@ -16,7 +16,7 @@ describe("adminIsAuthenticated", () => {
 
     it("returns the payload of the token when it is valid", () => {
       expect(adminIsAuthenticated(container)("token=valid.token")).toEqual({
-        admin: true,
+        type: "trustAdmin",
       });
     });
   });
@@ -41,7 +41,7 @@ describe("adminIsAuthenticated", () => {
   describe("valid user token", () => {
     beforeEach(() => {
       tokenProvider = {
-        validate: jest.fn(() => ({ admin: false })),
+        validate: jest.fn(() => ({ type: "wardStaff" })),
       };
       container = {
         getTokenProvider: () => tokenProvider,

--- a/src/usecases/userIsAuthenticated.js
+++ b/src/usecases/userIsAuthenticated.js
@@ -1,5 +1,7 @@
 import cookie from "cookie";
 
+const { WARD_STAFF } = require("../helpers/tokenTypes");
+
 export default ({ getTokenProvider, getRetrieveWardById }) => async (
   requestCookie
 ) => {
@@ -20,7 +22,7 @@ export default ({ getTokenProvider, getRetrieveWardById }) => async (
       return false;
     }
 
-    if (token && validatedToken.type !== "wardStaff") {
+    if (token && validatedToken.type !== WARD_STAFF) {
       return false;
     }
 

--- a/src/usecases/userIsAuthenticated.js
+++ b/src/usecases/userIsAuthenticated.js
@@ -20,7 +20,7 @@ export default ({ getTokenProvider, getRetrieveWardById }) => async (
       return false;
     }
 
-    if (token && validatedToken.admin) {
+    if (token && validatedToken.type !== "wardStaff") {
       return false;
     }
 

--- a/src/usecases/userIsAuthenticated.test.js
+++ b/src/usecases/userIsAuthenticated.test.js
@@ -4,32 +4,38 @@ describe("userIsAuthenticated", () => {
   let tokenProvider;
   let container;
 
-  beforeEach(() => {
-    tokenProvider = {
-      validate: jest.fn((token) => {
-        if (token === "valid.token") {
-          return token;
-        } else {
-          return false;
-        }
-      }),
-    };
-    container = {
-      getTokenProvider: () => tokenProvider,
-      getRetrieveWardById: () => jest.fn().mockReturnValue({ error: null }),
-    };
+  describe("valid user token", () => {
+    beforeEach(() => {
+      tokenProvider = {
+        validate: jest.fn(() => ({ type: "wardStaff" })),
+      };
+      container = {
+        getTokenProvider: () => tokenProvider,
+        getRetrieveWardById: () => jest.fn().mockReturnValue({ error: null }),
+      };
+    });
+    it("returns the payload of the token when it is valid", async () => {
+      expect(
+        await userIsAuthenticated(container)("token=valid.token")
+      ).toEqual({ type: "wardStaff" });
+    });
   });
 
-  it("returns the payload of the token when it is valid", async () => {
-    expect(await userIsAuthenticated(container)("token=valid.token")).toEqual(
-      "valid.token"
-    );
-  });
-
-  it("returns false when the token is invalid", async () => {
-    expect(await userIsAuthenticated(container)("token=invalid.token")).toEqual(
-      false
-    );
+  describe("invalid user token", () => {
+    beforeEach(() => {
+      tokenProvider = {
+        validate: jest.fn(() => false),
+      };
+      container = {
+        getTokenProvider: () => tokenProvider,
+        getRetrieveWardById: () => jest.fn().mockReturnValue({ error: null }),
+      };
+    });
+    it("returns false when the token is invalid", async () => {
+      expect(
+        await userIsAuthenticated(container)("token=invalid.token")
+      ).toEqual(false);
+    });
   });
 
   it("returns false when the ward is not present", async () => {

--- a/src/usecases/verifyAdminToken.test.js
+++ b/src/usecases/verifyAdminToken.test.js
@@ -16,7 +16,7 @@ describe("verifyAdminToken", () => {
     const expectedProps = { a: 1 };
     const callback = jest.fn(() => expectedProps);
     const authenticationToken = {
-      admin: true,
+      type: "trustAdmin",
     };
     const tokenProvider = {
       validate: jest.fn(() => authenticationToken),

--- a/src/usecases/verifyToken.test.js
+++ b/src/usecases/verifyToken.test.js
@@ -16,7 +16,7 @@ describe("verifyToken", () => {
     const expectedProps = { a: 1 };
     const callback = jest.fn(() => expectedProps);
     const authenticationToken = {
-      foo: true,
+      type: "wardStaff",
     };
     const tokenProvider = {
       validate: jest.fn(() => authenticationToken),


### PR DESCRIPTION
# What
Adds a new 'type' key to the token to distinguish user types. 

# Why
We currently use an 'admin' boolean to distinguish users from admins. This is not open to extending to more types in the future.

# Screenshots

# Notes
