### PR TITLE
Refactor test teardown

### DIFF
--- a/jest.contract.config.js
+++ b/jest.contract.config.js
@@ -126,7 +126,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  setupFilesAfterEnv: ["<rootDir>/testSetup.js"],
+  setupFilesAfterEnv: ["<rootDir>/testSetup.js", "<rootDir>/testTeardown.js"],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext .js",
     "test": "jest --silent",
     "test:coverage": "jest --silent --coverage",
-    "test:contract": "jest --config ./jest.contract.config.js",
+    "test:contract": "jest --config ./jest.contract.config.js --runInBand",
     "test:contract:watch": "npm run test:contract -- --watch",
     "test:watch": "jest --watch --silent",
     "test:ci": "npm run format:check && npm run test:contract -- --runInBand && npm run test -- --runInBand",

--- a/src/usecases/createTrust.contractTest.js
+++ b/src/usecases/createTrust.contractTest.js
@@ -12,9 +12,6 @@ describe("createTrust contract tests", () => {
 
   afterEach(async () => {
     await truncateAllTables(container);
-
-    const db = await container.getDb();
-    db.$pool.end();
   });
 
   it("creates a trust in the db when valid", async () => {

--- a/src/usecases/createTrust.contractTest.js
+++ b/src/usecases/createTrust.contractTest.js
@@ -1,18 +1,9 @@
 import createTrust from "./createTrust";
 import AppContainer from "../containers/AppContainer";
-import truncateAllTables from "../testUtils/truncateAllTables";
 
 describe("createTrust contract tests", () => {
   const container = AppContainer.getInstance();
   const retrieveTrustById = container.getRetrieveTrustById();
-
-  beforeEach(async () => {
-    await truncateAllTables(container);
-  });
-
-  afterEach(async () => {
-    await truncateAllTables(container);
-  });
 
   it("creates a trust in the db when valid", async () => {
     const request = {

--- a/src/usecases/createWard.contractTest.js
+++ b/src/usecases/createWard.contractTest.js
@@ -12,9 +12,6 @@ describe("createWard contract tests", () => {
 
   afterEach(async () => {
     await truncateAllTables(container);
-
-    const db = await container.getDb();
-    db.$pool.end();
   });
 
   it("creates a ward in the db when valid", async () => {

--- a/src/usecases/createWard.contractTest.js
+++ b/src/usecases/createWard.contractTest.js
@@ -1,18 +1,9 @@
 import createWard from "./createWard";
 import AppContainer from "../containers/AppContainer";
-import truncateAllTables from "../testUtils/truncateAllTables";
 import setupTrust from "../testUtils/setupTrust";
 
 describe("createWard contract tests", () => {
   const container = AppContainer.getInstance();
-
-  beforeEach(async () => {
-    await truncateAllTables(container);
-  });
-
-  afterEach(async () => {
-    await truncateAllTables(container);
-  });
 
   it("creates a ward in the db when valid", async () => {
     const trust = await setupTrust(container)({

--- a/testTeardown.js
+++ b/testTeardown.js
@@ -1,6 +1,17 @@
 import AppContainer from "./src/containers/AppContainer";
+import truncateAllTables from "./src/testUtils/truncateAllTables";
+
+const container = AppContainer.getInstance();
+
+beforeAll(async () => {
+  await truncateAllTables(container);
+});
+
+afterEach(async () => {
+  await truncateAllTables(container);
+});
+
 afterAll(async () => {
-  const container = AppContainer.getInstance();
   const db = await container.getDb();
   db.$pool.end();
 });

--- a/testTeardown.js
+++ b/testTeardown.js
@@ -1,0 +1,6 @@
+import AppContainer from "./src/containers/AppContainer";
+afterAll(async () => {
+  const container = AppContainer.getInstance();
+  const db = await container.getDb();
+  db.$pool.end();
+});


### PR DESCRIPTION
# What
Extracts the database closing test teardown step to a separate file

# Why
Ensures that the database connection is closed correctly after all tests have run without having to include it in every test

# Screenshots

# Notes
This change also runs contract tests on a single process when you run test:contract, as the database clearing causes issues when run in parallel (due to the fact that we only have 1 test database)
