### PR TITLE
Fix create trust api admin code

### DIFF
--- a/pageTests/api/create-trust.test.js
+++ b/pageTests/api/create-trust.test.js
@@ -12,6 +12,7 @@ describe("create-trust", () => {
       method: "POST",
       body: {
         name: "Test Trust",
+        adminCode: "admincode",
       },
       headers: {
         cookie: "token=valid.token.value",
@@ -83,6 +84,7 @@ describe("create-trust", () => {
     expect(createTrustSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "Test Trust",
+        adminCode: "admincode",
       })
     );
   });
@@ -101,58 +103,11 @@ describe("create-trust", () => {
 
     expect(response.status).toHaveBeenCalledWith(409);
     expect(response.end).toHaveBeenCalledWith(
-      JSON.stringify({ err: "Trust name already exists" })
+      JSON.stringify({ err: "Admin code already exists" })
     );
   });
 
-  it("returns a 400 if the name is an empty string", async () => {
-    const invalidRequest = {
-      method: "POST",
-      body: {
-        name: "",
-        trustName: "Yugi Muto Trust",
-      },
-      headers: {
-        cookie: "token=valid.token.value",
-      },
-    };
-
-    await createTrust(invalidRequest, response, {
-      container: {
-        ...container,
-      },
-    });
-
-    expect(response.status).toHaveBeenCalledWith(400);
-    expect(response.end).toHaveBeenCalledWith(
-      JSON.stringify({ err: "name must be present" })
-    );
-  });
-
-  it("returns a 400 if the name is not provided", async () => {
-    const invalidRequest = {
-      method: "POST",
-      body: {
-        trustName: "Yugi Muto Trust",
-      },
-      headers: {
-        cookie: "token=valid.token.value",
-      },
-    };
-
-    await createTrust(invalidRequest, response, {
-      container: {
-        ...container,
-      },
-    });
-
-    expect(response.status).toHaveBeenCalledWith(400);
-    expect(response.end).toHaveBeenCalledWith(
-      JSON.stringify({ err: "name must be present" })
-    );
-  });
-
-  it("returns a 400 if the trust name is an empty string", async () => {
+  it("returns a 409 if the name is an empty string", async () => {
     const invalidRequest = {
       method: "POST",
       body: {
@@ -169,9 +124,77 @@ describe("create-trust", () => {
       },
     });
 
-    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.status).toHaveBeenCalledWith(409);
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify({ err: "name must be present" })
+    );
+  });
+
+  it("returns a 409 if the name is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {},
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "name must be present" })
+    );
+  });
+
+  it("returns a 409 if the admin code is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "admin code must be present" })
+    );
+  });
+
+  it("returns a 409 if the admin code is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+        adminCode: "",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "admin code must be present" })
     );
   });
 });

--- a/pages/api/create-trust.js
+++ b/pages/api/create-trust.js
@@ -17,8 +17,14 @@ export default withContainer(
     }
 
     if (!body.name) {
-      res.status(400);
+      res.status(409);
       res.end(JSON.stringify({ err: "name must be present" }));
+      return;
+    }
+
+    if (!body.adminCode) {
+      res.status(409);
+      res.end(JSON.stringify({ err: "admin code must be present" }));
       return;
     }
 
@@ -28,11 +34,12 @@ export default withContainer(
 
     const { trustId, error } = await createTrust({
       name: body.name,
+      adminCode: body.adminCode,
     });
 
     if (error) {
       res.status(409);
-      res.end(JSON.stringify({ err: "Trust name already exists" }));
+      res.end(JSON.stringify({ err: "Admin code already exists" }));
     } else {
       res.status(201);
       res.end(JSON.stringify({ trustId: trustId }));

--- a/src/usecases/createTrust.contractTest.js
+++ b/src/usecases/createTrust.contractTest.js
@@ -22,4 +22,23 @@ describe("createTrust contract tests", () => {
 
     expect(error).toBeNull();
   });
+
+  it("returns an error if the admin_code is not unique", async () => {
+    await createTrust(container)({
+      name: "Test Trust",
+      adminCode: "adminCode",
+    });
+
+    const request = {
+      name: "Test Trust 2",
+      adminCode: "adminCode",
+    };
+
+    const { trustId, error } = await createTrust(container)(request);
+
+    expect(trustId).toBeNull();
+    expect(error.toString()).toEqual(
+      'error: duplicate key value violates unique constraint "trusts_admin_code_key"'
+    );
+  });
 });


### PR DESCRIPTION
# What
Ensures the admin code is provided to the create-trust API

# Why
The admin code is required when creating new Trusts

# Screenshots

# Notes
