### PR TITLE
Add hospitals page for a trust admin

### DIFF
--- a/pageTests/trust-admin/hospitals/index.test.js
+++ b/pageTests/trust-admin/hospitals/index.test.js
@@ -1,0 +1,118 @@
+import { getServerSideProps } from "../../../pages/trust-admin/hospitals/index";
+
+describe("trust-admin/hospitals", () => {
+  const trustId = 1;
+
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  const authenticatedReq = {
+    headers: {
+      cookie: "token=123",
+    },
+  };
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId: trustId })),
+  };
+
+  let retrieveTrustByIdSpy = jest.fn(async () => ({
+    trust: { name: "Doggo Trust" },
+    error: null,
+  }));
+
+  let getRetrieveHospitalsByTrustIdSpy = jest.fn(async () => ({
+    hospitals: [
+      { id: 1, name: "1" },
+      { id: 2, name: "2" },
+    ],
+    error: null,
+  }));
+
+  let res, container;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+    container = {
+      getRetrieveTrustById: () => retrieveTrustByIdSpy,
+      getRetrieveHospitalsByTrustId: () => getRetrieveHospitalsByTrustIdSpy,
+      getTokenProvider: () => tokenProvider,
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+
+    it("retrieves hospitals", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.hospitals.length).toEqual(2);
+      expect(props.hospitals[0].id).toEqual(1);
+      expect(props.hospitals[1].name).toEqual("2");
+    });
+
+    it("sets an error in props if hospital error", async () => {
+      getRetrieveHospitalsByTrustIdSpy = jest.fn(async () => ({
+        hospitals: null,
+        error: "Error!",
+      }));
+      container = {
+        ...container,
+        getRetrieveHospitalsByTrustId: () => getRetrieveHospitalsByTrustIdSpy,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.hospitalError).toEqual("Error!");
+    });
+
+    it("retrieves the trust of the trustAdmin", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveTrustByIdSpy).toHaveBeenCalledWith(trustId);
+      expect(props.trust).toEqual({ name: "Doggo Trust" });
+    });
+
+    it("sets an error in props if trust error", async () => {
+      retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: null,
+        error: "Error!",
+      }));
+      container = {
+        ...container,
+        getRetrieveHospitalsByTrustId: () => getRetrieveHospitalsByTrustIdSpy,
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(props.trustError).toEqual("Error!");
+    });
+  });
+});

--- a/pages/trust-admin/hospitals/index.js
+++ b/pages/trust-admin/hospitals/index.js
@@ -1,0 +1,62 @@
+import React from "react";
+import Error from "next/error";
+import Layout from "../../../src/components/Layout";
+import propsWithContainer from "../../../src/middleware/propsWithContainer";
+import verifyTrustAdminToken from "../../../src/usecases/verifyTrustAdminToken";
+import HospitalsTable from "../../../src/components/HospitalsTable";
+import { GridRow, GridColumn } from "../../../src/components/Grid";
+import Heading from "../../../src/components/Heading";
+import ActionLink from "../../../src/components/ActionLink";
+import Text from "../../../src/components/Text";
+
+const TrustAdmin = ({ hospitals, hospitalError, trust, trustError }) => {
+  if (hospitalError || trustError) {
+    return <Error err={hospitalError || trustError} />;
+  }
+
+  return (
+    <Layout title={`Hospitals for ${trust.name}`} renderLogout={true}>
+      <GridRow>
+        <GridColumn width="full">
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            Hospitals
+          </Heading>
+          <ActionLink href={`/trust-admin/add-a-hospital`}>
+            Add a hospital
+          </ActionLink>
+          {hospitals.length > 0 ? (
+            <HospitalsTable hospitals={hospitals} />
+          ) : (
+            <Text>There are no hospitals.</Text>
+          )}
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyTrustAdminToken(async ({ container, authenticationToken }) => {
+    const hospitalsResponse = await container.getRetrieveHospitalsByTrustId()(
+      authenticationToken.trustId
+    );
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
+
+    return {
+      props: {
+        hospitals: hospitalsResponse.hospitals,
+        hospitalError: hospitalsResponse.error,
+        trust: { name: trustResponse.trust?.name },
+        trustError: trustResponse.error,
+      },
+    };
+  })
+);
+
+export default TrustAdmin;

--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -1,0 +1,32 @@
+import React from "react";
+import AnchorLink from "../AnchorLink";
+
+const HospitalsTable = ({ hospitals }) => (
+  <div className="nhsuk-table-responsive">
+    <table className="nhsuk-table">
+      <caption className="nhsuk-table__caption">List of hospitals</caption>
+      <thead className="nhsuk-table__head">
+        <tr className="nhsuk-table__row">
+          <th className="nhsuk-table__header" scope="col">
+            Name
+          </th>
+          <th className="nhsuk-table__header" scope="col"></th>
+        </tr>
+      </thead>
+      <tbody className="nhsuk-table__body">
+        {hospitals.map((hospital) => (
+          <tr key={hospital.name} className="nhsuk-table__row">
+            <td className="nhsuk-table__cell">{hospital.name}</td>
+            <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
+              <AnchorLink href={`/trust-admin/hospitals/${hospital.id}`}>
+                View
+              </AnchorLink>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default HospitalsTable;


### PR DESCRIPTION
# What

Add a separate page for hospitals for a trust admin.

# Why

So we can have a single place where a trust admin can manage hospitals.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/83423005-46175900-a422-11ea-93c4-ccbe8cc96e17.png)

# Notes

Next step is to show the booked visits in the table.