### PR TITLE
Add visually hidden text to hospitals table

### DIFF
--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -16,7 +16,10 @@ const HospitalsTable = ({ hospitals }) => (
           <th className="nhsuk-table__header" scope="col">
             Booked visits
           </th>
-          <th className="nhsuk-table__header" scope="col"></th>
+          <th className="nhsuk-table__header" scope="col">
+            {" "}
+            <span className="nhsuk-u-visually-hidden">Actions</span>
+          </th>
         </tr>
       </thead>
       <tbody className="nhsuk-table__body">

--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -27,7 +27,11 @@ const HospitalsTable = ({ hospitals }) => (
             <td className="nhsuk-table__cell">{hospital.bookedVisits}</td>
             <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
               <AnchorLink href={`/trust-admin/hospitals/${hospital.id}`}>
-                View
+                View{" "}
+                <span className="nhsuk-u-visually-hidden">
+                  {" "}
+                  {hospital.name}
+                </span>
               </AnchorLink>
             </td>
           </tr>


### PR DESCRIPTION
# What

Add visually hidden hospital name for 'View' links and 'Actions' column header in HospitalsTable.

# Why

For users of screen readers. When using a screen reader and navigating links out of context, the Links List will show multiple "View" links. This doesn't provide context to what will be viewed and doesn't differentiate each link.

The links will now be read as "View She-Ra Hospital", "View Test Hospital".

# Screenshots

![Screenshot 2020-06-04 at 09 36 20](https://user-images.githubusercontent.com/42817036/83735339-2ceff180-a648-11ea-9e01-6ee0e351ed82.png)

# Notes

N/A
