### PR TITLE
Update retrieveHospitalWardVisitTotals to not return archived wards

### DIFF
--- a/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.contractTest.js
@@ -42,6 +42,15 @@ describe("retrieveHospitalWardVisitTotals contract tests", () => {
       trustId: trustId,
     });
 
+    const { wardId: ward5Id } = await container.getCreateWard()({
+      name: "Test Ward 5",
+      code: "wardCode5",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    await container.getArchiveWard()(ward5Id, trustId);
+
     const date1 = new Date("2020-06-01 13:00");
     const date2 = new Date("2020-06-02 13:00");
 

--- a/src/usecases/retrieveHospitalWardVisitTotals.js
+++ b/src/usecases/retrieveHospitalWardVisitTotals.js
@@ -8,7 +8,7 @@ export default ({ getDb }) => async (hospitalId) => {
       COALESCE(SUM(totals.total),0) AS total_visits
     FROM wards
     LEFT JOIN ward_visit_totals AS totals ON wards.id = totals.ward_id
-    WHERE wards.hospital_id = $1
+    WHERE wards.hospital_id = $1 AND wards.archived_at IS NULL
     GROUP BY wards.id`,
     [hospitalId]
   );


### PR DESCRIPTION
# What
Update `retrieveHospitalWardVisitTotals` usecase to not return archived wards.

# Why

Wards that are "deleted" are shown in the most or least visited wards.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/42817036/83764455-de574d00-a671-11ea-8e2f-abe90c59f62e.png)

## After

![image](https://user-images.githubusercontent.com/42817036/83764567-fe870c00-a671-11ea-973f-03916255827f.png)

# Notes

N/A