### PR TITLE
Do not include archived wards in retrieveHospitalsByTrustId

### DIFF
--- a/src/usecases/retrieveHospitalsByTrustId.contractTest.js
+++ b/src/usecases/retrieveHospitalsByTrustId.contractTest.js
@@ -68,6 +68,15 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
       trustId: trustId,
     });
 
+    const { wardId: ward4Id } = await container.getCreateWard()({
+      name: "Archived ward",
+      code: "wardCode4",
+      hospitalId: hospital2Id,
+      trustId: trustId,
+    });
+
+    await container.getArchiveWard()(ward4Id, trustId);
+
     const {
       hospitals,
       error,

--- a/src/usecases/retrieveHospitalsByTrustId.js
+++ b/src/usecases/retrieveHospitalsByTrustId.js
@@ -19,7 +19,7 @@ const retrieveHospitalsByTrustId = ({ getDb }) => async (
       hospitals = await Promise.all(
         hospitals.map(async (hospital) => {
           const wards = await db.any(
-            `SELECT * FROM wards WHERE hospital_id = $1`,
+            `SELECT * FROM wards WHERE hospital_id = $1 AND archived_at IS NULL`,
             hospital.id
           );
 


### PR DESCRIPTION
# What
Filters out archived wards in the retrieveHospitalsByTrustId usecase

# Why
Archived wards should not be returned as they are soft deleted

# Screenshots

# Notes
