### PR TITLE
Trust admin hospitals view page

### DIFF
--- a/pageTests/trust-admin/hospitals/[id].test.js
+++ b/pageTests/trust-admin/hospitals/[id].test.js
@@ -1,0 +1,67 @@
+import { getServerSideProps } from "../../../pages/trust-admin/hospitals/[id]";
+
+describe("trust-admin/hospitals/[id]", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  const authenticatedReq = {
+    headers: {
+      cookie: "token=123",
+    },
+  };
+  let res;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId: 1 })),
+  };
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+
+    it("provides the hospital and wards as props", async () => {
+      const hospitalId = 10;
+
+      const wardsSpy = jest.fn(async () => ({
+        wards: [{ id: 1 }, { id: 2 }],
+        error: null,
+      }));
+
+      const hospitalSpy = jest.fn(async () => ({
+        hospital: { name: "Test Hospital" },
+        error: null,
+      }));
+
+      const container = {
+        getRetrieveWardsByHospitalId: () => wardsSpy,
+        getRetrieveHospitalById: () => hospitalSpy,
+        getTokenProvider: () => tokenProvider,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: { id: hospitalId },
+        container,
+      });
+
+      expect(hospitalSpy).toHaveBeenCalledWith(hospitalId, 1);
+      expect(props.wards).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(props.hospital).toEqual({ name: "Test Hospital" });
+    });
+  });
+});

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -1,0 +1,48 @@
+import React from "react";
+import Error from "next/error";
+import propsWithContainer from "../../../src/middleware/propsWithContainer";
+import verifyTrustAdminToken from "../../../src/usecases/verifyTrustAdminToken";
+import ActionLink from "../../../src/components/ActionLink";
+import Heading from "../../../src/components/Heading";
+import { GridRow, GridColumn } from "../../../src/components/Grid";
+import Layout from "../../../src/components/Layout";
+import WardsTable from "../../../src/components/WardsTable";
+
+const ShowHospital = ({ hospital, wards, error }) => {
+  if (error) {
+    return <Error err={error} />;
+  }
+
+  return (
+    <Layout title={hospital.name} renderLogout={true}>
+      <GridRow>
+        <GridColumn width="full">
+          <Heading>{hospital.name}</Heading>
+          <ActionLink href={`/trust-admin/add-a-ward`}>Add a ward</ActionLink>
+          <WardsTable wards={wards} />
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyTrustAdminToken(async ({ authenticationToken, container, query }) => {
+    const { id: hospitalId } = query;
+    const trustId = authenticationToken.trustId;
+
+    const {
+      hospital,
+      error: hospitalError,
+    } = await container.getRetrieveHospitalById()(hospitalId, trustId);
+
+    const {
+      wards,
+      error: wardsError,
+    } = await container.getRetrieveWardsByHospitalId()(hospital.id);
+
+    return { props: { hospital, wards, error: hospitalError || wardsError } };
+  })
+);
+
+export default ShowHospital;


### PR DESCRIPTION
# What
The first iteration of the show hospitals page for trust admins

# Why
Allows Trust admins to view and manage individual hospitals

# Screenshots
![localhost_3000_trust-admin_hospitals_1(iPad)](https://user-images.githubusercontent.com/7527178/83278640-d14ae180-a1cb-11ea-8722-57a028048b8c.png)

# Notes
