### PR TITLE
Update cancelling a visit design and content

### DIFF
--- a/pageTests/wards/cancel-visit-success.test.js
+++ b/pageTests/wards/cancel-visit-success.test.js
@@ -85,8 +85,6 @@ describe("ward/cancel-visit-success", () => {
         });
         expect(res.writeHead).not.toHaveBeenCalled();
         expect(props.patientName).toEqual("Fred Bloggs");
-        expect(props.contactName).toEqual("John Doe");
-        expect(props.contactNumber).toEqual("07700900900");
         expect(props.callDateAndTime).toEqual("2020-04-15T23:00:00.000Z");
       });
     });

--- a/pages/wards/cancel-visit-confirmation.js
+++ b/pages/wards/cancel-visit-confirmation.js
@@ -29,10 +29,13 @@ const deleteVisitConfirmation = ({
   }
 
   return (
-    <Layout title="Confirm cancellation of virtual visit" renderLogout={true}>
+    <Layout
+      title="Are you sure you want to cancel this visit?"
+      renderLogout={true}
+    >
       <GridRow>
         <GridColumn width="full">
-          <Heading>Confirm cancellation of virtual visit</Heading>
+          <Heading>Are you sure you want to cancel this visit?</Heading>
         </GridColumn>
       </GridRow>
       <GridRow>
@@ -55,7 +58,7 @@ const deleteVisitConfirmation = ({
               </p>
             </div>
 
-            <Button>Confirm cancellation</Button>
+            <Button>Yes, cancel this visit</Button>
 
             <BackLink href="/wards/visits">Back to virtual visits</BackLink>
           </form>

--- a/pages/wards/cancel-visit-success.js
+++ b/pages/wards/cancel-visit-success.js
@@ -1,52 +1,55 @@
-import React, { useCallback } from "react";
-import Button from "../../src/components/Button";
-import { GridRow, GridColumn } from "../../src/components/Grid";
-import Heading from "../../src/components/Heading";
+import React from "react";
 import Layout from "../../src/components/Layout";
-import Router from "next/router";
+import ActionLink from "../../src/components/ActionLink";
+import AnchorLink from "../../src/components/AnchorLink";
 import verifyToken from "../../src/usecases/verifyToken";
 import retrieveVisitByCallId from "../../src/usecases/retrieveVisitByCallId";
 import deleteVisitByCallId from "../../src/usecases/deleteVisitByCallId";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import Error from "next/error";
-import VisitSummaryList from "../../src/components/VisitSummaryList";
+import formatDateAndTime from "../../src/helpers/formatDateAndTime";
 
 const deleteVisitSuccess = ({
   patientName,
-  contactName,
-  contactNumber,
   callDateAndTime,
   error,
   deleteError,
 }) => {
-  const onSubmit = useCallback(async (event) => {
-    event.preventDefault();
-    Router.push(`/wards/visits`);
-  });
-
   if (error || deleteError) {
     return <Error />;
   }
 
   return (
-    <Layout title="Virtual visit has been cancelled" renderLogout={true}>
-      <GridRow>
-        <GridColumn width="full">
-          <form onSubmit={onSubmit}>
-            <Heading>Virtual visit has been cancelled</Heading>
-            <p>The following virtual visit has been successfully cancelled.</p>
+    <Layout title="Virtual visit cancelled" renderLogout={true}>
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-two-thirds">
+          <div
+            className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+            style={{ textAlign: "center" }}
+          >
+            <h1 className="nhsuk-panel__title nhsuk-u-margin-bottom-4">
+              Virtual visit cancelled
+            </h1>
 
-            <VisitSummaryList
-              patientName={patientName}
-              visitorName={contactName}
-              visitorMobileNumber={contactNumber}
-              visitDateAndTime={callDateAndTime}
-            ></VisitSummaryList>
+            <div className="nhsuk-panel__body">
+              for {patientName} on
+              <br />
+              <strong>{formatDateAndTime(callDateAndTime, "HH:mm")}</strong>
+            </div>
+          </div>
+          <h2>What happens next</h2>
 
-            <Button>Return to virtual visits</Button>
-          </form>
-        </GridColumn>
-      </GridRow>
+          <ActionLink href={`/admin/add-a-ward`}>
+            Book a virtual visit
+          </ActionLink>
+
+          <p>
+            <AnchorLink href="/wards/visits">
+              Return to virtual visits
+            </AnchorLink>
+          </p>
+        </div>
+      </div>
     </Layout>
   );
 };
@@ -60,8 +63,6 @@ export const getServerSideProps = propsWithContainer(
     if (error && !scheduledCall) {
       scheduledCall = {
         patientName: "",
-        recipientName: "",
-        recipientNumber: "",
         callTime: "",
       };
     }
@@ -70,8 +71,6 @@ export const getServerSideProps = propsWithContainer(
     return {
       props: {
         patientName: scheduledCall.patientName,
-        contactName: scheduledCall.recipientName,
-        contactNumber: scheduledCall.recipientNumber,
         callDateAndTime: scheduledCall.callTime,
         error,
         deleteError,


### PR DESCRIPTION
# What

Update cancelling a visit design and content to be consistent with other pages.

# Why

So we're consistent throughout the service and feels weird to be using a summary list component at the end of deleting a visit.

# Screenshots

|     Before     |          After         |
|:-------------------------:|:------------------------:|
| ![screencapture-localhost-3000-wards-cancel-visit-confirmation-2020-05-26-09_04_47](https://user-images.githubusercontent.com/42817036/82876118-31bdf280-9f30-11ea-887e-89faea69975e.png) | ![screencapture-localhost-3000-wards-cancel-visit-confirmation-2020-05-26-09_04_22](https://user-images.githubusercontent.com/42817036/82876150-3c788780-9f30-11ea-9f0f-8e6f9c37c5e1.png)|
| ![screencapture-localhost-3000-wards-cancel-visit-success-2020-05-26-09_05_00](https://user-images.githubusercontent.com/42817036/82876178-4ac6a380-9f30-11ea-80f2-b8fef70d558c.png) |![screencapture-localhost-3000-wards-cancel-visit-success-2020-05-26-09_05_14](https://user-images.githubusercontent.com/42817036/82876239-62059100-9f30-11ea-9d4b-6c3f9768f432.png)|

# Notes

N/A