### PR TITLE
Trust overview metrics

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -61,6 +61,8 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveWardVisitTotals: () =>
+          jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
       };
 
@@ -75,6 +77,32 @@ describe("trust-admin", () => {
       expect(props.wardError).toBeNull();
     });
 
+    it("retrieves ward visit totals", async () => {
+      const getRetrieveWardsSpy = jest.fn(async () => ({
+        wards: wards,
+        error: null,
+      }));
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: { name: "Doggo Trust" },
+        error: null,
+      }));
+      const container = {
+        getRetrieveWards: () => getRetrieveWardsSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveWardVisitTotals: () =>
+          jest.fn().mockReturnValue({ total: 5 }),
+        getTokenProvider: () => tokenProvider,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.visitsScheduled).toEqual(5);
+    });
+
     it("sets an error in props if ward error", async () => {
       const getRetrieveWardsSpy = jest.fn(async () => ({
         wards: null,
@@ -87,6 +115,8 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveWardVisitTotals: () =>
+          jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
       };
 
@@ -114,6 +144,8 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveWardVisitTotals: () =>
+          jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
       };
 
@@ -140,6 +172,8 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveWardVisitTotals: () =>
+          jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
       };
 

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -61,6 +61,13 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
         getRetrieveWardVisitTotals: () =>
           jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
@@ -77,6 +84,46 @@ describe("trust-admin", () => {
       expect(props.wardError).toBeNull();
     });
 
+    it("retrieves hospitals", async () => {
+      const getRetrieveWardsSpy = jest.fn(async () => ({
+        wards: wards,
+        error: null,
+      }));
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: { name: "Doggo Trust" },
+        error: null,
+      }));
+      const container = {
+        getRetrieveWards: () => getRetrieveWardsSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
+        getRetrieveWardVisitTotals: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
+        getTokenProvider: () => tokenProvider,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.hospitals.length).toEqual(2);
+      expect(props.hospitals[0].id).toEqual(1);
+      expect(props.hospitals[1].name).toEqual("2");
+    });
+
     it("retrieves ward visit totals", async () => {
       const getRetrieveWardsSpy = jest.fn(async () => ({
         wards: wards,
@@ -89,6 +136,13 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
         getRetrieveWardVisitTotals: () =>
           jest.fn().mockReturnValue({ total: 5 }),
         getTokenProvider: () => tokenProvider,
@@ -115,6 +169,13 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
         getRetrieveWardVisitTotals: () =>
           jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
@@ -144,6 +205,13 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
         getRetrieveWardVisitTotals: () =>
           jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,
@@ -172,6 +240,13 @@ describe("trust-admin", () => {
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          jest.fn().mockReturnValue({
+            hospitals: [
+              { id: 1, name: "1" },
+              { id: 2, name: "2" },
+            ],
+          }),
         getRetrieveWardVisitTotals: () =>
           jest.fn().mockReturnValue({ total: 0 }),
         getTokenProvider: () => tokenProvider,

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -8,8 +8,15 @@ import { GridRow, GridColumn } from "../src/components/Grid";
 import Heading from "../src/components/Heading";
 import ActionLink from "../src/components/ActionLink";
 import Text from "../src/components/Text";
+import NumberTile from "../src/components/NumberTile";
 
-const TrustAdmin = ({ wardError, trustError, wards, trust }) => {
+const TrustAdmin = ({
+  wardError,
+  trustError,
+  wards,
+  trust,
+  visitsScheduled,
+}) => {
   if (wardError || trustError) {
     return <Error />;
   }
@@ -25,11 +32,15 @@ const TrustAdmin = ({ wardError, trustError, wards, trust }) => {
             </span>
             Ward administration
           </Heading>
+          <GridRow className="nhsuk-u-padding-bottom-3">
+            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
+              <NumberTile number={visitsScheduled} label="booked visits" />
+            </GridColumn>
+          </GridRow>
           <ActionLink href={`/trust-admin/add-a-ward`}>Add a ward</ActionLink>
           <ActionLink href={`/trust-admin/add-a-hospital`}>
             Add a hospital
           </ActionLink>
-
           {wards.length > 0 ? (
             <WardsTable wards={wards} />
           ) : (
@@ -50,7 +61,8 @@ export const getServerSideProps = propsWithContainer(
       authenticationToken.trustId
     );
 
-    // const trustName = trustResponse.trust ? trustResponse.trust.name : null;
+    const retrieveWardVisitTotals = container.getRetrieveWardVisitTotals();
+    const { total } = await retrieveWardVisitTotals();
 
     return {
       props: {
@@ -58,6 +70,7 @@ export const getServerSideProps = propsWithContainer(
         trust: { name: trustResponse.trust?.name },
         wardError: wardsResponse.error,
         trustError: trustResponse.error,
+        visitsScheduled: total,
       },
     };
   })

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -14,6 +14,7 @@ const TrustAdmin = ({
   wardError,
   trustError,
   wards,
+  hospitals,
   trust,
   visitsScheduled,
 }) => {
@@ -36,6 +37,12 @@ const TrustAdmin = ({
             <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
               <NumberTile number={visitsScheduled} label="booked visits" />
             </GridColumn>
+            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
+              <NumberTile number={hospitals.length} label="hospitals" />
+            </GridColumn>
+            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
+              <NumberTile number={wards.length} label="wards" />
+            </GridColumn>
           </GridRow>
           <ActionLink href={`/trust-admin/add-a-ward`}>Add a ward</ActionLink>
           <ActionLink href={`/trust-admin/add-a-hospital`}>
@@ -57,6 +64,9 @@ export const getServerSideProps = propsWithContainer(
     const wardsResponse = await container.getRetrieveWards()(
       authenticationToken.trustId
     );
+    const hospitalsResponse = await container.getRetrieveHospitalsByTrustId()(
+      authenticationToken.trustId
+    );
     const trustResponse = await container.getRetrieveTrustById()(
       authenticationToken.trustId
     );
@@ -67,6 +77,7 @@ export const getServerSideProps = propsWithContainer(
     return {
       props: {
         wards: wardsResponse.wards,
+        hospitals: hospitalsResponse.hospitals,
         trust: { name: trustResponse.trust?.name },
         wardError: wardsResponse.error,
         trustError: trustResponse.error,

--- a/src/components/Grid/index.js
+++ b/src/components/Grid/index.js
@@ -1,11 +1,15 @@
 import React from "react";
+import classnames from "classnames";
 
-const GridRow = ({ children }) => (
-  <div className="nhsuk-grid-row">{children}</div>
+const GridRow = ({ children, className }) => (
+  <div className={classnames("nhsuk-grid-row", className)}>{children}</div>
 );
 
-const GridColumn = ({ children, width, ...others }) => (
-  <div className={`nhsuk-grid-column-${width}`} {...others}>
+const GridColumn = ({ children, className, width, ...others }) => (
+  <div
+    className={classnames(`nhsuk-grid-column-${width}`, className)}
+    {...others}
+  >
     {children}
   </div>
 );

--- a/src/components/NumberTile/index.js
+++ b/src/components/NumberTile/index.js
@@ -1,0 +1,11 @@
+import React from "react";
+import "./styles.scss";
+
+const NumberTitle = ({ number, label }) => (
+  <div className="app-number-tile">
+    {number}
+    <span className="app-number-tile-label">{label}</span>
+  </div>
+);
+
+export default NumberTitle;

--- a/src/components/NumberTile/styles.scss
+++ b/src/components/NumberTile/styles.scss
@@ -1,0 +1,18 @@
+@import "node_modules/nhsuk-frontend/packages/nhsuk";
+
+.app-number-tile {
+  @include nhsuk-typography-responsive(48);
+
+  background-color: $color_nhsuk-blue;
+  color: $color_nhsuk-white;
+  width: 100%;
+  padding: 1.5rem 1rem;
+  font-weight: bold;
+
+  .app-number-tile-label {
+    @include nhsuk-typography-responsive(19);
+
+    font-weight: normal;
+    display: block;
+  }
+}


### PR DESCRIPTION
# What

Added trust overview metrics tiles to the trust-admin page, showing cumulative visit, hospital and ward counts for the trust.

# Why

To improve the trust administration workflow.

# Screenshots

![metrics](https://user-images.githubusercontent.com/7327692/83242469-629e6180-a194-11ea-936c-58f95dfb8f2d.png)

# Notes

N/A