### PR TITLE
Add pageLoadTimeout to places in Cypress tests where API is doing a lot 

### DIFF
--- a/cypress/integration/wards/bookingAVisit.js
+++ b/cypress/integration/wards/bookingAVisit.js
@@ -100,8 +100,10 @@ describe("As a ward staff, I want to schedule a virtual visit so that patients c
   }
 
   function ThenISeeTheVirtualVisitIsBooked() {
-    cy.url().should("include", "book-a-visit-success");
-    cy.get("h1").should("contain", "Virtual visit booked");
+    cy.get("h1", { timeout: cy.pageLoadTimeout }).should(
+      "contain",
+      "Virtual visit booked"
+    );
   }
 
   function WhenIClickViewVirtualVisits() {

--- a/cypress/integration/wards/startingAVisit.js
+++ b/cypress/integration/wards/startingAVisit.js
@@ -53,7 +53,7 @@ describe("As a ward staff, I want to start a virtual visit so that patients can 
   }
 
   function ThenISeeAVideoFrame() {
-    cy.get("iframe").should("be.visible");
+    cy.get("iframe", { timeout: cy.pageLoadTimeOut }).should("be.visible");
   }
 
   function AndISeeAnEndCallButton() {


### PR DESCRIPTION
# What

Add timeout and set to `cy.pageLoadTimeout` to places in Cypress tests where API is doing a lot i.e. booking a visit and starting a visit to avoid flakey tests.

# Why

These expectations need more time as the APIs for these are also sending
messages and emails or calling other APIs. Therefore, more time is
needed for these actions to complete before the next page is shown.

We tried to rectify this using `cy.url` (https://github.com/madetech/nhs-virtual-visit/pull/406) but upon looking at the docs,
this has the same timeout as `cy.get` so an optional timeout has been
added and set to the Cypress' pageLoadTimeout as if `cy.visit` was used to
view another page instead of it thinking it's on the same page.

# Screenshots

N/A

# Notes

Does this make sense? Is there a better way to deal with this?

https://docs.cypress.io/guides/references/configuration.html#Timeouts