### PR TITLE
Redirect to trust-admin/login if trust admin verification fails

### DIFF
--- a/pageTests/performance.test.js
+++ b/pageTests/performance.test.js
@@ -26,7 +26,7 @@ describe("/performance", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -85,7 +85,7 @@ describe("trust-admin", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin/add-a-hospital-success.test.js
+++ b/pageTests/trust-admin/add-a-hospital-success.test.js
@@ -30,7 +30,7 @@ describe("/trust-admin/add-a-hospital-success", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin/add-a-hospital.test.js
+++ b/pageTests/trust-admin/add-a-hospital.test.js
@@ -20,7 +20,7 @@ describe("/trust-admin/add-a-hospital", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
   });

--- a/pageTests/trust-admin/add-a-ward-success.test.js
+++ b/pageTests/trust-admin/add-a-ward-success.test.js
@@ -30,7 +30,7 @@ describe("/trust-admin/add-a-ward-success", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin/add-a-ward.test.js
+++ b/pageTests/trust-admin/add-a-ward.test.js
@@ -23,7 +23,7 @@ describe("/trust-admin/add-a-ward", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
   });

--- a/pageTests/trust-admin/archive-a-ward-confirmation.test.js
+++ b/pageTests/trust-admin/archive-a-ward-confirmation.test.js
@@ -20,7 +20,7 @@ describe("/trust-admin/archive-a-ward-confirmation", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
   });

--- a/pageTests/trust-admin/archive-a-ward-success.test.js
+++ b/pageTests/trust-admin/archive-a-ward-success.test.js
@@ -20,7 +20,7 @@ describe("/trust-admin/archive-a-ward-success", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
   });

--- a/pageTests/trust-admin/edit-a-ward-success.test.js
+++ b/pageTests/trust-admin/edit-a-ward-success.test.js
@@ -30,7 +30,7 @@ describe("/trust-admin/edit-a-ward-success", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin/edit-a-ward.test.js
+++ b/pageTests/trust-admin/edit-a-ward.test.js
@@ -30,7 +30,7 @@ describe("/trust-admin/edit-a-ward", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin/hospitals/[id].test.js
+++ b/pageTests/trust-admin/hospitals/[id].test.js
@@ -31,7 +31,7 @@ describe("trust-admin/hospitals/[id]", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/pageTests/trust-admin/hospitals/index.test.js
+++ b/pageTests/trust-admin/hospitals/index.test.js
@@ -60,7 +60,7 @@ describe("trust-admin/hospitals", () => {
       await getServerSideProps({ req: anonymousReq, res });
 
       expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: "/wards/login",
+        Location: "/trust-admin/login",
       });
     });
 

--- a/src/usecases/verifyTrustAdminToken.js
+++ b/src/usecases/verifyTrustAdminToken.js
@@ -11,7 +11,7 @@ export default function (callback) {
     if (authenticationToken) {
       return callback({ ...context, authenticationToken }) ?? { props: {} };
     } else {
-      res.writeHead(302, { Location: "/wards/login" }).end();
+      res.writeHead(302, { Location: "/trust-admin/login" }).end();
     }
   };
 }

--- a/src/usecases/verifyTrustAdminToken.test.js
+++ b/src/usecases/verifyTrustAdminToken.test.js
@@ -46,7 +46,7 @@ describe("verifyTrustAdminToken", () => {
 
     verifyTrustAdminToken(callback)({ req, res, container });
     expect(res.writeHead).toHaveBeenCalledWith(302, {
-      Location: "/wards/login",
+      Location: "/trust-admin/login",
     });
   });
 
@@ -62,7 +62,7 @@ describe("verifyTrustAdminToken", () => {
 
     verifyTrustAdminToken(callback)({ req, res, container });
     expect(res.writeHead).toHaveBeenCalledWith(302, {
-      Location: "/wards/login",
+      Location: "/trust-admin/login",
     });
   });
 });


### PR DESCRIPTION
# What
Redirects users to the trust-admin login page if they fail to authenticate against a trust-admin page

# Why
If someone is not authenticated but hits a trust admin page, we assume they would want to login as a trust admin and should be redirected to the correct login page

# Screenshots

# Notes
