### PR TITLE
Add number of booked visits on trust admin hospitals page

### DIFF
--- a/pageTests/trust-admin/hospitals/index.test.js
+++ b/pageTests/trust-admin/hospitals/index.test.js
@@ -19,12 +19,12 @@ describe("trust-admin/hospitals", () => {
     validate: jest.fn(() => ({ type: "trustAdmin", trustId: trustId })),
   };
 
-  let retrieveTrustByIdSpy = jest.fn(async () => ({
+  const retrieveTrustByIdSuccessStub = jest.fn(async () => ({
     trust: { name: "Doggo Trust" },
     error: null,
   }));
 
-  let getRetrieveHospitalsByTrustIdSpy = jest.fn(async () => ({
+  const retrieveHospitalsByTrustIdSuccessSpy = jest.fn(async () => ({
     hospitals: [
       { id: 1, name: "1" },
       { id: 2, name: "2" },
@@ -39,8 +39,8 @@ describe("trust-admin/hospitals", () => {
       writeHead: jest.fn().mockReturnValue({ end: () => {} }),
     };
     container = {
-      getRetrieveTrustById: () => retrieveTrustByIdSpy,
-      getRetrieveHospitalsByTrustId: () => getRetrieveHospitalsByTrustIdSpy,
+      getRetrieveTrustById: () => retrieveTrustByIdSuccessStub,
+      getRetrieveHospitalsByTrustId: () => retrieveHospitalsByTrustIdSuccessSpy,
       getTokenProvider: () => tokenProvider,
     };
   });
@@ -67,13 +67,14 @@ describe("trust-admin/hospitals", () => {
     });
 
     it("sets an error in props if hospital error", async () => {
-      getRetrieveHospitalsByTrustIdSpy = jest.fn(async () => ({
+      const retrieveHospitalsByTrustIdErrorStub = jest.fn(async () => ({
         hospitals: null,
         error: "Error!",
       }));
       container = {
         ...container,
-        getRetrieveHospitalsByTrustId: () => getRetrieveHospitalsByTrustIdSpy,
+        getRetrieveHospitalsByTrustId: () =>
+          retrieveHospitalsByTrustIdErrorStub,
       };
 
       const { props } = await getServerSideProps({
@@ -92,18 +93,18 @@ describe("trust-admin/hospitals", () => {
         container,
       });
 
-      expect(retrieveTrustByIdSpy).toHaveBeenCalledWith(trustId);
+      expect(retrieveTrustByIdSuccessStub).toHaveBeenCalledWith(trustId);
       expect(props.trust).toEqual({ name: "Doggo Trust" });
     });
 
     it("sets an error in props if trust error", async () => {
-      retrieveTrustByIdSpy = jest.fn(async () => ({
+      const retrieveTrustByIdErrorStub = jest.fn(async () => ({
         trust: null,
         error: "Error!",
       }));
       container = {
         ...container,
-        getRetrieveHospitalsByTrustId: () => getRetrieveHospitalsByTrustIdSpy,
+        getRetrieveTrustById: () => retrieveTrustByIdErrorStub,
       };
 
       const { props } = await getServerSideProps({

--- a/pageTests/trust-admin/hospitals/index.test.js
+++ b/pageTests/trust-admin/hospitals/index.test.js
@@ -32,6 +32,11 @@ describe("trust-admin/hospitals", () => {
     error: null,
   }));
 
+  const retrieveHospitalVisitTotalsStub = jest.fn(async () => ({
+    "1": 5,
+    "2": 10,
+  }));
+
   let res, container;
 
   beforeEach(() => {
@@ -41,6 +46,7 @@ describe("trust-admin/hospitals", () => {
     container = {
       getRetrieveTrustById: () => retrieveTrustByIdSuccessStub,
       getRetrieveHospitalsByTrustId: () => retrieveHospitalsByTrustIdSuccessSpy,
+      getRetrieveHospitalVisitTotals: () => retrieveHospitalVisitTotalsStub,
       getTokenProvider: () => tokenProvider,
     };
   });
@@ -114,6 +120,20 @@ describe("trust-admin/hospitals", () => {
       });
 
       expect(props.trustError).toEqual("Error!");
+    });
+
+    it("retrieves the number of booked visits for the trust's hospitals", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveHospitalVisitTotalsStub).toHaveBeenCalledWith(trustId);
+      expect(props.hospitals).toEqual([
+        { id: 1, name: "1", bookedVisits: 5 },
+        { id: 2, name: "2", bookedVisits: 10 },
+      ]);
     });
   });
 });

--- a/pages/trust-admin/hospitals/index.js
+++ b/pages/trust-admin/hospitals/index.js
@@ -47,10 +47,20 @@ export const getServerSideProps = propsWithContainer(
     const trustResponse = await container.getRetrieveTrustById()(
       authenticationToken.trustId
     );
+    const hospitalVisitTotalsResponse = await container.getRetrieveHospitalVisitTotals()(
+      authenticationToken.trustId
+    );
+
+    const hospitalsWithVisitTotals = hospitalsResponse.hospitals?.map(
+      (hospital) => {
+        hospital.bookedVisits = hospitalVisitTotalsResponse[hospital.id] || 0;
+        return hospital;
+      }
+    );
 
     return {
       props: {
-        hospitals: hospitalsResponse.hospitals,
+        hospitals: hospitalsWithVisitTotals,
         hospitalError: hospitalsResponse.error,
         trust: { name: trustResponse.trust?.name },
         trustError: trustResponse.error,

--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -10,6 +10,9 @@ const HospitalsTable = ({ hospitals }) => (
           <th className="nhsuk-table__header" scope="col">
             Name
           </th>
+          <th className="nhsuk-table__header" scope="col">
+            Booked visits
+          </th>
           <th className="nhsuk-table__header" scope="col"></th>
         </tr>
       </thead>
@@ -17,6 +20,7 @@ const HospitalsTable = ({ hospitals }) => (
         {hospitals.map((hospital) => (
           <tr key={hospital.name} className="nhsuk-table__row">
             <td className="nhsuk-table__cell">{hospital.name}</td>
+            <td className="nhsuk-table__cell">{hospital.bookedVisits}</td>
             <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
               <AnchorLink href={`/trust-admin/hospitals/${hospital.id}`}>
                 View


### PR DESCRIPTION
# What

Add the number of booked visits for each hospital in the "Hospitals" page for a trust admin.

# Why

So they can compare usage between each of their hospitals.

# Screenshots

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/83633904-8fd67f80-a599-11ea-99e4-d928f14ccab8.png)|![image](https://user-images.githubusercontent.com/42817036/83633870-851bea80-a599-11ea-8f31-bc60a0fb2f67.png)|

# Notes

Next step is to show the number of wards in this table.