### PR TITLE
Change export definition to use old format for compatibility

### DIFF
--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -1,4 +1,4 @@
-import { COMPLETE } from "../../src/helpers/visitStatus";
+const status = require("../../src/helpers/visitStatus");
 
 async function getDb() {
   const dotenv = require("dotenv");
@@ -18,7 +18,7 @@ async function cleanupScheduledCalls() {
     `UPDATE scheduled_calls_table 
      SET patient_name = null, recipient_number = null, recipient_name = null, call_password = null, recipient_email = null, status = $1
      WHERE call_time < (now() - INTERVAL '1 DAY')`,
-    COMPLETE
+    status.COMPLETE
   );
   return scheduledCalls;
 }

--- a/src/helpers/visitStatus.js
+++ b/src/helpers/visitStatus.js
@@ -1,6 +1,13 @@
 // Defined the set of statuses that a visit can have (status column in scheduled_calls_table)
 
-export const SCHEDULED = "scheduled"; // Default - initial state
-export const ARCHIVED = "archived"; // The visit's parent ward has been archived
-export const CANCELLED = "cancelled"; // The visit has been explicitly cancelled
-export const COMPLETE = "complete"; // The visit has occurred
+const SCHEDULED = "scheduled"; // Default - initial state
+const ARCHIVED = "archived"; // The visit's parent ward has been archived
+const CANCELLED = "cancelled"; // The visit has been explicitly cancelled
+const COMPLETE = "complete"; // The visit has occurred
+
+module.exports = {
+  SCHEDULED,
+  ARCHIVED,
+  CANCELLED,
+  COMPLETE,
+};

--- a/src/helpers/visitStatus.js
+++ b/src/helpers/visitStatus.js
@@ -1,3 +1,7 @@
+/*-----------------------------------------------------------------------------------------------+
+| This file uses an older method of exporting to maintain compatibility with the cleandb script  |
++-----------------------------------------------------------------------------------------------*/
+
 // Defined the set of statuses that a visit can have (status column in scheduled_calls_table)
 
 const SCHEDULED = "scheduled"; // Default - initial state


### PR DESCRIPTION
# What
Change export definition in `visitStatus.js` to use old format
# Why
For compatibility with the `cleandb` script
# Screenshots

# Notes
