### PR TITLE
Check that we are on the book a visit success page before checking if the visit is booked

### DIFF
--- a/cypress/integration/wards/bookingAVisit.js
+++ b/cypress/integration/wards/bookingAVisit.js
@@ -98,6 +98,7 @@ describe("As a ward staff, I want to schedule a virtual visit so that patients c
   }
 
   function ThenISeeTheVirtualVisitIsBooked() {
+    cy.url().should("include", "book-a-visit-success");
     cy.get("h1").should("contain", "Virtual visit booked");
   }
 


### PR DESCRIPTION
# What
Adds an expectation for the correct url in the booking a visit e2e test

# Why
Ensures that cypress waits for the page to load before we check for the correct
header


# Screenshots

# Notes
