### PR TITLE
Add navigation bar for wards and separate booking a visit page

### DIFF
--- a/pageTests/wards/book-a-visit-start.test.js
+++ b/pageTests/wards/book-a-visit-start.test.js
@@ -1,0 +1,27 @@
+import { getServerSideProps } from "../../pages/wards/book-a-visit-start";
+
+describe("/wards/book-a-visit-start", () => {
+  describe("getServerSideProps", () => {
+    const anonymousReq = {
+      headers: {
+        cookie: "",
+      },
+      query: {},
+    };
+    let res;
+    beforeEach(() => {
+      res = {
+        writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+        end: jest.fn(),
+      };
+    });
+
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+  });
+});

--- a/pages/wards/book-a-visit-confirmation.js
+++ b/pages/wards/book-a-visit-confirmation.js
@@ -77,7 +77,7 @@ const ScheduleConfirmation = ({
   return (
     <Layout
       title="Check your answers before booking a virtual visit"
-      renderLogout={true}
+      showNavigationBarForType="wardStaff"
     >
       <GridRow>
         <GridColumn width="two-thirds">

--- a/pages/wards/book-a-visit-start.js
+++ b/pages/wards/book-a-visit-start.js
@@ -1,0 +1,44 @@
+import React from "react";
+import Link from "next/link";
+import { GridRow, GridColumn } from "../../src/components/Grid";
+import Text from "../../src/components/Text";
+import Heading from "../../src/components/Heading";
+import Layout from "../../src/components/Layout";
+import verifyToken from "../../src/usecases/verifyToken";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+
+const BookAVisitStart = () => {
+  return (
+    <Layout
+      title="Before booking a virtual visit"
+      showNavigationBarForType="wardStaff"
+    >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <Heading>Before booking a virtual visit</Heading>
+
+          <Text>
+            Contact the visitor of the patient and agree a date and time for
+            their virtual visit.
+          </Text>
+          <Text>
+            You&apos;ll need their mobile number or email address so a
+            confirmation is sent to them.
+          </Text>
+
+          <Link href="/wards/book-a-visit">
+            <a className="nhsuk-button">Start now</a>
+          </Link>
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyToken(() => {
+    return { props: {} };
+  })
+);
+
+export default BookAVisitStart;

--- a/pages/wards/book-a-visit-success.js
+++ b/pages/wards/book-a-visit-success.js
@@ -10,7 +10,7 @@ import propsWithContainer from "../../src/middleware/propsWithContainer";
 
 const Success = () => {
   return (
-    <Layout title="Virtual visit booked" renderLogout={true}>
+    <Layout title="Virtual visit booked" showNavigationBarForType="wardStaff">
       <GridRow>
         <GridColumn width="two-thirds">
           <Heading>Virtual visit booked</Heading>

--- a/pages/wards/book-a-visit.js
+++ b/pages/wards/book-a-visit.js
@@ -164,7 +164,7 @@ const BookAVisit = ({
     <Layout
       title="Book a virtual visit"
       hasErrors={errors.length != 0}
-      renderLogout={true}
+      showNavigationBarForType="wardStaff"
     >
       <GridRow>
         <GridColumn width="two-thirds">

--- a/pages/wards/cancel-visit-confirmation.js
+++ b/pages/wards/cancel-visit-confirmation.js
@@ -31,7 +31,7 @@ const deleteVisitConfirmation = ({
   return (
     <Layout
       title="Are you sure you want to cancel this visit?"
-      renderLogout={true}
+      showNavigationBarForType="wardStaff"
     >
       <GridRow>
         <GridColumn width="full">

--- a/pages/wards/cancel-visit-success.js
+++ b/pages/wards/cancel-visit-success.js
@@ -20,7 +20,10 @@ const deleteVisitSuccess = ({
   }
 
   return (
-    <Layout title="Virtual visit cancelled" renderLogout={true}>
+    <Layout
+      title="Virtual visit cancelled"
+      showNavigationBarForType="wardStaff"
+    >
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div

--- a/pages/wards/visit-start.js
+++ b/pages/wards/visit-start.js
@@ -51,7 +51,10 @@ const VisitStart = ({
   }
 
   return (
-    <Layout title="Before handing over to the patient" renderLogout={true}>
+    <Layout
+      title="Before handing over to the patient"
+      showNavigationBarForType="wardStaff"
+    >
       <GridRow>
         <GridColumn width="two-thirds">
           <Heading>Before handing over to the patient</Heading>

--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Layout from "../../src/components/Layout";
 import HeadingWithTime from "../../src/components/HeadingWithTime";
-import ActionLink from "../../src/components/ActionLink";
 import { GridRow, GridColumn } from "../../src/components/Grid";
 import Error from "next/error";
 import Text from "../../src/components/Text";
@@ -14,7 +13,7 @@ export default function WardVisits({ scheduledCalls, ward, error }) {
     return <Error />;
   }
   return (
-    <Layout title="Virtual visits" renderLogout={true}>
+    <Layout title="Virtual visits" showNavigationBarForType="wardStaff">
       <GridRow>
         <GridColumn width="full">
           <HeadingWithTime>
@@ -24,19 +23,6 @@ export default function WardVisits({ scheduledCalls, ward, error }) {
             </span>
             Virtual visits
           </HeadingWithTime>
-
-          <h2 className="nhsuk-heading-l">Book a virtual visit</h2>
-
-          <Text>
-            You&apos;ll need the name and mobile number of your patient&apos;s
-            key contact in order to set up a virtual visit.
-          </Text>
-
-          <ActionLink href={`/wards/book-a-visit`}>
-            Book a virtual visit
-          </ActionLink>
-
-          <h2 className="nhsuk-heading-l">Pre-booked virtual visits</h2>
 
           {scheduledCalls.length > 0 ? (
             <AccordionVisits visits={scheduledCalls} />

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./styles.scss";
 import Head from "next/head";
 import LogoutButton from "../LogoutButton";
+import WardsNavigationBar from "../WardsNavigationBar";
+import MenuToggle from "../../../node_modules/nhsuk-frontend/packages/components/header/menuToggle";
 
 const Layout = ({
   title,
@@ -11,54 +13,75 @@ const Layout = ({
   mainStyleOverride,
   renderLogout = false,
   isBookService = true,
-}) => (
-  <>
-    <Head>
-      <title>
-        {hasErrors ? "Error: " : ""} {title} |{" "}
-        {isBookService ? "Book" : "Attend"} a virtual visit
-      </title>
-    </Head>
-    <a className="nhsuk-skip-link" href="#maincontent">
-      Skip to main content
-    </a>
-    <header className="nhsuk-header" role="banner">
-      <div className="nhsuk-width-container nhsuk-header__container">
-        <div className="nhsuk-header__logo nhsuk-header__logo--only">
-          <svg
-            className="nhsuk-logo"
-            xmlns="http://www.w3.org/2000/svg"
-            role="presentation"
-            focusable="false"
-            viewBox="0 0 40 16"
-          >
-            <path className="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
-            <path
-              className="nhsuk-logo__text"
-              d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"
-            ></path>
-            <image src="https://assets.nhs.uk/images/nhs-logo.png"></image>
-          </svg>
-        </div>
+  showNavigationBarForType,
+}) => {
+  useEffect(() => {
+    MenuToggle();
+    return () => {};
+  }, []);
 
-        <div className="nhsuk-header__content" id="content-header">
-          <div className="nhsuk-header__menu">
-            <LogoutButton renderLogout={renderLogout} />
+  return (
+    <>
+      <Head>
+        <title>
+          {hasErrors ? "Error: " : ""} {title} |{" "}
+          {isBookService ? "Book" : "Attend"} a virtual visit
+        </title>
+      </Head>
+      <a className="nhsuk-skip-link" href="#maincontent">
+        Skip to main content
+      </a>
+      <header className="nhsuk-header" role="banner">
+        <div className="nhsuk-width-container nhsuk-header__container">
+          <div className="nhsuk-header__logo nhsuk-header__logo--only">
+            <svg
+              className="nhsuk-logo"
+              xmlns="http://www.w3.org/2000/svg"
+              role="presentation"
+              focusable="false"
+              viewBox="0 0 40 16"
+            >
+              <path className="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
+              <path
+                className="nhsuk-logo__text"
+                d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"
+              ></path>
+              <image src="https://assets.nhs.uk/images/nhs-logo.png"></image>
+            </svg>
+          </div>
+
+          <div className="nhsuk-header__content" id="content-header">
+            <div className="nhsuk-header__menu">
+              {showNavigationBarForType && (
+                <button
+                  className="nhsuk-header__menu-toggle"
+                  id="toggle-menu"
+                  aria-controls="header-navigation"
+                  aria-label="Open menu"
+                  data-testid="navbar-menu-button"
+                >
+                  Menu
+                </button>
+              )}
+
+              {renderLogout && <LogoutButton renderLogout={renderLogout} />}
+            </div>
           </div>
         </div>
+        {showNavigationBarForType === "wardStaff" && <WardsNavigationBar />}
+      </header>
+      <div className="nhsuk-width-container">
+        <main
+          className="nhsuk-main-wrapper"
+          id="maincontent"
+          style={mainStyleOverride ? { paddingTop: "0" } : {}}
+        >
+          {children}
+          {backLink}
+        </main>
       </div>
-    </header>
-    <div className="nhsuk-width-container">
-      <main
-        className="nhsuk-main-wrapper"
-        id="maincontent"
-        style={mainStyleOverride ? { paddingTop: "0" } : {}}
-      >
-        {children}
-        {backLink}
-      </main>
-    </div>
-  </>
-);
+    </>
+  );
+};
 
 export default Layout;

--- a/src/components/Layout/index.test.js
+++ b/src/components/Layout/index.test.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Layout from "./index";
+
+describe("VisitorContactDetailsInput", () => {
+  describe("when renderLogout is true", () => {
+    it("displays the logout button", () => {
+      render(<Layout renderLogout={true} />);
+
+      expect(screen.getByTestId("logout-button")).toBeVisible();
+    });
+  });
+
+  describe("when renderLogout is false", () => {
+    it("does not display the logout button", () => {
+      render(<Layout renderLogout={false} />);
+
+      expect(screen.queryByTestId("logout-button")).toBeNull();
+    });
+  });
+
+  describe("when showNavigationBarForType is 'wardStaff'", () => {
+    it("does not display the logout button", () => {
+      render(<Layout showNavigationBarForType="wardStaff" />);
+
+      expect(screen.queryByTestId("logout-button")).toBeNull();
+    });
+
+    it("displays the menu button for the navbar", () => {
+      render(<Layout showNavigationBarForType="wardStaff" />);
+
+      expect(screen.getByTestId("navbar-menu-button")).toBeVisible();
+    });
+
+    it("displays the wards navigation bar", () => {
+      render(<Layout showNavigationBarForType="wardStaff" />);
+
+      expect(screen.getByTestId("wards-navbar")).toBeVisible();
+    });
+  });
+});

--- a/src/components/LogoutButton/index.js
+++ b/src/components/LogoutButton/index.js
@@ -19,6 +19,7 @@ const LogoutButton = ({
   if (renderLogout) {
     return (
       <button
+        data-testid="logout-button"
         type={type}
         className={classnames("nhsuk-button nhsuk-button--reverse", className)}
         onClick={logout}

--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -1,0 +1,55 @@
+import React from "react";
+import Link from "next/link";
+
+const NavigationBar = ({ links, testId }) => (
+  <nav
+    className="nhsuk-header__navigation"
+    id="header-navigation"
+    role="navigation"
+    aria-label="Primary navigation"
+    aria-labelledby="label-navigation"
+    data-testid={testId}
+  >
+    <div className="nhsuk-width-container">
+      <p className="nhsuk-header__navigation-title">
+        <span id="label-navigation">Menu</span>
+        <button className="nhsuk-header__navigation-close" id="close-menu">
+          <svg
+            className="nhsuk-icon nhsuk-icon__close"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+          </svg>
+          <span className="nhsuk-u-visually-hidden">Close menu</span>
+        </button>
+      </p>
+      <ul className="nhsuk-header__navigation-list">
+        {links.map((link) => (
+          <li className="nhsuk-header__navigation-item" key={link.text}>
+            <Link href={link.href}>
+              <a
+                className="nhsuk-header__navigation-link"
+                onClick={link?.onClick}
+              >
+                {link.text}
+                <svg
+                  className="nhsuk-icon nhsuk-icon__chevron-right"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                </svg>
+              </a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </nav>
+);
+
+export default NavigationBar;

--- a/src/components/WardsNavigationBar/index.js
+++ b/src/components/WardsNavigationBar/index.js
@@ -1,0 +1,32 @@
+import React from "react";
+import NavigationBar from "../NavigationBar";
+
+const logout = async () => {
+  await fetch("/api/session", {
+    method: "DELETE",
+  });
+
+  window.location.href = "/wards/login";
+};
+
+const WardsNavigationBar = () => {
+  const links = [
+    {
+      text: "Virtual visits",
+      href: "/wards/visits",
+    },
+    {
+      text: "Book a virtual visit",
+      href: "/wards/book-a-visit-start",
+    },
+    {
+      text: "Log out",
+      href: "#",
+      onClick: logout,
+    },
+  ];
+
+  return <NavigationBar links={links} testId="wards-navbar" />;
+};
+
+export default WardsNavigationBar;

--- a/testSetup.js
+++ b/testSetup.js
@@ -2,3 +2,8 @@ import "@testing-library/jest-dom";
 import dotenvLoad from "dotenv-load";
 
 dotenvLoad();
+
+jest.mock(
+  "./node_modules/nhsuk-frontend/packages/components/header/menuToggle",
+  () => jest.fn()
+);


### PR DESCRIPTION
# What

Add a navigation bar for wards and move booking a visit into a separate page with a new "Before booking a virtual visit" page.

# Why

To separate the flow of booking a visit and starting/viewing a visit. 

# Screenshots

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/83397371-6e3c9300-a3f5-11ea-8603-78d797db821d.png)|![image](https://user-images.githubusercontent.com/42817036/83397415-7eed0900-a3f5-11ea-9a16-1b47d84effcd.png)|

## "Before booking a virtual visit" page

![image](https://user-images.githubusercontent.com/42817036/83397462-91ffd900-a3f5-11ea-8ac0-36326b4ca0b8.png)

# Notes

- Best reviewed commit by commit.