### PR TITLE
Update job names in CircleCI to be a tad more descriptive

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -57,7 +57,7 @@ workflows:
     jobs:
       - build
       - test
-  linux-build:
+  end-to-end-test:
     jobs:
       # checks out code and installs dependencies once
       - cypress/install:
@@ -75,7 +75,7 @@ workflows:
       # and records on Cypress Dashboard
       - cypress/run:
           executor: pg-cypress
-          name: "1 machine"
+          name: "End to end test"
           # job will use workspace with code and dependencies
           # installed by the "install" job
           requires:


### PR DESCRIPTION
# What

Update job names in CircleCI to be a tad more descriptive.

# Why

Seeing `1 machine` run on CI can be confusing at first sight. Someone has to dig in to find out this is running our end to end tests using Cypress.

# Screenshots

N/A

# Notes

Will have to update the branch protection rules.