### PR TITLE
Create trust form

### DIFF
--- a/pageTests/admin.test.js
+++ b/pageTests/admin.test.js
@@ -1,0 +1,90 @@
+import { getServerSideProps } from "../pages/admin";
+
+describe("admin", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  const authenticatedReq = {
+    headers: {
+      cookie: "token=123",
+    },
+  };
+
+  const trusts = [
+    {
+      id: 1,
+      name: "Test Trust 1",
+      adminCode: "test_code",
+    },
+    {
+      id: 2,
+      name: "Test Trust 2",
+      adminCode: "test_code_2",
+    },
+  ];
+
+  let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "admin" })),
+  };
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+
+    it("retrieves trusts", async () => {
+      const getRetrieveTrustsSpy = jest.fn(async () => ({
+        trusts: trusts,
+        error: null,
+      }));
+      const container = {
+        getRetrieveTrusts: () => getRetrieveTrustsSpy,
+        getTokenProvider: () => tokenProvider,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(getRetrieveTrustsSpy).toHaveBeenCalled();
+      expect(props.trusts).toEqual(trusts);
+      expect(props.error).toBeNull();
+    });
+
+    it("sets an error in props if trusts error", async () => {
+      const getRetrieveTrustsSpy = jest.fn(async () => ({
+        trusts: null,
+        error: "Error!",
+      }));
+      const container = {
+        getRetrieveTrusts: () => getRetrieveTrustsSpy,
+        getTokenProvider: () => tokenProvider,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.error).toEqual("Error!");
+    });
+  });
+});

--- a/pageTests/admin/add-a-trust-success.test.js
+++ b/pageTests/admin/add-a-trust-success.test.js
@@ -1,0 +1,91 @@
+import { getServerSideProps } from "../../pages/admin/add-a-trust-success";
+
+const authenticatedReq = {
+  headers: {
+    cookie: "token=123",
+  },
+};
+
+const tokenProvider = {
+  validate: jest.fn(() => ({ type: "admin" })),
+};
+
+describe("/admin/add-a-trust-success", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+
+    describe("with trustId parameter", () => {
+      it("retrieves a trust by the trustId parameter", async () => {
+        const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+          trust: {
+            id: 1,
+            name: "Northwick Park Trust",
+          },
+          error: null,
+        });
+
+        const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
+          getTokenProvider: () => tokenProvider,
+        };
+
+        await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query: {
+            trustId: "trust ID",
+          },
+          container,
+        });
+
+        expect(retrieveTrustByIdSpy).toHaveBeenCalledWith("trust ID");
+      });
+
+      it("set a trust prop based on the retrieved trust", async () => {
+        const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+          trust: {
+            id: 1,
+            name: "Northwick Park Trust",
+          },
+          error: null,
+        });
+
+        const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
+          getTokenProvider: () => tokenProvider,
+        };
+
+        const { props } = await getServerSideProps({
+          req: authenticatedReq,
+          res,
+          query: {
+            trustId: "trust ID",
+          },
+          container,
+        });
+
+        expect(props.name).toEqual("Northwick Park Trust");
+      });
+    });
+  });
+});

--- a/pageTests/admin/add-a-trust.test.js
+++ b/pageTests/admin/add-a-trust.test.js
@@ -1,0 +1,27 @@
+import { getServerSideProps } from "../../pages/admin/add-a-trust";
+
+describe("/trust-admin/add-a-trust", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+  });
+});

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -4,6 +4,7 @@ import propsWithContainer from "../src/middleware/propsWithContainer";
 import verifyAdminToken from "../src/usecases/verifyAdminToken";
 import { GridRow, GridColumn } from "../src/components/Grid";
 import Heading from "../src/components/Heading";
+import ActionLink from "../src/components/ActionLink";
 
 const Admin = () => {
   return (
@@ -11,6 +12,7 @@ const Admin = () => {
       <GridRow>
         <GridColumn width="full">
           <Heading>Site administration</Heading>
+          <ActionLink href={`/admin/add-a-trust`}>Add a trust</ActionLink>
         </GridColumn>
       </GridRow>
     </Layout>

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -5,14 +5,27 @@ import verifyAdminToken from "../src/usecases/verifyAdminToken";
 import { GridRow, GridColumn } from "../src/components/Grid";
 import Heading from "../src/components/Heading";
 import ActionLink from "../src/components/ActionLink";
+import TrustsTable from "../src/components/TrustsTable";
+import Text from "../src/components/Text";
+import Error from "next/error";
 
-const Admin = () => {
+const Admin = ({ trusts, error }) => {
+  if (error) {
+    return <Error err={error} />;
+  }
+
   return (
     <Layout title={`Site administration`} renderLogout={true}>
       <GridRow>
         <GridColumn width="full">
           <Heading>Site administration</Heading>
           <ActionLink href={`/admin/add-a-trust`}>Add a trust</ActionLink>
+
+          {trusts.length > 0 ? (
+            <TrustsTable trusts={trusts} />
+          ) : (
+            <Text>There are no trusts.</Text>
+          )}
         </GridColumn>
       </GridRow>
     </Layout>
@@ -20,9 +33,11 @@ const Admin = () => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(async () => {
+  verifyAdminToken(async ({ container }) => {
+    const { trusts, error } = await container.getRetrieveTrusts()();
+
     return {
-      props: {},
+      props: { trusts: trusts, error: error },
     };
   })
 );

--- a/pages/admin/add-a-trust-success.js
+++ b/pages/admin/add-a-trust-success.js
@@ -1,0 +1,55 @@
+import React from "react";
+import Error from "next/error";
+import Layout from "../../src/components/Layout";
+import AnchorLink from "../../src/components/AnchorLink";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+import verifyAdminToken from "../../src/usecases/verifyAdminToken";
+import ActionLink from "../../src/components/ActionLink";
+
+const AddATrustSuccess = ({ error, name }) => {
+  if (error) {
+    return <Error />;
+  }
+
+  return (
+    <Layout title={`${name} has been added`} renderLogout={true}>
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-two-thirds">
+          <div
+            className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+            style={{ textAlign: "center" }}
+          >
+            <h1 className="nhsuk-panel__title">{name} has been added</h1>
+          </div>
+          <h2>What happens next</h2>
+
+          <ActionLink href={`/admin/add-a-trust`}>Add another trust</ActionLink>
+
+          <p>
+            <AnchorLink href="/admin">Return to site administration</AnchorLink>
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyAdminToken(async ({ container, query }) => {
+    const getRetrieveTrustById = container.getRetrieveTrustById();
+    const { trust, error } = await getRetrieveTrustById(query.trustId);
+
+    if (error) {
+      return { props: { error: error } };
+    } else {
+      return {
+        props: {
+          error: error,
+          name: trust.name,
+        },
+      };
+    }
+  })
+);
+
+export default AddATrustSuccess;

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -106,10 +106,10 @@ const AddATrust = () => {
         const status = response.status;
 
         if (status == 201) {
-          await response.json();
+          const { trustId } = await response.json();
           Router.push({
-            pathname: "/admin",
-            query: {},
+            pathname: "/admin/add-a-trust-success",
+            query: { trustId: trustId },
           });
         } else if (status === 409) {
           const { err } = await response.json();

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -1,0 +1,213 @@
+import React, { useState, useCallback } from "react";
+import ErrorSummary from "../../src/components/ErrorSummary";
+import { GridRow, GridColumn } from "../../src/components/Grid";
+import Layout from "../../src/components/Layout";
+import verifyAdminToken from "../../src/usecases/verifyAdminToken";
+
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+import FormGroup from "../../src/components/FormGroup";
+import Heading from "../../src/components/Heading";
+import Input from "../../src/components/Input";
+import Label from "../../src/components/Label";
+import Button from "../../src/components/Button";
+import Router from "next/router";
+
+const AddATrust = () => {
+  const [errors, setErrors] = useState([]);
+  const [name, setName] = useState("");
+  const [adminCode, setAdminCode] = useState("");
+  const [adminCodeConfirmation, setAdminCodeConfirmation] = useState("");
+
+  const hasError = (field) =>
+    errors.find((error) => error.id === `${field}-error`);
+
+  const errorMessage = (field) => {
+    const error = errors.filter((err) => err.id === `${field}-error`);
+    return error.length === 1 ? error[0].message : "";
+  };
+
+  const onSubmit = useCallback(async (event) => {
+    event.preventDefault();
+    const onSubmitErrors = [];
+
+    const setNameError = (errors) => {
+      errors.push({
+        id: "trust-name-error",
+        message: "Enter a trust name",
+      });
+    };
+
+    const setAdminCodeUniqueError = (errors, err) => {
+      errors.push({
+        id: "trust-admin-code-error",
+        message: err,
+      });
+    };
+
+    const setAdminCodeError = (errors) => {
+      errors.push({
+        id: "trust-admin-code-error",
+        message: "Enter a trust admin code",
+      });
+    };
+
+    const setAdminCodeLengthError = (errors) => {
+      errors.push({
+        id: "trust-admin-code-error",
+        message: "Trust admin code must be at least 8 characters long",
+      });
+    };
+
+    const setAdminCodeConfirmationMismatchError = (errors) => {
+      errors.push({
+        id: "trust-admin-code-confirmation-error",
+        message: "Trust admin code confirmation does not match",
+      });
+    };
+
+    const setAdminCodeConfirmationError = (errors) => {
+      errors.push({
+        id: "trust-admin-code-confirmation-error",
+        message: "Confirm the trust admin code",
+      });
+    };
+
+    if (name.length === 0) {
+      setNameError(onSubmitErrors);
+    }
+
+    if (adminCode.length === 0) {
+      setAdminCodeError(onSubmitErrors);
+    } else if (adminCode.length < 8) {
+      setAdminCodeLengthError(onSubmitErrors);
+    }
+
+    if (adminCodeConfirmation.length !== 0) {
+      if (adminCode !== adminCodeConfirmation) {
+        setAdminCodeConfirmationMismatchError(onSubmitErrors);
+      }
+    } else {
+      setAdminCodeConfirmationError(onSubmitErrors);
+    }
+
+    if (onSubmitErrors.length === 0) {
+      const submitAnswers = async (name) => {
+        const response = await fetch("/api/create-trust", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            name,
+            adminCode,
+          }),
+        });
+
+        const status = response.status;
+
+        if (status == 201) {
+          await response.json();
+          Router.push({
+            pathname: "/admin",
+            query: {},
+          });
+        } else if (status === 409) {
+          const { err } = await response.json();
+          setAdminCodeUniqueError(onSubmitErrors, err);
+        } else {
+          onSubmitErrors.push({
+            message: "Something went wrong, please try again later.",
+          });
+          setErrors(onSubmitErrors);
+        }
+      };
+
+      await submitAnswers(name);
+    }
+    setErrors(onSubmitErrors);
+  });
+
+  return (
+    <Layout
+      title="Add a Trust"
+      hasErrors={errors.length != 0}
+      renderLogout={true}
+    >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <ErrorSummary errors={errors} />
+          <form onSubmit={onSubmit}>
+            <Heading>Add a Trust</Heading>
+            <FormGroup>
+              <Label htmlFor="trust-name" className="nhsuk-label--l">
+                What is the trust name?
+              </Label>
+              <Input
+                id="trust-name"
+                type="text"
+                hasError={hasError("trust-name")}
+                errorMessage={errorMessage("trust-name")}
+                className="nhsuk-u-font-size-32 nhsuk-input--width-10"
+                style={{ padding: "16px!important", height: "64px" }}
+                onChange={(event) => setName(event.target.value)}
+                name="trust-name"
+                autoComplete="off"
+                value={name || ""}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Label htmlFor="trust-admin-code" className="nhsuk-label--l">
+                Create a trust admin code
+              </Label>
+              <Input
+                id="trust-admin-code"
+                type="text"
+                hasError={hasError("trust-admin-code")}
+                errorMessage={errorMessage("trust-admin-code")}
+                className="nhsuk-u-font-size-32 nhsuk-input--width-10"
+                style={{ padding: "16px!important", height: "64px" }}
+                onChange={(event) => setAdminCode(event.target.value)}
+                name="trust-admin-code"
+                autoComplete="off"
+                value={adminCode || ""}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Label
+                htmlFor="trust-admin-code-confirmation"
+                className="nhsuk-label--l"
+              >
+                Confirm the trust admin code
+              </Label>
+              <Input
+                id="trust-admin-code-confirmation"
+                type="text"
+                hasError={hasError("trust-admin-code-confirmation")}
+                errorMessage={errorMessage("trust-admin-code-confirmation")}
+                className="nhsuk-u-font-size-32 nhsuk-input--width-10"
+                style={{ padding: "16px!important", height: "64px" }}
+                onChange={(event) =>
+                  setAdminCodeConfirmation(event.target.value)
+                }
+                name="trust-admin-code-confirmation"
+                autoComplete="off"
+                value={adminCodeConfirmation || ""}
+              />
+            </FormGroup>
+            <Button className="nhsuk-u-margin-top-5">Add Trust</Button>
+          </form>
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyAdminToken(async () => {
+    return {
+      props: {},
+    };
+  })
+);
+
+export default AddATrust;

--- a/src/components/TrustsTable/index.js
+++ b/src/components/TrustsTable/index.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+const TrustsTable = ({ trusts }) => (
+  <div className="nhsuk-table-responsive">
+    <table className="nhsuk-table">
+      <caption className="nhsuk-table__caption">List of trusts</caption>
+      <thead className="nhsuk-table__head">
+        <tr className="nhsuk-table__row">
+          <th className="nhsuk-table__header" scope="col">
+            Trust name
+          </th>
+        </tr>
+      </thead>
+      <tbody className="nhsuk-table__body">
+        {trusts.map((trust) => (
+          <tr key={trust.callId} className="nhsuk-table__row">
+            <td className="nhsuk-table__cell">{trust.name}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default TrustsTable;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -26,6 +26,7 @@ import archiveWard from "../usecases/archiveWard";
 import validateEmailAddress from "../usecases/validateEmailAddress";
 import validateMobileNumber from "../usecases/validateMobileNumber";
 import createTrust from "../usecases/createTrust";
+import retrieveTrusts from "../usecases/retrieveTrusts";
 
 class AppContainer {
   getDb = () => {
@@ -138,6 +139,10 @@ class AppContainer {
 
   getCreateTrust = () => {
     return createTrust(this);
+  };
+
+  getRetrieveTrusts = () => {
+    return retrieveTrusts(this);
   };
 }
 

--- a/src/usecases/retrieveTrusts.contractTest.js
+++ b/src/usecases/retrieveTrusts.contractTest.js
@@ -1,0 +1,24 @@
+import AppContainer from "../containers/AppContainer";
+
+describe("retrieveTrusts contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("retrieves all Trusts from the db", async () => {
+    const { trustId: trustId1 } = await container.getCreateTrust()({
+      name: "Test Trust",
+      adminCode: "code1",
+    });
+
+    const { trustId: trustId2 } = await container.getCreateTrust()({
+      name: "Test Trust 2",
+      adminCode: "code2",
+    });
+
+    const { trusts } = await container.getRetrieveTrusts()();
+
+    expect(trusts).toEqual([
+      { id: trustId1, name: "Test Trust", adminCode: "code1" },
+      { id: trustId2, name: "Test Trust 2", adminCode: "code2" },
+    ]);
+  });
+});

--- a/src/usecases/retrieveTrusts.js
+++ b/src/usecases/retrieveTrusts.js
@@ -1,0 +1,30 @@
+const retrieveTrusts = ({ getDb }) => async () => {
+  const db = await getDb();
+  try {
+    const trusts = await db.any(
+      `SELECT
+        id as id,
+        name as name,
+        admin_code as admin_code
+      FROM
+        trusts`
+    );
+
+    return {
+      trusts: trusts.map((trust) => ({
+        id: trust.id,
+        name: trust.name,
+        adminCode: trust.admin_code,
+      })),
+      error: null,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      trusts: null,
+      error: error.toString(),
+    };
+  }
+};
+
+export default retrieveTrusts;


### PR DESCRIPTION
# What
Adds a form to create new Trusts via the Site administration page

# Why
Allows Admins to create Trusts without the need of developer intervention

# Screenshots
![localhost_3000_admin_add-a-trust(iPad)](https://user-images.githubusercontent.com/7527178/83046129-76d04a80-a03e-11ea-98dd-60ac91695dca.png)

# Notes
