### PR TITLE
Update links to point to hospital page after performing Trust Admin actions

### DIFF
--- a/pages/trust-admin/add-a-hospital-success.js
+++ b/pages/trust-admin/add-a-hospital-success.js
@@ -35,7 +35,7 @@ const AddAHospitalSuccess = ({ error, name }) => {
 
           <p>
             <AnchorLink href="/trust-admin">
-              Return to ward administration
+              Return to trust dashboard
             </AnchorLink>
           </p>
         </div>

--- a/pages/trust-admin/add-a-hospital-success.js
+++ b/pages/trust-admin/add-a-hospital-success.js
@@ -7,7 +7,7 @@ import verifyTrustAdminToken from "../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../src/components/ActionLink";
 import { TRUST_ADMIN } from "../../src/helpers/userTypes";
 
-const AddAHospitalSuccess = ({ error, name }) => {
+const AddAHospitalSuccess = ({ error, name, id }) => {
   if (error) {
     return <Error />;
   }
@@ -34,8 +34,8 @@ const AddAHospitalSuccess = ({ error, name }) => {
           </ActionLink>
 
           <p>
-            <AnchorLink href="/trust-admin">
-              Return to trust dashboard
+            <AnchorLink href={`/trust-admin/hospitals/${id}`}>
+              {`Go to ${name}`}
             </AnchorLink>
           </p>
         </div>
@@ -59,6 +59,7 @@ export const getServerSideProps = propsWithContainer(
         props: {
           error: error,
           name: hospital.name,
+          id: hospital.id,
         },
       };
     }

--- a/pages/trust-admin/add-a-ward-success.js
+++ b/pages/trust-admin/add-a-ward-success.js
@@ -7,7 +7,7 @@ import verifyTrustAdminToken from "../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../src/components/ActionLink";
 import { TRUST_ADMIN } from "../../src/helpers/userTypes";
 
-const AddAWardSuccess = ({ error, name, hospitalName }) => {
+const AddAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
   if (error) {
     return <Error />;
   }
@@ -36,8 +36,8 @@ const AddAWardSuccess = ({ error, name, hospitalName }) => {
           </ActionLink>
 
           <p>
-            <AnchorLink href="/trust-admin">
-              Return to trust dashboard
+            <AnchorLink href={`/trust-admin/hospitals/${hospitalId}`}>
+              {`Return to ${hospitalName}`}
             </AnchorLink>
           </p>
         </div>
@@ -58,6 +58,7 @@ export const getServerSideProps = propsWithContainer(
         error: error,
         name: ward.name,
         hospitalName: ward.hospitalName,
+        hospitalId: ward.hospitalId,
       },
     };
   })

--- a/pages/trust-admin/add-a-ward-success.js
+++ b/pages/trust-admin/add-a-ward-success.js
@@ -37,7 +37,7 @@ const AddAWardSuccess = ({ error, name, hospitalName }) => {
 
           <p>
             <AnchorLink href="/trust-admin">
-              Return to ward administration
+              Return to trust dashboard
             </AnchorLink>
           </p>
         </div>

--- a/pages/trust-admin/archive-a-ward-confirmation.js
+++ b/pages/trust-admin/archive-a-ward-confirmation.js
@@ -74,7 +74,7 @@ const ArchiveAWardConfirmation = ({
             <p>All booked visits for this ward will be cancelled.</p>
 
             <Button>Yes, delete this ward</Button>
-            <BackLink href="/trust-admin">Back to ward administration</BackLink>
+            <BackLink href="/trust-admin">Back to trust dashboard</BackLink>
           </form>
         </GridColumn>
       </GridRow>

--- a/pages/trust-admin/archive-a-ward-confirmation.js
+++ b/pages/trust-admin/archive-a-ward-confirmation.js
@@ -17,6 +17,7 @@ const ArchiveAWardConfirmation = ({
   name,
   hospitalName,
   trustId,
+  hospitalId,
 }) => {
   const [hasError, setHasError] = useState(error);
 
@@ -45,7 +46,7 @@ const ArchiveAWardConfirmation = ({
     });
     if (response.status === 200) {
       Router.push(
-        `/trust-admin/archive-a-ward-success?name=${name}&hospitalName=${hospitalName}`
+        `/trust-admin/archive-a-ward-success?name=${name}&hospitalName=${hospitalName}&hospitalId=${hospitalId}`
       );
     } else {
       setHasError(true);
@@ -74,7 +75,9 @@ const ArchiveAWardConfirmation = ({
             <p>All booked visits for this ward will be cancelled.</p>
 
             <Button>Yes, delete this ward</Button>
-            <BackLink href="/trust-admin">Back to trust dashboard</BackLink>
+            <BackLink
+              href={`/trust-admin/hospitals/${hospitalId}`}
+            >{`Back to ${hospitalName}`}</BackLink>
           </form>
         </GridColumn>
       </GridRow>
@@ -101,6 +104,7 @@ export const getServerSideProps = propsWithContainer(
           name: ward.name,
           hospitalName: ward.hospitalName,
           trustId: authenticationToken.trustId,
+          hospitalId: ward.hospitalId,
         },
       };
     }

--- a/pages/trust-admin/archive-a-ward-success.js
+++ b/pages/trust-admin/archive-a-ward-success.js
@@ -25,7 +25,7 @@ const archiveAWardSuccess = ({ name, hospitalName }) => {
           </div>
           <p>
             <AnchorLink href="/trust-admin">
-              Return to ward administration
+              Return to trust dashboard
             </AnchorLink>
           </p>
         </div>

--- a/pages/trust-admin/archive-a-ward-success.js
+++ b/pages/trust-admin/archive-a-ward-success.js
@@ -1,11 +1,16 @@
 import React from "react";
+import Error from "next/error";
 import Layout from "../../src/components/Layout";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../src/usecases/verifyTrustAdminToken";
 import AnchorLink from "../../src/components/AnchorLink";
 import { TRUST_ADMIN } from "../../src/helpers/userTypes";
 
-const archiveAWardSuccess = ({ name, hospitalName }) => {
+const archiveAWardSuccess = ({ name, hospitalName, hospitalId, error }) => {
+  if (error) {
+    return <Error err={error} />;
+  }
+
   return (
     <Layout
       title={`${name} has been deleted`}
@@ -24,8 +29,8 @@ const archiveAWardSuccess = ({ name, hospitalName }) => {
             <div className="nhsuk-panel__body">for {hospitalName}</div>
           </div>
           <p>
-            <AnchorLink href="/trust-admin">
-              Return to trust dashboard
+            <AnchorLink href={`/trust-admin/hospitals/${hospitalId}`}>
+              {`Return to ${hospitalName}`}
             </AnchorLink>
           </p>
         </div>
@@ -37,8 +42,13 @@ const archiveAWardSuccess = ({ name, hospitalName }) => {
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ query }) => {
     console.log(query);
+
     return {
-      props: { name: query.name, hospitalName: query.hospitalName },
+      props: {
+        name: query.name,
+        hospitalName: query.hospitalName,
+        hospitalId: query.hospitalId,
+      },
     };
   })
 );

--- a/pages/trust-admin/edit-a-ward-success.js
+++ b/pages/trust-admin/edit-a-ward-success.js
@@ -7,7 +7,7 @@ import verifyTrustAdminToken from "../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../src/components/ActionLink";
 import { TRUST_ADMIN } from "../../src/helpers/userTypes";
 
-const EditAWardSuccess = ({ error, name, hospitalName }) => {
+const EditAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
   if (error) {
     return <Error />;
   }
@@ -34,8 +34,8 @@ const EditAWardSuccess = ({ error, name, hospitalName }) => {
           <ActionLink href={`/trust-admin/add-a-ward`}>Add a ward</ActionLink>
 
           <p>
-            <AnchorLink href="/trust-admin">
-              Return to trust dashboard
+            <AnchorLink href={`/trust-admin/hospitals/${hospitalId}`}>
+              {`Return to ${hospitalName}`}
             </AnchorLink>
           </p>
         </div>
@@ -57,6 +57,7 @@ export const getServerSideProps = propsWithContainer(
         error: error,
         name: ward.name,
         hospitalName: ward.hospitalName,
+        hospitalId: ward.hospitalId,
       },
     };
   })

--- a/pages/trust-admin/edit-a-ward-success.js
+++ b/pages/trust-admin/edit-a-ward-success.js
@@ -35,7 +35,7 @@ const EditAWardSuccess = ({ error, name, hospitalName }) => {
 
           <p>
             <AnchorLink href="/trust-admin">
-              Return to ward administration
+              Return to trust dashboard
             </AnchorLink>
           </p>
         </div>


### PR DESCRIPTION
# What
Updates the links that previously took you back to the Trust dashboard to now redirect to the Hospital you were making changes to

# Why
Maintains a smooth experience when adding / editing / deleting multiple wards as you don't have to keep navigating to the hospital page after each action

# Screenshots
![ScreenShot 2020-06-04 at 12 59 51](https://user-images.githubusercontent.com/7527178/83754100-50746580-a663-11ea-805b-94ebb10de9f2.png)

![ScreenShot 2020-06-04 at 12 59 08](https://user-images.githubusercontent.com/7527178/83754053-3c306880-a663-11ea-84fc-eb26d4cf7f88.png)

![ScreenShot 2020-06-04 at 13 00 33](https://user-images.githubusercontent.com/7527178/83754164-6b46da00-a663-11ea-8a8c-62c5de5fb8a0.png)

# Notes
