### PR TITLE
Only show visits for the current trust on trust overview metrics

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -125,6 +125,7 @@ describe("trust-admin", () => {
     });
 
     it("retrieves ward visit totals", async () => {
+      const trustId = 1;
       const getRetrieveWardsSpy = jest.fn(async () => ({
         wards: wards,
         error: null,
@@ -133,6 +134,9 @@ describe("trust-admin", () => {
         trust: { name: "Doggo Trust" },
         error: null,
       }));
+      const retrieveWardVisitTotalsSpy = jest
+        .fn()
+        .mockReturnValue({ total: 5 });
       const container = {
         getRetrieveWards: () => getRetrieveWardsSpy,
         getRetrieveTrustById: () => retrieveTrustByIdSpy,
@@ -143,8 +147,7 @@ describe("trust-admin", () => {
               { id: 2, name: "2" },
             ],
           }),
-        getRetrieveWardVisitTotals: () =>
-          jest.fn().mockReturnValue({ total: 5 }),
+        getRetrieveWardVisitTotals: () => retrieveWardVisitTotalsSpy,
         getTokenProvider: () => tokenProvider,
       };
 
@@ -154,6 +157,7 @@ describe("trust-admin", () => {
         container,
       });
 
+      expect(retrieveWardVisitTotalsSpy).toHaveBeenCalledWith(trustId);
       expect(props.visitsScheduled).toEqual(5);
     });
 

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -70,9 +70,9 @@ export const getServerSideProps = propsWithContainer(
     const trustResponse = await container.getRetrieveTrustById()(
       authenticationToken.trustId
     );
-
-    const retrieveWardVisitTotals = container.getRetrieveWardVisitTotals();
-    const { total } = await retrieveWardVisitTotals();
+    const retrieveWardVisitTotals = await container.getRetrieveWardVisitTotals()(
+      authenticationToken.trustId
+    );
 
     return {
       props: {
@@ -81,7 +81,7 @@ export const getServerSideProps = propsWithContainer(
         trust: { name: trustResponse.trust?.name },
         wardError: wardsResponse.error,
         trustError: trustResponse.error,
-        visitsScheduled: total,
+        visitsScheduled: retrieveWardVisitTotals.total,
       },
     };
   })

--- a/src/usecases/retrieveWardVisitTotals.contractTest.js
+++ b/src/usecases/retrieveWardVisitTotals.contractTest.js
@@ -1,0 +1,177 @@
+import AppContainer from "../containers/AppContainer";
+
+describe("retrieveWardVisitTotals contract tests", () => {
+  const container = AppContainer.getInstance();
+  const date1 = new Date("2020-06-01 13:00");
+  const date2 = new Date("2020-06-02 13:00");
+
+  describe("when a trustID isn't provided", () => {
+    it("returns the number of booked visits for the service and by all wards", async () => {
+      // A trust with 1 hospital and 2 wards
+      const { trustId } = await container.getCreateTrust()({
+        name: "Test Trust",
+        adminCode: "TEST",
+      });
+      const { hospitalId } = await container.getCreateHospital()({
+        name: "Test Hospital",
+        trustId: trustId,
+      });
+      const { wardId: ward1Id } = await container.getCreateWard()({
+        name: "Test Ward 1",
+        code: "wardCode1",
+        hospitalId: hospitalId,
+        trustId: trustId,
+      });
+      const { wardId: ward2Id } = await container.getCreateWard()({
+        name: "Test Ward 2",
+        code: "wardCode2",
+        hospitalId: hospitalId,
+        trustId: trustId,
+      });
+
+      // A trust with 1 hospital and 1 ward
+      const { trustId: trust2Id } = await container.getCreateTrust()({
+        name: "Test Trust 2",
+        adminCode: "TEST2",
+      });
+      const { hospitalId: hospital2Id } = await container.getCreateHospital()({
+        name: "Test Hospital 2",
+        trustId: trust2Id,
+      });
+      const { wardId: ward3Id } = await container.getCreateWard()({
+        name: "Test Ward 3",
+        code: "wardCode3",
+        hospitalId: hospital2Id,
+        trustId: trust2Id,
+      });
+
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward1Id,
+        date: date1.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward1Id,
+        date: date1.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward2Id,
+        date: date1.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward2Id,
+        date: date2.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward3Id,
+        date: date2.toISOString(),
+      });
+
+      const { total, byWard } = await container.getRetrieveWardVisitTotals()();
+
+      expect(total).toEqual(5);
+      expect(byWard).toEqual([
+        {
+          hospitalName: "Test Hospital",
+          name: "Test Ward 1",
+          visits: 2,
+          trustId: trustId,
+        },
+        {
+          hospitalName: "Test Hospital",
+          name: "Test Ward 2",
+          visits: 2,
+          trustId: trustId,
+        },
+        {
+          hospitalName: "Test Hospital 2",
+          name: "Test Ward 3",
+          visits: 1,
+          trustId: trust2Id,
+        },
+      ]);
+    });
+  });
+
+  describe("when a trustID is provided", () => {
+    it("returns the number of booked visits for the trust and by ward", async () => {
+      // A trust with 1 hospital and 2 wards
+      const { trustId } = await container.getCreateTrust()({
+        name: "Test Trust",
+        adminCode: "TEST",
+      });
+      const { hospitalId } = await container.getCreateHospital()({
+        name: "Test Hospital",
+        trustId: trustId,
+      });
+      const { wardId: ward1Id } = await container.getCreateWard()({
+        name: "Test Ward 1",
+        code: "wardCode1",
+        hospitalId: hospitalId,
+        trustId: trustId,
+      });
+      const { wardId: ward2Id } = await container.getCreateWard()({
+        name: "Test Ward 2",
+        code: "wardCode2",
+        hospitalId: hospitalId,
+        trustId: trustId,
+      });
+
+      // A trust with 1 hospital and 1 ward
+      const { trustId: trust2Id } = await container.getCreateTrust()({
+        name: "Test Trust 2",
+        adminCode: "TEST2",
+      });
+      const { hospitalId: hospital2Id } = await container.getCreateHospital()({
+        name: "Test Hospital 2",
+        trustId: trust2Id,
+      });
+      const { wardId: ward3Id } = await container.getCreateWard()({
+        name: "Test Ward 3",
+        code: "wardCode3",
+        hospitalId: hospital2Id,
+        trustId: trust2Id,
+      });
+
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward1Id,
+        date: date1.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward1Id,
+        date: date1.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward2Id,
+        date: date1.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward2Id,
+        date: date2.toISOString(),
+      });
+      await container.getUpdateWardVisitTotals()({
+        wardId: ward3Id,
+        date: date2.toISOString(),
+      });
+
+      const { total, byWard } = await container.getRetrieveWardVisitTotals()(
+        trustId
+      );
+
+      expect(total).toEqual(4);
+      expect(byWard).toEqual([
+        {
+          hospitalName: "Test Hospital",
+          name: "Test Ward 1",
+          visits: 2,
+          trustId: trustId,
+        },
+        {
+          hospitalName: "Test Hospital",
+          name: "Test Ward 2",
+          visits: 2,
+          trustId: trustId,
+        },
+      ]);
+    });
+  });
+});

--- a/src/usecases/retrieveWardVisitTotals.js
+++ b/src/usecases/retrieveWardVisitTotals.js
@@ -17,7 +17,8 @@ const getVisitsByWard = async (db, trustId) => {
     wards.hospital_id as hospital_id,
     wards.trust_id as trust_id
     FROM ward_visit_totals AS totals JOIN wards ON wards.id = totals.ward_id AND ($1 IS NULL OR wards.trust_id = $1)
-    GROUP BY wards.trust_id, wards.hospital_id, wards.name`,
+    GROUP BY wards.trust_id, wards.hospital_id, wards.name
+    ORDER BY wards.name`,
     [trustId]
   );
 

--- a/src/usecases/retrieveWardVisitTotals.js
+++ b/src/usecases/retrieveWardVisitTotals.js
@@ -1,35 +1,40 @@
 const calculateTotalNumberOfVisits = (visitsByWard) =>
   visitsByWard.reduce((total, { visits }) => total + visits, 0);
 
-const getVisitsByWard = async (db) => {
+const getVisitsByWard = async (db, trustId) => {
   const queryResult = await db.any(
     `SELECT
-      wards.name,
-      SUM(totals.total) AS total_visits,
-      (
-        SELECT
-          name
-        FROM
-          hospitals
-        WHERE
-          id = wards.hospital_id
-      ) as hospital_name,
-      wards.hospital_id as hospital_id
-    FROM ward_visit_totals AS totals JOIN wards ON wards.id = totals.ward_id
-    GROUP BY wards.hospital_id, wards.name`
+    wards.name,
+    SUM(totals.total) AS total_visits,
+    (
+      SELECT
+        name
+      FROM
+        hospitals
+      WHERE
+        id = wards.hospital_id
+    ) as hospital_name,
+    wards.hospital_id as hospital_id,
+    wards.trust_id as trust_id
+    FROM ward_visit_totals AS totals JOIN wards ON wards.id = totals.ward_id AND ($1 IS NULL OR wards.trust_id = $1)
+    GROUP BY wards.trust_id, wards.hospital_id, wards.name`,
+    [trustId]
   );
 
-  return queryResult.map(({ hospital_name, total_visits, name }) => ({
+  return queryResult.map(({ hospital_name, total_visits, name, trust_id }) => ({
     hospitalName: hospital_name,
     name,
     visits: parseInt(total_visits),
+    trustId: trust_id,
   }));
 };
 
-export default ({ getDb }) => async () => {
+const retrieveWardVisitTotals = ({ getDb }) => async (trustId) => {
   const db = await getDb();
-  const visitTotals = await getVisitsByWard(db);
+  const visitTotals = await getVisitsByWard(db, trustId);
   const overallTotal = calculateTotalNumberOfVisits(visitTotals);
 
   return { total: overallTotal, byWard: visitTotals };
 };
+
+export default retrieveWardVisitTotals;

--- a/src/usecases/retrieveWardVisitTotals.js
+++ b/src/usecases/retrieveWardVisitTotals.js
@@ -17,7 +17,7 @@ const getVisitsByWard = async (db, trustId) => {
     wards.hospital_id as hospital_id,
     wards.trust_id as trust_id
     FROM ward_visit_totals AS totals JOIN wards ON wards.id = totals.ward_id AND ($1 IS NULL OR wards.trust_id = $1)
-    GROUP BY wards.trust_id, wards.hospital_id, wards.name
+    GROUP BY wards.trust_id, wards.hospital_id, wards.id
     ORDER BY wards.name`,
     [trustId]
   );

--- a/src/usecases/retrieveWardVisitTotals.test.js
+++ b/src/usecases/retrieveWardVisitTotals.test.js
@@ -1,7 +1,7 @@
 import retrieveWardVisitTotals from "./retrieveWardVisitTotals";
 
 describe("retrieveWardVisitTotals", () => {
-  describe("Given no visits", () => {
+  describe("No trustId specified", () => {
     it("Returns 0 overall total", async () => {
       const anySpy = jest.fn(async () => []);
 
@@ -18,11 +18,39 @@ describe("retrieveWardVisitTotals", () => {
     });
   });
 
+  describe("Given no visits", () => {
+    it("Returns 0 overall total", async () => {
+      const anySpy = jest.fn(async () => []);
+
+      const container = {
+        getDb: async () => ({
+          any: anySpy,
+          trustId: 0,
+        }),
+      };
+
+      const response = await retrieveWardVisitTotals(container)();
+
+      expect(anySpy).toHaveBeenCalled();
+      expect(response).toEqual({ total: 0, byWard: [] });
+    });
+  });
+
   describe("Given some visits", () => {
-    it("Returns the totals per ward and the overall total", async () => {
+    it("Returns the totals per ward and the overall total for all trusts", async () => {
       const anySpy = jest.fn(async () => [
-        { hospital_name: "Hospital One", name: "Ward One", total_visits: "10" },
-        { hospital_name: "Hospital One", name: "Ward Two", total_visits: "20" },
+        {
+          hospital_name: "Hospital One",
+          name: "Ward One",
+          total_visits: "10",
+          trust_id: 0,
+        },
+        {
+          hospital_name: "Hospital One",
+          name: "Ward Two",
+          total_visits: "20",
+          trust_id: 1,
+        },
       ]);
 
       const container = {
@@ -37,8 +65,52 @@ describe("retrieveWardVisitTotals", () => {
       expect(res).toEqual({
         total: 30,
         byWard: [
-          { hospitalName: "Hospital One", name: "Ward One", visits: 10 },
-          { hospitalName: "Hospital One", name: "Ward Two", visits: 20 },
+          {
+            hospitalName: "Hospital One",
+            name: "Ward One",
+            visits: 10,
+            trustId: 0,
+          },
+          {
+            hospitalName: "Hospital One",
+            name: "Ward Two",
+            visits: 20,
+            trustId: 1,
+          },
+        ],
+      });
+    });
+
+    it("Returns the totals per ward and the overall total for the specified trust", async () => {
+      const trustId = 1;
+      const anySpy = jest.fn(async () => [
+        {
+          hospital_name: "Hospital One",
+          name: "Ward Two",
+          total_visits: "20",
+          trust_id: trustId,
+        },
+      ]);
+
+      const container = {
+        getDb: async () => ({
+          any: anySpy,
+          trustId: trustId,
+        }),
+      };
+
+      let res = await retrieveWardVisitTotals(container)(trustId);
+
+      expect(anySpy).toHaveBeenCalled();
+      expect(res).toEqual({
+        total: 20,
+        byWard: [
+          {
+            hospitalName: "Hospital One",
+            name: "Ward Two",
+            visits: 20,
+            trustId: trustId,
+          },
         ],
       });
     });


### PR DESCRIPTION
# What

Update retrieveWardVisitTotals to accept an optional trustId parameter and modify trust-admin to pass the trustId.

# Why

The function will now return data for all trusts if no trustId is passed or filter the visit data to include only that for the specified trust.

# Screenshots

# Notes
