### PR TITLE
Save recipient email address in scheduled calls table

### DIFF
--- a/src/usecases/createVisit.js
+++ b/src/usecases/createVisit.js
@@ -3,13 +3,14 @@ const createVisit = ({ getDb }) => async (visit) => {
 
   return await db.one(
     `INSERT INTO scheduled_calls_table
-      (id, patient_name, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password)
-      VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8)
+      (id, patient_name, recipient_email, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password)
+      VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING id
     `,
     [
       visit.patientName,
-      visit.contactNumber,
+      visit.contactEmail || "",
+      visit.contactNumber || "",
       visit.contactName || "",
       visit.callTime,
       visit.callId,

--- a/src/usecases/createVisit.test.js
+++ b/src/usecases/createVisit.test.js
@@ -13,6 +13,7 @@ describe("createVisit", () => {
 
     const request = {
       patientName: "Bob Smith",
+      contactEmail: "bob.smith@madetech.com",
       contactName: "John Smith",
       contactNumber: "07123456789",
       callTime: new Date(),
@@ -28,6 +29,7 @@ describe("createVisit", () => {
 
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.patientName,
+      request.contactEmail,
       request.contactNumber,
       request.contactName,
       request.callTime,


### PR DESCRIPTION
# What

Update createVisit usecase to save email address of recipient.

# Why

To support notifying recipients via email.

# Screenshots

# Notes
