### PR TITLE
Update filtering of visits

### DIFF
--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -60,7 +60,7 @@ const AccordionVisits = ({ visits }) => {
               onClick={() => {
                 setDisplayedVisits(filterPastVisits(visits));
                 setVisitsPanelListTitle("Past");
-                setShowButtons(false);
+                setShowButtons(true);
               }}
             >
               Past

--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import filterTodaysVisits from "../../helpers/filterTodaysVisits";
 import filterUpcomingVisits from "../../helpers/filterUpcomingVisits";
 import filterPastVisits from "../../helpers/filterPastVisits";
@@ -11,6 +11,25 @@ const AccordionVisits = ({ visits }) => {
   );
   const [visitsPanelListTitle, setVisitsPanelListTitle] = useState("Today");
   const [showButtons, setShowButtons] = useState(true);
+
+  const oneMinute = 60000;
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      let updatedVisits;
+
+      if (visitsPanelListTitle === "Today") {
+        updatedVisits = filterTodaysVisits(visits);
+      } else if (visitsPanelListTitle === "Upcoming") {
+        updatedVisits = filterUpcomingVisits(visits);
+      } else {
+        updatedVisits = filterPastVisits(visits);
+      }
+
+      setDisplayedVisits(updatedVisits);
+    }, oneMinute);
+    return () => clearInterval(interval);
+  }, [visitsPanelListTitle]);
 
   return (
     <div className="nhsuk-grid-row">

--- a/src/components/AccordionVisits/index.js
+++ b/src/components/AccordionVisits/index.js
@@ -52,18 +52,20 @@ const AccordionVisits = ({ visits }) => {
           </li>
           <li
             className={
-              visitsPanelListTitle == "Past" ? "nhsuk-u-font-weight-bold" : ""
+              visitsPanelListTitle == "Past 12 hours"
+                ? "nhsuk-u-font-weight-bold"
+                : ""
             }
           >
             <a
               href="#"
               onClick={() => {
                 setDisplayedVisits(filterPastVisits(visits));
-                setVisitsPanelListTitle("Past");
+                setVisitsPanelListTitle("Past 12 hours");
                 setShowButtons(true);
               }}
             >
-              Past
+              Past 12 hours
             </a>
           </li>
         </ul>

--- a/src/helpers/filterPastVisits.js
+++ b/src/helpers/filterPastVisits.js
@@ -2,6 +2,9 @@ import moment from "moment";
 
 export default function filterPastVisits(visits) {
   return visits.filter((visit) =>
-    moment(visit.callTime).isBefore(moment().startOf("day"))
+    moment(visit.callTime).isBetween(
+      moment().subtract(12, "hours").subtract(1, "seconds"),
+      moment().subtract(1, "hours").add(1, "seconds")
+    )
   );
 }

--- a/src/helpers/filterPastVisits.test.js
+++ b/src/helpers/filterPastVisits.test.js
@@ -3,25 +3,31 @@ import filterPastVisits from "./filterPastVisits";
 
 describe("filterPastVisits", () => {
   beforeEach(() => {
-    MockDate.set(new Date("2020-05-18"));
+    MockDate.set(new Date("2020-05-18 13:00"));
   });
 
   afterEach(() => {
     MockDate.reset();
   });
 
-  it("returns visits that were scheduled in the past", () => {
+  it("returns visits that were scheduled between 1 hour ago and 12 hours ago", () => {
     const visits = [
-      { callTime: "2020-05-17 13:00:00" },
-      { callTime: "2020-05-17 23:59:59" },
-      { callTime: "2020-05-18 00:00:00" },
-      { callTime: "2020-05-18 00:00:01" },
+      { callTime: "2020-05-17 15:00:00" },
+      { callTime: "2020-05-18 00:59:59" },
+      { callTime: "2020-05-18 01:00:00" },
+      { callTime: "2020-05-18 09:00:00" },
+      { callTime: "2020-05-18 11:59:59" },
+      { callTime: "2020-05-18 12:00:00" },
+      { callTime: "2020-05-18 12:00:01" },
       { callTime: "2020-05-18 13:00:00" },
+      { callTime: "2020-05-18 15:00:00" },
     ];
 
     expect(filterPastVisits(visits)).toEqual([
-      { callTime: "2020-05-17 13:00:00" },
-      { callTime: "2020-05-17 23:59:59" },
+      { callTime: "2020-05-18 01:00:00" },
+      { callTime: "2020-05-18 09:00:00" },
+      { callTime: "2020-05-18 11:59:59" },
+      { callTime: "2020-05-18 12:00:00" },
     ]);
   });
 });

--- a/src/helpers/filterTodaysVisits.js
+++ b/src/helpers/filterTodaysVisits.js
@@ -3,7 +3,7 @@ import moment from "moment";
 export default function filterTodaysVisits(visits) {
   return visits.filter((visit) =>
     moment(visit.callTime).isBetween(
-      moment().startOf("day"),
+      moment().subtract(1, "hours"),
       moment().endOf("day")
     )
   );

--- a/src/helpers/filterTodaysVisits.test.js
+++ b/src/helpers/filterTodaysVisits.test.js
@@ -3,24 +3,29 @@ import filterTodaysVisits from "./filterTodaysVisits";
 
 describe("filterTodaysVisits", () => {
   beforeEach(() => {
-    MockDate.set(new Date("2020-05-18"));
+    MockDate.set(new Date("2020-05-18 13:00"));
   });
 
   afterEach(() => {
     MockDate.reset();
   });
 
-  it("returns visits that are scheduled for today", () => {
+  it("returns visits that are scheduled between 1 hour ago until end of the day", () => {
     const visits = [
       { callTime: "2020-05-17 23:59:59" },
+      { callTime: "2020-05-18 09:00:00" },
+      { callTime: "2020-05-18 11:59:59" },
+      { callTime: "2020-05-18 12:00:00" },
+      { callTime: "2020-05-18 12:00:01" },
       { callTime: "2020-05-18 13:00:00" },
-      { callTime: "2020-05-18 13:00:00" },
+      { callTime: "2020-05-18 15:00:00" },
       { callTime: "2020-05-19 01:00:00" },
     ];
 
     expect(filterTodaysVisits(visits)).toEqual([
+      { callTime: "2020-05-18 12:00:01" },
       { callTime: "2020-05-18 13:00:00" },
-      { callTime: "2020-05-18 13:00:00" },
+      { callTime: "2020-05-18 15:00:00" },
     ]);
   });
 


### PR DESCRIPTION
# What

Update filtering of visits so that:

- Today is 1 hour ago until the end of the day
- Past is between 1 hour ago and 12 hours

# Why

This makes it consistent to what we have on the visits table and is the expected behaviour.

# Screenshots

N/A

# Notes

~Currently the user will have to refresh the page to see it a visit more than an hour ago "move" the past.~ 😢