### PR TITLE
Add visually hidden ward name for 'Edit' and 'Delete' links in wards table

### DIFF
--- a/src/components/AnchorLink/index.js
+++ b/src/components/AnchorLink/index.js
@@ -1,9 +1,10 @@
 import React from "react";
 import Link from "next/link";
+import classNames from "classnames";
 
-const AnchorLink = ({ href, children }) => (
+const AnchorLink = ({ href, className, children }) => (
   <Link href={href}>
-    <a className="nhsuk-link">{children}</a>
+    <a className={classNames("nhsuk-link", className)}>{children}</a>
   </Link>
 );
 

--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -17,7 +17,6 @@ const HospitalsTable = ({ hospitals }) => (
             Booked visits
           </th>
           <th className="nhsuk-table__header" scope="col">
-            {" "}
             <span className="nhsuk-u-visually-hidden">Actions</span>
           </th>
         </tr>
@@ -30,7 +29,7 @@ const HospitalsTable = ({ hospitals }) => (
             <td className="nhsuk-table__cell">{hospital.bookedVisits}</td>
             <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
               <AnchorLink href={`/trust-admin/hospitals/${hospital.id}`}>
-                View{" "}
+                View
                 <span className="nhsuk-u-visually-hidden">
                   {" "}
                   {hospital.name}

--- a/src/components/WardsTable/index.js
+++ b/src/components/WardsTable/index.js
@@ -23,8 +23,9 @@ const WardsTable = ({ wards, wardVisitTotals }) => (
               Booked visits
             </th>
           )}
-          <th className="nhsuk-table__header" scope="col"></th>
-          <th className="nhsuk-table__header" scope="col"></th>
+          <th className="nhsuk-table__header" scope="col">
+            <span className="nhsuk-u-visually-hidden">Actions</span>
+          </th>
         </tr>
       </thead>
       <tbody className="nhsuk-table__body">
@@ -38,16 +39,19 @@ const WardsTable = ({ wards, wardVisitTotals }) => (
             {wardVisitTotals && (
               <td className="nhsuk-table__cell">{wardVisitTotals[ward.id]}</td>
             )}
-            <td className="nhsuk-table__cell">
-              <AnchorLink href={`/trust-admin/edit-a-ward?wardId=${ward.id}`}>
+            <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
+              <AnchorLink
+                href={`/trust-admin/edit-a-ward?wardId=${ward.id}`}
+                className="nhsuk-u-margin-right-4"
+              >
                 Edit
+                <span className="nhsuk-u-visually-hidden"> {ward.name}</span>
               </AnchorLink>
-            </td>
-            <td className="nhsuk-table__cell">
               <AnchorLink
                 href={`/trust-admin/archive-a-ward-confirmation?wardId=${ward.id}`}
               >
                 Delete
+                <span className="nhsuk-u-visually-hidden"> {ward.name}</span>
               </AnchorLink>
             </td>
           </tr>


### PR DESCRIPTION
# What

Add visually hidden ward name for 'Edit' and 'Delete' links in wards table. Also, move both links into an 'Actions' column and center them.

# Why

Currently using a screen reader these links using the links list functionality will show multiple "Edit" and "Delete" links with no context as to what ward they'll be editing or deleting. Adding the ward name visually hidden will read them as "Edit Test Ward One", and "Delete Test Ward Three".

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/42817036/84009303-faf1ce80-a96a-11ea-88ea-9174b05e750e.png)

## After

![image](https://user-images.githubusercontent.com/42817036/84009206-d72e8880-a96a-11ea-97fd-b45cc1ea3074.png)

# Notes

N/A