### PR TITLE
Add create-trust API endpoint

### DIFF
--- a/pageTests/api/create-trust.test.js
+++ b/pageTests/api/create-trust.test.js
@@ -1,0 +1,177 @@
+import createTrust from "../../pages/api/create-trust";
+
+jest.mock("node-fetch");
+
+describe("create-trust", () => {
+  let validRequest;
+  let response;
+  let container;
+
+  beforeEach(() => {
+    validRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+    response = {
+      status: jest.fn(),
+      setHeader: jest.fn(),
+      send: jest.fn(),
+      end: jest.fn(),
+      body: jest.fn(),
+    };
+    container = {
+      getCreateTrust: jest.fn().mockReturnValue(() => {
+        return { trustId: 1, error: null };
+      }),
+      getAdminIsAuthenticated: jest
+        .fn()
+        .mockReturnValue((cookie) => cookie === "token=valid.token.value"),
+    };
+  });
+
+  it("returns 405 if not POST method", async () => {
+    validRequest.method = "GET";
+
+    await createTrust(validRequest, response, {
+      container: container,
+    });
+
+    expect(response.status).toHaveBeenCalledWith(405);
+  });
+
+  it("returns a 401 if no token provided", async () => {
+    const adminIsAuthenticatedSpy = jest.fn().mockReturnValue(false);
+
+    await createTrust(
+      {
+        method: "POST",
+        body: {},
+        headers: {},
+      },
+      response,
+      {
+        container: {
+          ...container,
+          getAdminIsAuthenticated: () => adminIsAuthenticatedSpy,
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(adminIsAuthenticatedSpy).toHaveBeenCalled();
+  });
+
+  it("creates a new trust if valid", async () => {
+    const createTrustSpy = jest
+      .fn()
+      .mockReturnValue({ trustId: 123, error: null });
+
+    await createTrust(validRequest, response, {
+      container: {
+        ...container,
+        getCreateTrust: () => createTrustSpy,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(response.end).toHaveBeenCalledWith(JSON.stringify({ trustId: 123 }));
+    expect(createTrustSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Test Trust",
+      })
+    );
+  });
+
+  it("returns a 409 status if errors", async () => {
+    const createTrustStub = jest
+      .fn()
+      .mockReturnValue({ trustId: null, error: "Error message" });
+
+    await createTrust(validRequest, response, {
+      container: {
+        ...container,
+        getCreateTrust: () => createTrustStub,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "Trust name already exists" })
+    );
+  });
+
+  it("returns a 400 if the name is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "",
+        trustName: "Yugi Muto Trust",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "name must be present" })
+    );
+  });
+
+  it("returns a 400 if the name is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        trustName: "Yugi Muto Trust",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "name must be present" })
+    );
+  });
+
+  it("returns a 400 if the trust name is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "name must be present" })
+    );
+  });
+});

--- a/pages/api/create-trust.js
+++ b/pages/api/create-trust.js
@@ -1,0 +1,41 @@
+import withContainer from "../../src/middleware/withContainer";
+
+export default withContainer(
+  async ({ headers, body, method }, res, { container }) => {
+    if (method !== "POST") {
+      res.status(405);
+      res.end(JSON.stringify({ err: "method not allowed" }));
+      return;
+    }
+
+    const adminIsAuthenticated = container.getAdminIsAuthenticated();
+
+    if (!adminIsAuthenticated(headers.cookie)) {
+      res.status(401);
+      res.end(JSON.stringify({ err: "not authenticated" }));
+      return;
+    }
+
+    if (!body.name) {
+      res.status(400);
+      res.end(JSON.stringify({ err: "name must be present" }));
+      return;
+    }
+
+    res.setHeader("Content-Type", "application/json");
+
+    const createTrust = container.getCreateTrust();
+
+    const { trustId, error } = await createTrust({
+      name: body.name,
+    });
+
+    if (error) {
+      res.status(409);
+      res.end(JSON.stringify({ err: "Trust name already exists" }));
+    } else {
+      res.status(201);
+      res.end(JSON.stringify({ trustId: trustId }));
+    }
+  }
+);

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -25,6 +25,7 @@ import retrieveHospitalById from "../usecases/retrieveHospitalById";
 import archiveWard from "../usecases/archiveWard";
 import validateEmailAddress from "../usecases/validateEmailAddress";
 import validateMobileNumber from "../usecases/validateMobileNumber";
+import createTrust from "../usecases/createTrust";
 
 class AppContainer {
   getDb = () => {
@@ -133,6 +134,10 @@ class AppContainer {
 
   getValidateMobileNumber = () => {
     return validateMobileNumber(this);
+  };
+
+  getCreateTrust = () => {
+    return createTrust(this);
   };
 }
 


### PR DESCRIPTION
# What
Adds a create-trust API endpoint

# Why
Provides us with an API to hook up to a form for creating Trusts in the admin dashboard

# Screenshots

# Notes
