### PR TITLE
Always show the accordion visits even if there are no scheduled calls

### DIFF
--- a/pages/wards/visits.js
+++ b/pages/wards/visits.js
@@ -50,11 +50,7 @@ export default function WardVisits({
               <h2 className="nhsuk-heading-l">Pre-booked virtual visits</h2>
             </>
           )}
-          {scheduledCalls.length > 0 ? (
-            <AccordionVisits visits={scheduledCalls} />
-          ) : (
-            <Text>There are no upcoming virtual visits.</Text>
-          )}
+          <AccordionVisits visits={scheduledCalls} />
         </GridColumn>
       </GridRow>
     </Layout>


### PR DESCRIPTION
# What
Always shows the accordion view for visits even if no visits are scheduled

# Why
Maintains a consistent UI before and after calls are scheduled

# Screenshots
![no_visits_after](https://user-images.githubusercontent.com/7527178/83625487-df15b380-a58b-11ea-962f-90f44292a40c.png)


# Notes
