### PR TITLE
Rename 'Virtual visits' to 'Home' in wards navigation bar

### DIFF
--- a/src/components/WardsNavigationBar/index.js
+++ b/src/components/WardsNavigationBar/index.js
@@ -12,7 +12,7 @@ const logout = async () => {
 const WardsNavigationBar = () => {
   const links = [
     {
-      text: "Virtual visits",
+      text: "Home",
       href: "/wards/visits",
     },
     {


### PR DESCRIPTION
# What

Rename 'Virtual visits' to 'Home' in wards navigation bar.

# Why

We received some feedback on whether 'Virtual visits' is the correct wording.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/42817036/83622606-213cf600-a588-11ea-95d0-09e3e527782a.png)

## After

![Screenshot 2020-06-03 at 10 50 24](https://user-images.githubusercontent.com/42817036/83622569-12564380-a588-11ea-9890-f8e08362d999.png)

# Notes

N/A