### PR TITLE
Add Cypress test for deleting a ward

### DIFF
--- a/cypress/integration/trust-admin/deletingAWard.js
+++ b/cypress/integration/trust-admin/deletingAWard.js
@@ -1,0 +1,80 @@
+describe("As a trust admin, I want to delete a ward so that it can no longer use the virtual visits service.", () => {
+  before(() => {
+    // reset and seed the database
+    cy.exec(
+      "npm run dbmigratetest reset && npm run dbmigratetest up && npm run db:seed"
+    );
+  });
+
+  it("allows a trust admin to delete a ward", () => {
+    GivenIAmLoggedInAsATrustAdmin();
+    WhenIClickHospitalsOnTheNavigationBar();
+    ThenISeeTheHospitalsPage();
+
+    WhenIClickOnAHospital();
+    ThenISeeThePageForTheHospital();
+
+    WhenIClickToDeleteAWard();
+    ThenISeeTheDeleteAWardConfirmationPage();
+
+    WhenIConfirmIWantToDeleteThisWard();
+    ThenISeeTheWardIsDeleted();
+
+    WhenIClickToReturnToThePageForTheHospital();
+    ThenISeeThePageForTheHospital();
+    AndIDoNotSeeTheDeletedWard();
+  });
+
+  // Allows a trust admin to delete a ward
+  function GivenIAmLoggedInAsATrustAdmin() {
+    cy.visit(Cypress.env("baseUrl") + "/trust-admin/login");
+
+    cy.get("input[name=code]").type(Cypress.env("validTrustAdminCode"));
+    cy.get("input[name=password]").type(Cypress.env("validTrustAdminPassword"));
+
+    cy.get("button").contains("Log in").click();
+  }
+
+  function WhenIClickHospitalsOnTheNavigationBar() {
+    cy.get("a.nhsuk-header__navigation-link").contains("Hospitals").click();
+  }
+
+  function ThenISeeTheHospitalsPage() {
+    cy.get("h1").should("contain", "Hospitals");
+  }
+
+  function WhenIClickOnAHospital() {
+    cy.get("a").contains("View Test Hospital").click();
+  }
+
+  function ThenISeeThePageForTheHospital() {
+    cy.get("h1").should("contain", "Test Hospital");
+  }
+
+  function WhenIClickToDeleteAWard() {
+    cy.get("a").contains("Delete Test Ward One").click();
+  }
+
+  function ThenISeeTheDeleteAWardConfirmationPage() {
+    cy.get("h1").should(
+      "contain",
+      "Are you sure you want to delete this ward?"
+    );
+  }
+
+  function WhenIConfirmIWantToDeleteThisWard() {
+    cy.get("button").contains("Yes, delete this ward").click();
+  }
+
+  function ThenISeeTheWardIsDeleted() {
+    cy.get("h1").should("contain", "Test Ward One has been deleted");
+  }
+
+  function WhenIClickToReturnToThePageForTheHospital() {
+    cy.get("a").contains("Return to Test Hospital").click();
+  }
+
+  function AndIDoNotSeeTheDeletedWard() {
+    cy.get("td").should("not.contain", "Test Ward One");
+  }
+});

--- a/cypress/integration/trust-admin/editingAWard.js
+++ b/cypress/integration/trust-admin/editingAWard.js
@@ -41,7 +41,7 @@ describe("As a trust admin, I want to edit a ward so that I can modify the detai
     ThenISeeErrors();
   });
 
-  // Allows a trust admin to add a hospital
+  // Allows a trust admin to edit a ward
   function GivenIAmLoggedInAsATrustAdmin() {
     cy.visit(Cypress.env("baseUrl") + "/trust-admin/login");
 


### PR DESCRIPTION
# What

Add Cypress test for deleting a ward as a trust admin.

# Why

To increase our test coverage around a user need of the service.

# Screenshots

N/A

# Notes

N/A