### PR TITLE
Update cancelling confirmation page to show visitor email address

### DIFF
--- a/pageTests/wards/cancel-visit-confirmation.test.js
+++ b/pageTests/wards/cancel-visit-confirmation.test.js
@@ -65,6 +65,7 @@ describe("ward/cancel-visit-confirmation", () => {
                   patient_name: "Fred Bloggs",
                   recipient_name: "John Doe",
                   recipient_number: "07700900900",
+                  recipient_email: "john@example.com",
                   call_time: new Date("2020-04-15T23:00:00.000Z"),
                   call_id: "Test-Call-Id",
                   provider: "Test",
@@ -88,6 +89,7 @@ describe("ward/cancel-visit-confirmation", () => {
         expect(props.patientName).toEqual("Fred Bloggs");
         expect(props.contactName).toEqual("John Doe");
         expect(props.contactNumber).toEqual("07700900900");
+        expect(props.contactEmail).toEqual("john@example.com");
         expect(props.callDateAndTime).toEqual("2020-04-15T23:00:00.000Z");
       });
     });

--- a/pages/wards/cancel-visit-confirmation.js
+++ b/pages/wards/cancel-visit-confirmation.js
@@ -17,6 +17,7 @@ const deleteVisitConfirmation = ({
   patientName,
   contactName,
   contactNumber,
+  contactEmail,
   callDateAndTime,
   error,
   showNavigationBar,
@@ -49,6 +50,7 @@ const deleteVisitConfirmation = ({
               patientName={patientName}
               visitorName={contactName}
               visitorMobileNumber={contactNumber}
+              visitorEmailAddress={contactEmail}
               visitDateAndTime={callDateAndTime}
             ></VisitSummaryList>
 
@@ -95,6 +97,7 @@ export const getServerSideProps = propsWithContainer(
         patientName: scheduledCall.patientName,
         contactName: scheduledCall.recipientName,
         contactNumber: scheduledCall.recipientNumber,
+        contactEmail: scheduledCall.recipientEmail,
         callDateAndTime: scheduledCall.callTime,
         callId,
         error,


### PR DESCRIPTION
# What

Update cancelling confirmation page to show visitor email address.

# Why

The cancelling confirmation page isn't showing this! This would be confusing for a ward staff to see `N/A` when it shows on the home page.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/42817036/84049118-f39ae700-a9a3-11ea-8365-3f41f0033049.png)

## After 

![image](https://user-images.githubusercontent.com/42817036/84049096-ed0c6f80-a9a3-11ea-8de6-7c78d6df9091.png)

# Notes

Was writing a Cypress test for cancelling a visit and found dis. 🕵️‍♀️ 