### PR TITLE
Set expiresIn option on the JWT token

### DIFF
--- a/src/providers/TokenProvider.js
+++ b/src/providers/TokenProvider.js
@@ -20,6 +20,7 @@ class TokenProvider {
       this.signingKey,
       {
         algorithm: "HS256",
+        expiresIn: "14h",
       }
     );
   }


### PR DESCRIPTION
# What
Sets an expiry option on the JWT token

# Why
We will eventually use the expiry on the token to decide when to refresh the token

# Screenshots

# Notes
