### PR TITLE
Return empty props, even when redirecting

### DIFF
--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -203,11 +203,7 @@ const AddATrust = () => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyAdminToken(async () => {
-    return {
-      props: {},
-    };
-  })
+  verifyAdminToken(() => ({ props: {} }))
 );
 
 export default AddATrust;

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,6 +9,8 @@ export function getServerSideProps({ res }) {
     Location: "/wards/login",
   });
   res.end();
+
+  return { props: {} };
 }
 
 export default LoginRedirect;

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -104,6 +104,8 @@ export const getServerSideProps = propsWithContainer(
         Location: "/error",
       });
       res.end();
+
+      return { props: {} };
     }
   }
 );


### PR DESCRIPTION
# What
Explicitly return an empty set of props, even if we're redirecting

# Why
Because of this sentry error https://sentry.io/organizations/made-tech-vv/issues/1650631098/events/a15956940c8542a397dcc7c97c4ecd7e/?project=5224365

# Screenshots

# Notes
