### PR TITLE
Govnotify email contract tests

### DIFF
--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -71,6 +71,13 @@ export class NotifyClient {
   });
 
   sendEmail = jest.fn((templateId) => {
+    if (!uuidValidate(templateId)) {
+      return this._rejectWithError({
+        error: "ValidationError",
+        message: "template_id is not a valid UUID",
+      });
+    }
+
     if (
       Object.values(TemplateStore).findIndex(
         (it) => it.templateId === templateId

--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -70,7 +70,7 @@ export class NotifyClient {
     });
   });
 
-  sendEmail = jest.fn((templateId) => {
+  sendEmail = jest.fn((templateId, emailAddress, { personalisation }) => {
     if (!uuidValidate(templateId)) {
       return this._rejectWithError({
         error: "ValidationError",
@@ -86,6 +86,27 @@ export class NotifyClient {
       return this._rejectWithError({
         error: "BadRequestError",
         message: "Template not found",
+      });
+    }
+
+    const missingPersonalisation = this._validatePersonalisation(
+      templateId,
+      personalisation
+    );
+
+    if (missingPersonalisation.length) {
+      return this._rejectWithError({
+        error: "BadRequestError",
+        message: `Missing personalisation: ${missingPersonalisation.join(
+          ", "
+        )}`,
+      });
+    }
+
+    if (emailAddress.length <= 3) {
+      return this._rejectWithError({
+        error: "ValidationError",
+        message: "email_address Not a valid email address",
       });
     }
 

--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -110,6 +110,8 @@ export class NotifyClient {
       });
     }
 
-    return Promise.resolve({});
+    return Promise.resolve({
+      id: "740e5834-3a29-46b4-9a6f-16142fde533a",
+    });
   });
 }

--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -1,5 +1,6 @@
 import uuidValidate from "uuid-validate";
 import TemplateStore from "../src/gateways/GovNotify/TemplateStore";
+import validateEmailAddress from "../src/helpers/validateEmailAddress";
 
 export class NotifyClient {
   _rejectWithError = ({ error, message }) => {
@@ -91,7 +92,7 @@ export class NotifyClient {
       return requestValidationError;
     }
 
-    if (emailAddress.length <= 3) {
+    if (!validateEmailAddress(emailAddress)) {
       return this._rejectWithError({
         error: "ValidationError",
         message: "email_address Not a valid email address",

--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -81,5 +81,7 @@ export class NotifyClient {
         message: "Template not found",
       });
     }
+
+    return Promise.resolve({});
   });
 }

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -119,7 +119,8 @@ describe(
 
     const validEmailAddress = "simulate-delivered@notifications.service.gov.uk";
 
-    xdescribe("sendEmail", () => {
+    // WIP, NK
+    describe.skip("sendEmail", () => {
       it("Can successfully send an Email", async () => {
         const result = await client.sendEmail(templateId, validEmailAddress, {
           personalisation,

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -121,13 +121,13 @@ describe(
 
     describe("sendEmail", () => {
       it("can successfully send an Email", async () => {
-        console.log(personalisation);
         const result = await client.sendEmail(templateId, validEmailAddress, {
           personalisation,
         });
 
         expect(result).toBeDefined;
         expect(result.response).toBeDefined;
+        expect(result.id).toBeDefined;
       });
 
       it("rejects when templateId is an invalid UUID", async () => {

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -119,8 +119,7 @@ describe(
 
     const validEmailAddress = "simulate-delivered@notifications.service.gov.uk";
 
-    // WIP, NK
-    describe.skip("sendEmail", () => {
+    describe("sendEmail", () => {
       it("Can successfully send an Email", async () => {
         const result = await client.sendEmail(templateId, validEmailAddress, {
           personalisation,

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -29,7 +29,7 @@ const contractTestClient = (testCallback) => () => {
 };
 
 describe(
-  "GovNotify contract tests",
+  "GovNotify contract sms tests",
   contractTestClient(({ client }) => {
     const { templateId, personalisationKeys } = TemplateStore.firstText;
 

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -120,7 +120,8 @@ describe(
     const validEmailAddress = "simulate-delivered@notifications.service.gov.uk";
 
     describe("sendEmail", () => {
-      it("Can successfully send an Email", async () => {
+      it("can successfully send an Email", async () => {
+        console.log(personalisation);
         const result = await client.sendEmail(templateId, validEmailAddress, {
           personalisation,
         });
@@ -158,6 +159,36 @@ describe(
           })
         );
       });
+    });
+
+    it("rejects when personalisation values are missing", async () => {
+      await expect(
+        client.sendEmail(templateId, validEmailAddress, {
+          personalisation: {
+            hospital_name: "Test Hopsital",
+          },
+        })
+      ).rejects.toMatchObject(
+        buildError({
+          error: "BadRequestError",
+          message: expect.stringMatching(
+            /Missing personalisation: ward_name, visit_date, visit_time/
+          ),
+        })
+      );
+    });
+
+    it("rejects an invalid email address", async () => {
+      await expect(
+        client.sendEmail(templateId, "@", {
+          personalisation,
+        })
+      ).rejects.toMatchObject(
+        buildError({
+          error: "ValidationError",
+          message: "email_address Not a valid email address",
+        })
+      );
     });
   })
 );

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -128,6 +128,36 @@ describe(
         expect(result).toBeDefined;
         expect(result.response).toBeDefined;
       });
+
+      it("rejects when templateId is an invalid UUID", async () => {
+        await expect(
+          client.sendEmail("", validEmailAddress, {
+            personalisation: {},
+          })
+        ).rejects.toMatchObject(
+          buildError({
+            error: "ValidationError",
+            message: "template_id is not a valid UUID",
+          })
+        );
+      });
+
+      it("rejects when templateId does not match a template", async () => {
+        await expect(
+          client.sendEmail(
+            "3b45757d-aaaa-4e33-ac7c-00674a70888d",
+            validEmailAddress,
+            {
+              personalisation: {},
+            }
+          )
+        ).rejects.toMatchObject(
+          buildError({
+            error: "BadRequestError",
+            message: "Template not found",
+          })
+        );
+      });
     });
   })
 );

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -110,6 +110,28 @@ describe(
   })
 );
 
+describe(
+  "GovNotify contract email tests",
+  contractTestClient(({ client }) => {
+    const { templateId, personalisationKeys } = TemplateStore.firstEmail;
+
+    const personalisation = fillObjectWithStrings(personalisationKeys);
+
+    const validEmailAddress = "simulate-delivered@notifications.service.gov.uk";
+
+    xdescribe("sendEmail", () => {
+      it("Can successfully send an Email", async () => {
+        const result = await client.sendEmail(templateId, validEmailAddress, {
+          personalisation,
+        });
+
+        expect(result).toBeDefined;
+        expect(result.response).toBeDefined;
+      });
+    });
+  })
+);
+
 const buildError = ({ error, message }) => ({
   error: {
     errors: [


### PR DESCRIPTION
# What
Implements the contract testing fake `NotifyClient`

# Why

Enables de-coupled and isolated contract tests.

# Screenshots
N/A

# Notes
Below is now implemented in a47bbca
~There is a very basic test for a valid email address. Is there value in reusing our recently implemented validator (`helpers/validateEmailAddress.js`) in the fake?~