### PR TITLE
Fix adding a ward showing an error when default hospital option

### DIFF
--- a/pageTests/trust-admin/add-a-ward.test.js
+++ b/pageTests/trust-admin/add-a-ward.test.js
@@ -1,4 +1,7 @@
+import React from "react";
 import { getServerSideProps } from "../../pages/trust-admin/add-a-ward";
+import AddAWard from "../../pages/trust-admin/add-a-ward";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 describe("/trust-admin/add-a-ward", () => {
   const anonymousReq = {
@@ -22,6 +25,24 @@ describe("/trust-admin/add-a-ward", () => {
       expect(res.writeHead).toHaveBeenCalledWith(302, {
         Location: "/wards/login",
       });
+    });
+  });
+
+  describe("AddAWard", () => {
+    it("does not throw a hospital error when default select hospital option", () => {
+      render(
+        <AddAWard
+          hospitals={[
+            { id: "1", name: "Adora Hospital" },
+            { id: "2", name: "Catra Hospital" },
+          ]}
+          hospitalId={1}
+        />
+      );
+
+      fireEvent.click(screen.getByText("Add ward"));
+
+      expect(screen.queryAllByText(/Select a hospital/)).toEqual([]);
     });
   });
 });

--- a/src/components/AddWardForm/index.js
+++ b/src/components/AddWardForm/index.js
@@ -15,7 +15,7 @@ const isPresent = (input) => {
 };
 
 const AddWardForm = ({ errors, setErrors, hospitals, defaultHospitalId }) => {
-  const [hospitalId, setHospitalId] = useState("");
+  const [hospitalId, setHospitalId] = useState(defaultHospitalId);
   const [wardName, setWardName] = useState("");
   const [wardCode, setWardCode] = useState("");
   const [wardCodeConfirmation, setWardCodeConfirmation] = useState("");


### PR DESCRIPTION
# What

Fix the add a ward form from showing the `Select a hospital` error when there's a default hospital option passed through.

# Why

This would be confusing for a user seeing an error to select a hospital when a hospital **_is_** selected.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/42817036/83539921-90b2d700-a4ef-11ea-8d7b-9be211ea0e01.png)

# Notes

Would like feedback on the test added, does it make sense?