### PR TITLE
Call password fix

### DIFF
--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -16,7 +16,7 @@ async function cleanupScheduledCalls() {
   const db = await getDb();
   const scheduledCalls = await db.result(
     `UPDATE scheduled_calls_table 
-     SET patient_name = null, recipient_number = null, recipient_name = null, call_password = null, recipient_email = null, status = $1
+     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1
      WHERE call_time < (now() - INTERVAL '1 DAY')`,
     status.COMPLETE
   );


### PR DESCRIPTION
# What
Remove the removal of the call password
# Why
call_password is marked as `NOT NULL`, so removal of the password causes the `cleandb` script to fail
# Screenshots

# Notes
The call password isn't personal data so doesn't need to be removed anyway