### PR TITLE
Improve the Trust admin view hospital page

### DIFF
--- a/pageTests/trust-admin/hospitals/[id].test.js
+++ b/pageTests/trust-admin/hospitals/[id].test.js
@@ -51,6 +51,7 @@ describe("trust-admin/hospitals/[id]", () => {
       const visitTotalsSpy = jest.fn().mockReturnValue({ 1: 10, 2: 3 });
 
       const hospitalWardTotalsSpy = jest.fn().mockReturnValue({
+        wards: { 1: 10, 2: 5 },
         mostVisited: { wardName: "Most Visited", total_visits: 10 },
         leastVisited: { wardName: "Least Visited", total_visits: 5 },
       });
@@ -84,6 +85,7 @@ describe("trust-admin/hospitals/[id]", () => {
         wardName: "Least Visited",
         total_visits: 5,
       });
+      expect(props.wardVisitTotals).toEqual({ 1: 10, 2: 5 });
     });
   });
 });

--- a/pageTests/trust-admin/hospitals/[id].test.js
+++ b/pageTests/trust-admin/hospitals/[id].test.js
@@ -44,16 +44,22 @@ describe("trust-admin/hospitals/[id]", () => {
       }));
 
       const hospitalSpy = jest.fn(async () => ({
-        hospital: { name: "Test Hospital" },
+        hospital: { id: hospitalId, name: "Test Hospital" },
         error: null,
       }));
 
       const visitTotalsSpy = jest.fn().mockReturnValue({ 1: 10, 2: 3 });
 
+      const hospitalWardTotalsSpy = jest.fn().mockReturnValue({
+        mostVisited: { wardName: "Most Visited", total_visits: 10 },
+        leastVisited: { wardName: "Least Visited", total_visits: 5 },
+      });
+
       const container = {
         getRetrieveWardsByHospitalId: () => wardsSpy,
         getRetrieveHospitalById: () => hospitalSpy,
         getRetrieveHospitalVisitTotals: () => visitTotalsSpy,
+        getRetrieveHospitalWardVisitTotals: () => hospitalWardTotalsSpy,
         getTokenProvider: () => tokenProvider,
       };
 
@@ -66,8 +72,18 @@ describe("trust-admin/hospitals/[id]", () => {
 
       expect(hospitalSpy).toHaveBeenCalledWith(hospitalId, trustId);
       expect(visitTotalsSpy).toHaveBeenCalledWith(trustId);
+      expect(hospitalWardTotalsSpy).toHaveBeenCalledWith(hospitalId);
+
       expect(props.wards).toEqual([{ id: 1 }, { id: 2 }]);
-      expect(props.hospital).toEqual({ name: "Test Hospital" });
+      expect(props.hospital).toEqual({ id: hospitalId, name: "Test Hospital" });
+      expect(props.mostVisitedWard).toEqual({
+        wardName: "Most Visited",
+        total_visits: 10,
+      });
+      expect(props.leastVisitedWard).toEqual({
+        wardName: "Least Visited",
+        total_visits: 5,
+      });
     });
   });
 });

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -34,13 +34,22 @@ const TrustAdmin = ({
             Ward administration
           </Heading>
           <GridRow className="nhsuk-u-padding-bottom-3">
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-third"
+              width="one-third"
+            >
               <NumberTile number={visitsScheduled} label="booked visits" />
             </GridColumn>
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-third"
+              width="one-third"
+            >
               <NumberTile number={hospitals.length} label="hospitals" />
             </GridColumn>
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-third">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-third"
+              width="one-third"
+            >
               <NumberTile number={wards.length} label="wards" />
             </GridColumn>
           </GridRow>

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -51,7 +51,7 @@ const ShowHospital = ({
             >
               <Panel
                 title="Most booked visits"
-                body={`${mostVisitedWard.wardName} (${mostVisitedWard.total_visits})`}
+                body={`${mostVisitedWard.wardName} (${mostVisitedWard.totalVisits})`}
               />
             </GridColumn>
             <GridColumn
@@ -60,7 +60,7 @@ const ShowHospital = ({
             >
               <Panel
                 title="Least booked visits"
-                body={`${leastVisitedWard.wardName} (${leastVisitedWard.total_visits})`}
+                body={`${leastVisitedWard.wardName} (${leastVisitedWard.totalVisits})`}
               />
             </GridColumn>
           </GridRow>

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -9,6 +9,7 @@ import { GridRow, GridColumn } from "../../../src/components/Grid";
 import Layout from "../../../src/components/Layout";
 import WardsTable from "../../../src/components/WardsTable";
 import NumberTile from "../../../src/components/NumberTile";
+import Panel from "../../../src/components/Panel";
 
 const ShowHospital = ({
   hospital,
@@ -38,15 +39,15 @@ const ShowHospital = ({
 
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
-              <NumberTile
-                label={`${mostVisitedWard.wardName} (${mostVisitedWard.total_visits})`}
-                number="Most booked visits"
+              <Panel
+                title="Most booked visits"
+                body={`${mostVisitedWard.wardName} (${mostVisitedWard.total_visits})`}
               />
             </GridColumn>
             <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
-              <NumberTile
-                label={`${leastVisitedWard.wardName} (${leastVisitedWard.total_visits})`}
-                number="Least booked visits"
+              <Panel
+                title="Least booked visits"
+                body={`${leastVisitedWard.wardName} (${leastVisitedWard.total_visits})`}
               />
             </GridColumn>
           </GridRow>

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -18,6 +18,7 @@ const ShowHospital = ({
   totalBookedVisits,
   mostVisitedWard,
   leastVisitedWard,
+  wardVisitTotals,
 }) => {
   if (error) {
     return <Error err={error} />;
@@ -63,7 +64,7 @@ const ShowHospital = ({
               />
             </GridColumn>
           </GridRow>
-          <WardsTable wards={wards} />
+          <WardsTable wards={wards} wardVisitTotals={wardVisitTotals} />
           <Button
             className="nhsuk-button"
             onClick={() => {
@@ -103,6 +104,7 @@ export const getServerSideProps = propsWithContainer(
     const totalBookedVisits = visitTotals[hospital.id] || 0;
 
     const {
+      wards: wardVisitTotals,
       mostVisited: mostVisitedWard,
       leastVisited: leastVisitedWard,
     } = await container.getRetrieveHospitalWardVisitTotals()(hospital.id);
@@ -115,6 +117,7 @@ export const getServerSideProps = propsWithContainer(
         totalBookedVisits,
         mostVisitedWard,
         leastVisitedWard,
+        wardVisitTotals,
       },
     };
   })

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -29,22 +29,34 @@ const ShowHospital = ({
         <GridColumn width="full">
           <Heading>{hospital.name}</Heading>
           <GridRow className="nhsuk-u-padding-bottom-3">
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-half"
+            >
               <NumberTile number={totalBookedVisits} label="booked visits" />
             </GridColumn>
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-half"
+            >
               <NumberTile number={wards.length} label="wards" />
             </GridColumn>
           </GridRow>
 
           <GridRow className="nhsuk-u-padding-bottom-3">
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-half"
+            >
               <Panel
                 title="Most booked visits"
                 body={`${mostVisitedWard.wardName} (${mostVisitedWard.total_visits})`}
               />
             </GridColumn>
-            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-half"
+            >
               <Panel
                 title="Least booked visits"
                 body={`${leastVisitedWard.wardName} (${leastVisitedWard.total_visits})`}

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -10,7 +10,14 @@ import Layout from "../../../src/components/Layout";
 import WardsTable from "../../../src/components/WardsTable";
 import NumberTile from "../../../src/components/NumberTile";
 
-const ShowHospital = ({ hospital, wards, error, totalBookedVisits }) => {
+const ShowHospital = ({
+  hospital,
+  wards,
+  error,
+  totalBookedVisits,
+  mostVisitedWard,
+  leastVisitedWard,
+}) => {
   if (error) {
     return <Error err={error} />;
   }
@@ -26,6 +33,21 @@ const ShowHospital = ({ hospital, wards, error, totalBookedVisits }) => {
             </GridColumn>
             <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
               <NumberTile number={wards.length} label="wards" />
+            </GridColumn>
+          </GridRow>
+
+          <GridRow className="nhsuk-u-padding-bottom-3">
+            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
+              <NumberTile
+                label={`${mostVisitedWard.wardName} (${mostVisitedWard.total_visits})`}
+                number="Most booked visits"
+              />
+            </GridColumn>
+            <GridColumn className="nhsuk-u-padding-bottom-3" width="one-half">
+              <NumberTile
+                label={`${leastVisitedWard.wardName} (${leastVisitedWard.total_visits})`}
+                number="Least booked visits"
+              />
             </GridColumn>
           </GridRow>
           <WardsTable wards={wards} />
@@ -67,12 +89,19 @@ export const getServerSideProps = propsWithContainer(
 
     const totalBookedVisits = visitTotals[hospital.id] || 0;
 
+    const {
+      mostVisited: mostVisitedWard,
+      leastVisited: leastVisitedWard,
+    } = await container.getRetrieveHospitalWardVisitTotals()(hospital.id);
+
     return {
       props: {
         hospital,
         wards,
         error: hospitalError || wardsError,
         totalBookedVisits,
+        mostVisitedWard,
+        leastVisitedWard,
       },
     };
   })

--- a/src/components/Panel/index.js
+++ b/src/components/Panel/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+import Text from "../Text";
+
+const Panel = ({ title, body }) => {
+  return (
+    <>
+      <div className="nhsuk-panel nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0">
+        <h3>{title}</h3>
+        <Text>{body}</Text>
+      </div>
+    </>
+  );
+};
+
+export default Panel;

--- a/src/components/WardsTable/index.js
+++ b/src/components/WardsTable/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import AnchorLink from "../AnchorLink";
 
-const WardsTable = ({ wards }) => (
+const WardsTable = ({ wards, wardVisitTotals }) => (
   <div className="nhsuk-table-responsive">
     <table className="nhsuk-table">
       <caption className="nhsuk-table__caption">List of wards</caption>
@@ -16,6 +16,11 @@ const WardsTable = ({ wards }) => (
           <th className="nhsuk-table__header" scope="col">
             Ward code
           </th>
+          {wardVisitTotals && (
+            <th className="nhsuk-table__header" scope="col">
+              Booked visits
+            </th>
+          )}
           <th className="nhsuk-table__header" scope="col"></th>
           <th className="nhsuk-table__header" scope="col"></th>
         </tr>
@@ -26,6 +31,9 @@ const WardsTable = ({ wards }) => (
             <td className="nhsuk-table__cell">{ward.hospitalName}</td>
             <td className="nhsuk-table__cell">{ward.name}</td>
             <td className="nhsuk-table__cell">{ward.code}</td>
+            {wardVisitTotals && (
+              <td className="nhsuk-table__cell">{wardVisitTotals[ward.id]}</td>
+            )}
             <td className="nhsuk-table__cell">
               <AnchorLink href={`/trust-admin/edit-a-ward?wardId=${ward.id}`}>
                 Edit

--- a/src/components/WardsTable/index.js
+++ b/src/components/WardsTable/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Router from "next/router";
+import AnchorLink from "../AnchorLink";
 
 const WardsTable = ({ wards }) => (
   <div className="nhsuk-table-responsive">
@@ -27,32 +27,16 @@ const WardsTable = ({ wards }) => (
             <td className="nhsuk-table__cell">{ward.name}</td>
             <td className="nhsuk-table__cell">{ward.code}</td>
             <td className="nhsuk-table__cell">
-              <button
-                className="nhsuk-button"
-                onClick={() => {
-                  const wardId = ward.id;
-                  Router.push({
-                    pathname: `/trust-admin/edit-a-ward`,
-                    query: { wardId },
-                  });
-                }}
-              >
+              <AnchorLink href={`/trust-admin/edit-a-ward?wardId=${ward.id}`}>
                 Edit
-              </button>
+              </AnchorLink>
             </td>
             <td className="nhsuk-table__cell">
-              <button
-                className="nhsuk-button nhsuk-button--secondary"
-                onClick={() => {
-                  const wardId = ward.id;
-                  Router.push({
-                    pathname: `/trust-admin/archive-a-ward-confirmation`,
-                    query: { wardId },
-                  });
-                }}
+              <AnchorLink
+                href={`/trust-admin/archive-a-ward-confirmation?wardId=${ward.id}`}
               >
                 Delete
-              </button>
+              </AnchorLink>
             </td>
           </tr>
         ))}

--- a/src/components/WardsTable/index.js
+++ b/src/components/WardsTable/index.js
@@ -7,9 +7,11 @@ const WardsTable = ({ wards, wardVisitTotals }) => (
       <caption className="nhsuk-table__caption">List of wards</caption>
       <thead className="nhsuk-table__head">
         <tr className="nhsuk-table__row">
-          <th className="nhsuk-table__header" scope="col">
-            Hospital name
-          </th>
+          {!wardVisitTotals && (
+            <th className="nhsuk-table__header" scope="col">
+              Hospital name
+            </th>
+          )}
           <th className="nhsuk-table__header" scope="col">
             Ward name
           </th>
@@ -28,7 +30,9 @@ const WardsTable = ({ wards, wardVisitTotals }) => (
       <tbody className="nhsuk-table__body">
         {wards.map((ward) => (
           <tr key={ward.callId} className="nhsuk-table__row">
-            <td className="nhsuk-table__cell">{ward.hospitalName}</td>
+            {!wardVisitTotals && (
+              <td className="nhsuk-table__cell">{ward.hospitalName}</td>
+            )}
             <td className="nhsuk-table__cell">{ward.name}</td>
             <td className="nhsuk-table__cell">{ward.code}</td>
             {wardVisitTotals && (

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -31,6 +31,7 @@ import retrieveTrusts from "../usecases/retrieveTrusts";
 import regenerateToken from "../usecases/regenerateToken";
 import retrieveWardsByHospitalId from "../usecases/retrieveWardsByHospitalId";
 import retrieveHospitalVisitTotals from "../usecases/retrieveHospitalVisitTotals";
+import retrieveHospitalWardVisitTotals from "../usecases/retrieveHospitalWardVisitTotals";
 
 class AppContainer {
   getDb = () => {
@@ -163,6 +164,10 @@ class AppContainer {
 
   getRetrieveHospitalVisitTotals = () => {
     return retrieveHospitalVisitTotals(this);
+  };
+
+  getRetrieveHospitalWardVisitTotals = () => {
+    return retrieveHospitalWardVisitTotals(this);
   };
 }
 

--- a/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
@@ -81,11 +81,11 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
 
     expect(mostVisited).toEqual({
       wardName: "Test Ward 1",
-      total_visits: 3,
+      totalVisits: 3,
     });
     expect(leastVisited).toEqual({
       wardName: "Test Ward 2",
-      total_visits: 1,
+      totalVisits: 1,
     });
   });
 
@@ -93,8 +93,8 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
     const response = await container.getRetrieveHospitalWardVisitTotals()();
     expect(response).toEqual({
       wards: {},
-      mostVisited: { wardName: "", total_visits: 0 },
-      leastVisited: { wardName: "", total_visits: 0 },
+      mostVisited: { wardName: "", totalVisits: 0 },
+      leastVisited: { wardName: "", totalVisits: 0 },
     });
   });
 
@@ -102,8 +102,8 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
     const response = await container.getRetrieveHospitalWardVisitTotals()(12);
     expect(response).toEqual({
       wards: {},
-      mostVisited: { wardName: "", total_visits: 0 },
-      leastVisited: { wardName: "", total_visits: 0 },
+      mostVisited: { wardName: "", totalVisits: 0 },
+      leastVisited: { wardName: "", totalVisits: 0 },
     });
   });
 });

--- a/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
@@ -35,6 +35,13 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
       trustId: trustId,
     });
 
+    const { wardId: ward4Id } = await container.getCreateWard()({
+      name: "Test Ward 4",
+      code: "wardCode4",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
     const date1 = new Date("2020-06-01 13:00");
     const date2 = new Date("2020-06-02 13:00");
 
@@ -68,24 +75,27 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
       date: date2.toISOString(),
     });
 
+    // 0 visits for Ward 4
+
     const {
       wards,
       mostVisited,
       leastVisited,
     } = await container.getRetrieveHospitalWardVisitTotals()(hospitalId);
 
-    expect(Object.keys(wards).length).toEqual(3);
+    expect(Object.keys(wards).length).toEqual(4);
     expect(wards[ward1Id]).toEqual(3);
     expect(wards[ward2Id]).toEqual(1);
     expect(wards[ward3Id]).toEqual(2);
+    expect(wards[ward4Id]).toEqual(0);
 
     expect(mostVisited).toEqual({
       wardName: "Test Ward 1",
       totalVisits: 3,
     });
     expect(leastVisited).toEqual({
-      wardName: "Test Ward 2",
-      totalVisits: 1,
+      wardName: "Test Ward 4",
+      totalVisits: 0,
     });
   });
 

--- a/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
@@ -92,7 +92,7 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
   it("returns an empty object if no hospitalId is provided", async () => {
     const response = await container.getRetrieveHospitalWardVisitTotals()();
     expect(response).toEqual({
-      wards: [],
+      wards: {},
       mostVisited: { wardName: "", total_visits: 0 },
       leastVisited: { wardName: "", total_visits: 0 },
     });
@@ -101,7 +101,7 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
   it("returns an empty object if the hospitalId does not exist", async () => {
     const response = await container.getRetrieveHospitalWardVisitTotals()(12);
     expect(response).toEqual({
-      wards: [],
+      wards: {},
       mostVisited: { wardName: "", total_visits: 0 },
       leastVisited: { wardName: "", total_visits: 0 },
     });

--- a/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
@@ -1,0 +1,109 @@
+import AppContainer from "../containers/AppContainer";
+
+describe("retrieveHospitalWardVisitTotals contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns the total number of visits for each hospital", async () => {
+    const { trustId } = await container.getCreateTrust()({
+      name: "Test Trust",
+      adminCode: "TEST",
+    });
+
+    const { hospitalId } = await container.getCreateHospital()({
+      name: "Test Hospital",
+      trustId: trustId,
+    });
+
+    const { wardId: ward1Id } = await container.getCreateWard()({
+      name: "Test Ward 1",
+      code: "wardCode1",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const { wardId: ward2Id } = await container.getCreateWard()({
+      name: "Test Ward 2",
+      code: "wardCode2",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const { wardId: ward3Id } = await container.getCreateWard()({
+      name: "Test Ward 3",
+      code: "wardCode3",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const date1 = new Date("2020-06-01 13:00");
+    const date2 = new Date("2020-06-02 13:00");
+
+    // 3 visits for Ward 1
+    await container.getUpdateWardVisitTotals()({
+      wardId: ward1Id,
+      date: date1.toISOString(),
+    });
+    await container.getUpdateWardVisitTotals()({
+      wardId: ward1Id,
+      date: date1.toISOString(),
+    });
+    await container.getUpdateWardVisitTotals()({
+      wardId: ward1Id,
+      date: date2.toISOString(),
+    });
+
+    //  1 visit for Ward 2
+    await container.getUpdateWardVisitTotals()({
+      wardId: ward2Id,
+      date: date1.toISOString(),
+    });
+
+    // 2 visits for Ward 3
+    await container.getUpdateWardVisitTotals()({
+      wardId: ward3Id,
+      date: date1.toISOString(),
+    });
+    await container.getUpdateWardVisitTotals()({
+      wardId: ward3Id,
+      date: date2.toISOString(),
+    });
+
+    const {
+      wards,
+      mostVisited,
+      leastVisited,
+    } = await container.getRetrieveHospitalWardVisitTotals()(hospitalId);
+
+    expect(Object.keys(wards).length).toEqual(3);
+    expect(wards[ward1Id]).toEqual(3);
+    expect(wards[ward2Id]).toEqual(1);
+    expect(wards[ward3Id]).toEqual(2);
+
+    expect(mostVisited).toEqual({
+      wardName: "Test Ward 1",
+      total_visits: 3,
+    });
+    expect(leastVisited).toEqual({
+      wardName: "Test Ward 2",
+      total_visits: 1,
+    });
+  });
+
+  it("returns an empty object if no hospitalId is provided", async () => {
+    const response = await container.getRetrieveHospitalWardVisitTotals()();
+    expect(response).toEqual({
+      wards: [],
+      mostVisited: { wardName: "", total_visits: 0 },
+      leastVisited: { wardName: "", total_visits: 0 },
+    });
+  });
+
+  it("returns an empty object if the hospitalId does not exist", async () => {
+    const response = await container.getRetrieveHospitalWardVisitTotals()(12);
+    expect(response).toEqual({
+      wards: [],
+      mostVisited: { wardName: "", total_visits: 0 },
+      leastVisited: { wardName: "", total_visits: 0 },
+    });
+  });
+});

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -5,7 +5,7 @@ export default ({ getDb }) => async (hospitalId) => {
     `SELECT
       wards.id as ward_id,
       wards.name as ward_name,
-      SUM(totals.total) AS total_visits
+      COALESCE(SUM(totals.total),0) AS total_visits
     FROM wards
     LEFT JOIN ward_visit_totals AS totals ON wards.id = totals.ward_id
     WHERE wards.hospital_id = $1
@@ -16,7 +16,7 @@ export default ({ getDb }) => async (hospitalId) => {
   let wards = {};
 
   queryResult.map(({ ward_id, total_visits }) => {
-    wards[ward_id] = parseInt(total_visits) || 0;
+    wards[ward_id] = parseInt(total_visits);
   });
 
   const sortedByTotalVisitsDescending = queryResult.sort(
@@ -30,14 +30,14 @@ export default ({ getDb }) => async (hospitalId) => {
   const mostVisited = mostVisitedWard
     ? {
         wardName: mostVisitedWard.ward_name,
-        totalVisits: parseInt(mostVisitedWard.total_visits) || 0,
+        totalVisits: parseInt(mostVisitedWard.total_visits),
       }
     : { wardName: "", totalVisits: 0 };
 
   const leastVisited = leastVisitedWard
     ? {
         wardName: leastVisitedWard.ward_name,
-        totalVisits: parseInt(leastVisitedWard.total_visits) || 0,
+        totalVisits: parseInt(leastVisitedWard.total_visits),
       }
     : { wardName: "", totalVisits: 0 };
 

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -1,0 +1,45 @@
+export default ({ getDb }) => async (hospitalId) => {
+  const db = await getDb();
+
+  const queryResult = await db.any(
+    `SELECT
+      wards.id as ward_id,
+      wards.name as ward_name,
+      SUM(totals.total) AS total_visits
+    FROM ward_visit_totals AS totals
+      JOIN wards ON wards.id = totals.ward_id
+    WHERE wards.hospital_id = $1
+    GROUP BY wards.id`,
+    [hospitalId]
+  );
+
+  let wards = [];
+
+  queryResult.map(({ ward_id, total_visits }) => {
+    wards[ward_id] = parseInt(total_visits);
+  });
+
+  const mostVisitedResult = queryResult.sort(
+    (a, b) => b.total_visits - a.total_visits
+  )[0];
+
+  const leastVisitedResult = queryResult.sort(
+    (a, b) => b.total_visits - a.total_visits
+  )[queryResult.length - 1];
+
+  const mostVisited = mostVisitedResult
+    ? {
+        wardName: mostVisitedResult.ward_name,
+        total_visits: parseInt(mostVisitedResult.total_visits),
+      }
+    : { wardName: "", total_visits: 0 };
+
+  const leastVisited = leastVisitedResult
+    ? {
+        wardName: leastVisitedResult.ward_name,
+        total_visits: parseInt(leastVisitedResult.total_visits),
+      }
+    : { wardName: "", total_visits: 0 };
+
+  return { wards, mostVisited, leastVisited };
+};

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -19,13 +19,12 @@ export default ({ getDb }) => async (hospitalId) => {
     wards[ward_id] = parseInt(total_visits);
   });
 
-  const mostVisitedResult = queryResult.sort(
+  const sortedResults = queryResult.sort(
     (a, b) => b.total_visits - a.total_visits
-  )[0];
+  );
 
-  const leastVisitedResult = queryResult.sort(
-    (a, b) => b.total_visits - a.total_visits
-  )[queryResult.length - 1];
+  const mostVisitedResult = sortedResults[0];
+  const leastVisitedResult = sortedResults[sortedResults.length - 1];
 
   const mostVisited = mostVisitedResult
     ? {

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -19,24 +19,25 @@ export default ({ getDb }) => async (hospitalId) => {
     wards[ward_id] = parseInt(total_visits);
   });
 
-  const sortedResults = queryResult.sort(
+  const sortedByTotalVisitsDescending = queryResult.sort(
     (a, b) => b.total_visits - a.total_visits
   );
 
-  const mostVisitedResult = sortedResults[0];
-  const leastVisitedResult = sortedResults[sortedResults.length - 1];
+  const mostVisitedWard = sortedByTotalVisitsDescending[0];
+  const leastVisitedWard =
+    sortedByTotalVisitsDescending[sortedByTotalVisitsDescending.length - 1];
 
-  const mostVisited = mostVisitedResult
+  const mostVisited = mostVisitedWard
     ? {
-        wardName: mostVisitedResult.ward_name,
-        totalVisits: parseInt(mostVisitedResult.total_visits),
+        wardName: mostVisitedWard.ward_name,
+        totalVisits: parseInt(mostVisitedWard.total_visits),
       }
     : { wardName: "", totalVisits: 0 };
 
-  const leastVisited = leastVisitedResult
+  const leastVisited = leastVisitedWard
     ? {
-        wardName: leastVisitedResult.ward_name,
-        totalVisits: parseInt(leastVisitedResult.total_visits),
+        wardName: leastVisitedWard.ward_name,
+        totalVisits: parseInt(leastVisitedWard.total_visits),
       }
     : { wardName: "", totalVisits: 0 };
 

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -13,7 +13,7 @@ export default ({ getDb }) => async (hospitalId) => {
     [hospitalId]
   );
 
-  let wards = [];
+  let wards = {};
 
   queryResult.map(({ ward_id, total_visits }) => {
     wards[ward_id] = parseInt(total_visits);

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -29,16 +29,16 @@ export default ({ getDb }) => async (hospitalId) => {
   const mostVisited = mostVisitedResult
     ? {
         wardName: mostVisitedResult.ward_name,
-        total_visits: parseInt(mostVisitedResult.total_visits),
+        totalVisits: parseInt(mostVisitedResult.total_visits),
       }
-    : { wardName: "", total_visits: 0 };
+    : { wardName: "", totalVisits: 0 };
 
   const leastVisited = leastVisitedResult
     ? {
         wardName: leastVisitedResult.ward_name,
-        total_visits: parseInt(leastVisitedResult.total_visits),
+        totalVisits: parseInt(leastVisitedResult.total_visits),
       }
-    : { wardName: "", total_visits: 0 };
+    : { wardName: "", totalVisits: 0 };
 
   return { wards, mostVisited, leastVisited };
 };

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -6,8 +6,8 @@ export default ({ getDb }) => async (hospitalId) => {
       wards.id as ward_id,
       wards.name as ward_name,
       SUM(totals.total) AS total_visits
-    FROM ward_visit_totals AS totals
-      JOIN wards ON wards.id = totals.ward_id
+    FROM wards
+    LEFT JOIN ward_visit_totals AS totals ON wards.id = totals.ward_id
     WHERE wards.hospital_id = $1
     GROUP BY wards.id`,
     [hospitalId]
@@ -16,7 +16,7 @@ export default ({ getDb }) => async (hospitalId) => {
   let wards = {};
 
   queryResult.map(({ ward_id, total_visits }) => {
-    wards[ward_id] = parseInt(total_visits);
+    wards[ward_id] = parseInt(total_visits) || 0;
   });
 
   const sortedByTotalVisitsDescending = queryResult.sort(
@@ -30,14 +30,14 @@ export default ({ getDb }) => async (hospitalId) => {
   const mostVisited = mostVisitedWard
     ? {
         wardName: mostVisitedWard.ward_name,
-        totalVisits: parseInt(mostVisitedWard.total_visits),
+        totalVisits: parseInt(mostVisitedWard.total_visits) || 0,
       }
     : { wardName: "", totalVisits: 0 };
 
   const leastVisited = leastVisitedWard
     ? {
         wardName: leastVisitedWard.ward_name,
-        totalVisits: parseInt(leastVisitedWard.total_visits),
+        totalVisits: parseInt(leastVisitedWard.total_visits) || 0,
       }
     : { wardName: "", totalVisits: 0 };
 


### PR DESCRIPTION
# What
Adds two new panels to the view hospital page displaying the most and least visited Wards in that Hospital. Also updates the table of wards to include number of booked visits and restyled edit / delete ward links

# Why
To give a better performance overview of a Hospital

# Screenshots
![ScreenShot 2020-06-04 at 09 57 37](https://user-images.githubusercontent.com/7527178/83736934-3d08d080-a64a-11ea-8234-319cbd3f741a.png)


# Notes
This PR also fixes the issue of the GridColumns going full width on smaller viewports for the NumberTile and Panels (which we want to maintain their width)