### PR TITLE
Add password to create trust form

### DIFF
--- a/cypress/integration/admin/addingATrust.js
+++ b/cypress/integration/admin/addingATrust.js
@@ -1,0 +1,82 @@
+describe("As an admin, I want to add a trust so that a trust can use the virtual visits service.", () => {
+  before(() => {
+    // reset and seed the database
+    cy.exec(
+      "npm run dbmigratetest reset && npm run dbmigratetest up && npm run db:seed"
+    );
+  });
+
+  it("allows an admin to add a trust", () => {
+    GivenIAmLoggedInAsAnAdmin();
+    WhenIClickOnAddATrust();
+    ThenISeeTheAddATrustForm();
+
+    WhenIFillOutTheForm();
+    AndISubmitTheForm();
+    ThenISeeTheTrustIsAdded();
+
+    WhenIClickToReturnToSiteAdministration();
+    ThenISeeTheSiteAdministrationPage();
+    AndISeeTheAddedTrust();
+  });
+
+  it("displays errors when fields have been left blank", () => {
+    GivenIAmLoggedInAsAnAdmin();
+    WhenIClickOnAddATrust();
+    ThenISeeTheAddATrustForm();
+
+    WhenISubmitFormWithoutFillingAnythingOut();
+    ThenISeeErrors();
+  });
+
+  // Allows an admin to add a trust
+  function GivenIAmLoggedInAsAnAdmin() {
+    cy.visit(Cypress.env("baseUrl") + "/wards/login");
+    cy.get("input[name=code]").type(Cypress.env("validAdminCode"));
+    cy.get("button").contains("Log in").click();
+  }
+
+  function WhenIClickOnAddATrust() {
+    cy.get("a.nhsuk-action-link__link").contains("Add a trust").click();
+  }
+
+  function ThenISeeTheAddATrustForm() {
+    cy.get("h1").should("contain", "Add a trust");
+  }
+
+  function WhenIFillOutTheForm() {
+    cy.get("input[name=trust-name]").type("Bow Trust");
+    cy.get("input[name=trust-admin-code]").type("bowcode");
+    cy.get("input[name=trust-password]").type("bowpassword");
+    cy.get("input[name=trust-password-confirmation]").type("bowpassword");
+  }
+
+  function AndISubmitTheForm() {
+    cy.get("button").contains("Add trust").click();
+  }
+
+  function ThenISeeTheTrustIsAdded() {
+    cy.get("h1").should("contain", "Bow Trust has been added");
+  }
+
+  function WhenIClickToReturnToSiteAdministration() {
+    cy.get("a").contains("Return to site administration").click();
+  }
+
+  function ThenISeeTheSiteAdministrationPage() {
+    cy.get("h1").should("contain", "Site administration");
+  }
+
+  function AndISeeTheAddedTrust() {
+    cy.get("td").should("contain", "Bow Trust");
+  }
+
+  // Displays errors when fields have been left blank
+  function WhenISubmitFormWithoutFillingAnythingOut() {
+    cy.get("button").contains("Add trust").click();
+  }
+
+  function ThenISeeErrors() {
+    cy.contains("There is a problem").should("be.visible");
+  }
+});

--- a/pageTests/api/create-trust.test.js
+++ b/pageTests/api/create-trust.test.js
@@ -13,6 +13,7 @@ describe("create-trust", () => {
       body: {
         name: "Test Trust",
         adminCode: "admincode",
+        password: "password",
       },
       headers: {
         cookie: "token=valid.token.value",
@@ -195,6 +196,55 @@ describe("create-trust", () => {
     expect(response.status).toHaveBeenCalledWith(409);
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify({ err: "admin code must be present" })
+    );
+  });
+
+  it("returns a 409 if the password is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+        adminCode: "admincode",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "password must be present" })
+    );
+  });
+
+  it("returns a 409 if the password is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+        adminCode: "admincode",
+        password: "",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "password must be present" })
     );
   });
 });

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -17,7 +17,8 @@ const AddATrust = () => {
   const [errors, setErrors] = useState([]);
   const [name, setName] = useState("");
   const [adminCode, setAdminCode] = useState("");
-  const [adminCodeConfirmation, setAdminCodeConfirmation] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
 
   const hasError = (field) =>
     errors.find((error) => error.id === `${field}-error`);
@@ -52,24 +53,31 @@ const AddATrust = () => {
       });
     };
 
-    const setAdminCodeLengthError = (errors) => {
+    const setPasswordError = (errors) => {
       errors.push({
-        id: "trust-admin-code-error",
-        message: "Trust admin code must be at least 8 characters long",
+        id: "trust-password-error",
+        message: "Enter a password",
       });
     };
 
-    const setAdminCodeConfirmationMismatchError = (errors) => {
+    const setPasswordLengthError = (errors) => {
       errors.push({
-        id: "trust-admin-code-confirmation-error",
-        message: "Trust admin code confirmation does not match",
+        id: "trust-password-error",
+        message: "Password must be at least 8 characters long",
       });
     };
 
-    const setAdminCodeConfirmationError = (errors) => {
+    const setPasswordConfirmationMismatchError = (errors) => {
       errors.push({
-        id: "trust-admin-code-confirmation-error",
-        message: "Confirm the trust admin code",
+        id: "trust-password-confirmation-error",
+        message: "Password confirmation does not match",
+      });
+    };
+
+    const setPasswordConfirmationError = (errors) => {
+      errors.push({
+        id: "trust-password-confirmation-error",
+        message: "Confirm the password",
       });
     };
 
@@ -79,16 +87,20 @@ const AddATrust = () => {
 
     if (adminCode.length === 0) {
       setAdminCodeError(onSubmitErrors);
-    } else if (adminCode.length < 8) {
-      setAdminCodeLengthError(onSubmitErrors);
     }
 
-    if (adminCodeConfirmation.length !== 0) {
-      if (adminCode !== adminCodeConfirmation) {
-        setAdminCodeConfirmationMismatchError(onSubmitErrors);
+    if (password.length === 0) {
+      setPasswordError(onSubmitErrors);
+    } else if (password.length < 8) {
+      setPasswordLengthError(onSubmitErrors);
+    }
+
+    if (passwordConfirmation.length !== 0) {
+      if (password !== passwordConfirmation) {
+        setPasswordConfirmationMismatchError(onSubmitErrors);
       }
     } else {
-      setAdminCodeConfirmationError(onSubmitErrors);
+      setPasswordConfirmationError(onSubmitErrors);
     }
 
     if (onSubmitErrors.length === 0) {
@@ -101,6 +113,7 @@ const AddATrust = () => {
           body: JSON.stringify({
             name,
             adminCode,
+            password,
           }),
         });
 
@@ -176,25 +189,42 @@ const AddATrust = () => {
               />
             </FormGroup>
             <FormGroup>
-              <Label
-                htmlFor="trust-admin-code-confirmation"
-                className="nhsuk-label--l"
-              >
-                Confirm the trust admin code
+              <Label htmlFor="trust-password" className="nhsuk-label--l">
+                Create a password
               </Label>
               <Input
-                id="trust-admin-code-confirmation"
-                type="text"
-                hasError={hasError("trust-admin-code-confirmation")}
-                errorMessage={errorMessage("trust-admin-code-confirmation")}
+                id="trust-password"
+                type="password"
+                hasError={hasError("trust-password")}
+                errorMessage={errorMessage("trust-password")}
+                className="nhsuk-u-font-size-32 nhsuk-input--width-10"
+                style={{ padding: "16px!important", height: "64px" }}
+                onChange={(event) => setPassword(event.target.value)}
+                name="trust-password"
+                autoComplete="off"
+                value={password || ""}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Label
+                htmlFor="trust-password-confirmation"
+                className="nhsuk-label--l"
+              >
+                Confirm the password
+              </Label>
+              <Input
+                id="trust-password-confirmation"
+                type="password"
+                hasError={hasError("trust-password-confirmation")}
+                errorMessage={errorMessage("trust-password-confirmation")}
                 className="nhsuk-u-font-size-32 nhsuk-input--width-10"
                 style={{ padding: "16px!important", height: "64px" }}
                 onChange={(event) =>
-                  setAdminCodeConfirmation(event.target.value)
+                  setPasswordConfirmation(event.target.value)
                 }
-                name="trust-admin-code-confirmation"
+                name="trust-password-confirmation"
                 autoComplete="off"
-                value={adminCodeConfirmation || ""}
+                value={passwordConfirmation || ""}
               />
             </FormGroup>
             <Button className="nhsuk-u-margin-top-5">Add Trust</Button>

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -143,7 +143,7 @@ const AddATrust = () => {
 
   return (
     <Layout
-      title="Add a Trust"
+      title="Add a trust"
       hasErrors={errors.length != 0}
       renderLogout={true}
       showNavigationBarForType={ADMIN}
@@ -153,7 +153,7 @@ const AddATrust = () => {
         <GridColumn width="two-thirds">
           <ErrorSummary errors={errors} />
           <form onSubmit={onSubmit}>
-            <Heading>Add a Trust</Heading>
+            <Heading>Add a trust</Heading>
             <FormGroup>
               <Label htmlFor="trust-name" className="nhsuk-label--l">
                 What is the trust name?
@@ -227,7 +227,7 @@ const AddATrust = () => {
                 value={passwordConfirmation || ""}
               />
             </FormGroup>
-            <Button className="nhsuk-u-margin-top-5">Add Trust</Button>
+            <Button className="nhsuk-u-margin-top-5">Add trust</Button>
           </form>
         </GridColumn>
       </GridRow>

--- a/pages/api/create-trust.js
+++ b/pages/api/create-trust.js
@@ -28,6 +28,12 @@ export default withContainer(
       return;
     }
 
+    if (!body.password) {
+      res.status(409);
+      res.end(JSON.stringify({ err: "password must be present" }));
+      return;
+    }
+
     res.setHeader("Content-Type", "application/json");
 
     const createTrust = container.getCreateTrust();
@@ -35,6 +41,7 @@ export default withContainer(
     const { trustId, error } = await createTrust({
       name: body.name,
       adminCode: body.adminCode,
+      password: body.password,
     });
 
     if (error) {

--- a/src/usecases/createTrust.contractTest.js
+++ b/src/usecases/createTrust.contractTest.js
@@ -9,6 +9,7 @@ describe("createTrust contract tests", () => {
     const request = {
       name: "Defoe Trust",
       adminCode: "adminCode",
+      password: "trustpassword",
     };
 
     const { trustId, error } = await createTrust(container)(request);

--- a/src/usecases/createTrust.js
+++ b/src/usecases/createTrust.js
@@ -1,15 +1,15 @@
-const createTrust = ({ getDb }) => async ({ name, adminCode }) => {
+const createTrust = ({ getDb }) => async ({ name, adminCode, password }) => {
   const db = await getDb();
 
   try {
     console.log("Creating trust", name);
     const createdTrust = await db.one(
       `INSERT INTO trusts
-            (id, name, admin_code)
-            VALUES (default, $1, $2)
+            (id, name, admin_code, password)
+            VALUES (default, $1, $2, crypt($3, gen_salt('bf', 8)))
             RETURNING id
           `,
-      [name, adminCode]
+      [name, adminCode, password]
     );
 
     return {

--- a/src/usecases/createTrust.test.js
+++ b/src/usecases/createTrust.test.js
@@ -14,6 +14,7 @@ describe("createTrust", () => {
     const request = {
       name: "Defoe Trust",
       adminCode: "adminCode",
+      password: "password",
     };
 
     const { trustId, error } = await createTrust(container)(request);
@@ -22,6 +23,7 @@ describe("createTrust", () => {
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       "Defoe Trust",
       "adminCode",
+      "password",
     ]);
   });
 

--- a/src/usecases/verifyTrustAdminCode.contractTest.js
+++ b/src/usecases/verifyTrustAdminCode.contractTest.js
@@ -1,12 +1,11 @@
 import verifyTrustAdminCode from "./verifyTrustAdminCode";
 import AppContainer from "../containers/AppContainer";
-import setupTrust from "../testUtils/setupTrust";
 
 describe("verifyTrustAdminCode contract tests", () => {
   const container = AppContainer.getInstance();
 
   it("verifies if a admin code and password match an existing trust", async () => {
-    const createdTrust = await setupTrust(container)({
+    const { trustId } = await container.getCreateTrust()({
       name: "Test Trust",
       adminCode: "TESTCODE",
       password: "TESTPASSWORD",
@@ -17,12 +16,12 @@ describe("verifyTrustAdminCode contract tests", () => {
     )("TESTCODE", "TESTPASSWORD");
 
     expect(validTrustAdminCode).toEqual(true);
-    expect(trust).toEqual({ id: createdTrust.id });
+    expect(trust).toEqual({ id: trustId });
     expect(error).toBeNull;
   });
 
   it("is not valid if the password is not provided", async () => {
-    await setupTrust(container)({
+    await container.getCreateTrust()({
       name: "Test Trust",
       adminCode: "TESTCODE",
       password: "TESTPASSWORD",
@@ -38,7 +37,7 @@ describe("verifyTrustAdminCode contract tests", () => {
   });
 
   it("is not valid if the code is incorrect", async () => {
-    await setupTrust(container)({
+    await container.getCreateTrust()({
       name: "Test Trust",
       adminCode: "TESTCODE",
       password: "TESTPASSWORD",
@@ -54,7 +53,7 @@ describe("verifyTrustAdminCode contract tests", () => {
   });
 
   it("is not valid if the password is incorrect", async () => {
-    await setupTrust(container)({
+    await container.getCreateTrust()({
       name: "Test Trust",
       adminCode: "TESTCODE",
       password: "TESTPASSWORD",


### PR DESCRIPTION
# What
Updates the create trust form to include a password

# Why
So that Admins can set a password when creating a new trust

# Screenshots
![localhost_3000_admin_add-a-trust(iPad) (1)](https://user-images.githubusercontent.com/7527178/84397948-34d70500-abf7-11ea-92c3-79bd6874709c.png)

# Notes
