### PR TITLE
Remove reference to dropped column when updating a ward

### DIFF
--- a/src/usecases/updateWard.contractTest.js
+++ b/src/usecases/updateWard.contractTest.js
@@ -1,0 +1,49 @@
+import updateWard from "./updateWard";
+import AppContainer from "../containers/AppContainer";
+
+describe("updateWard contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("updates a ward in the db when valid", async () => {
+    const { trustId } = await container.getCreateTrust(container)({
+      name: "Test Trust",
+      adminCode: "TEST",
+    });
+
+    const { hospitalId } = await container.getCreateHospital()({
+      name: "Test Hospital",
+      trustId: trustId,
+    });
+
+    const { wardId: existingWardId } = await container.getCreateWard()({
+      name: "Test Ward",
+      code: "wardCode",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const request = {
+      name: "Test Ward 2",
+      hospitalId: hospitalId,
+      id: existingWardId,
+    };
+
+    const { wardId: updatedWardId, error } = await updateWard(container)(
+      request
+    );
+
+    const { ward } = await container.getRetrieveWardById()(
+      updatedWardId,
+      trustId
+    );
+
+    expect(ward).toEqual({
+      id: existingWardId,
+      name: "Test Ward 2",
+      hospitalId: hospitalId,
+      hospitalName: "Test Hospital",
+    });
+
+    expect(error).toBeNull();
+  });
+});

--- a/src/usecases/updateWard.js
+++ b/src/usecases/updateWard.js
@@ -4,13 +4,12 @@ export default ({ getDb }) => async (ward) => {
     const updatedWard = await db.one(
       `UPDATE wards
       SET name = $1,
-          hospital_name = $2,
-          hospital_id = $3
+          hospital_id = $2
       WHERE
-          id = $4
+          id = $3
       RETURNING id
           `,
-      [ward.name, ward.hospitalName, ward.hospitalId, ward.id]
+      [ward.name, ward.hospitalId, ward.id]
     );
     return {
       wardId: updatedWard.id,

--- a/src/usecases/updateWard.test.js
+++ b/src/usecases/updateWard.test.js
@@ -13,7 +13,6 @@ describe("updateWard", () => {
     const request = {
       id: 10,
       name: "Defoe Ward",
-      hospitalName: "Test Hospital",
       hospitalId: 1,
     };
     const { wardId, error } = await updateWard(container)(request);
@@ -21,7 +20,6 @@ describe("updateWard", () => {
     expect(error).toBeNull();
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.name,
-      request.hospitalName,
       request.hospitalId,
       request.id,
     ]);


### PR DESCRIPTION
# What
Removes a reference to dropped the column hospital_name when updating a ward

# Why
To prevent errors when updating a ward due to the reference to a non-existent column

# Screenshots

# Notes
