### PR TITLE
Added contract test for cleanup script and modified db visit cleanup logic to better handle visit status

### DIFF
--- a/db/scripts/cleanup_scheduled_calls.contractTest.js
+++ b/db/scripts/cleanup_scheduled_calls.contractTest.js
@@ -1,0 +1,104 @@
+const { cleanupScheduledCalls } = require("./cleanup_scheduled_calls");
+import AppContainer from "../../src/containers/AppContainer";
+import moment from "moment";
+
+describe("test cleanup script", () => {
+  it("updates visit states and data correctly", async () => {
+    const container = AppContainer.getInstance();
+
+    const { trustId } = await container.getCreateTrust()({
+      name: "Test Trust",
+      adminCode: "TEST",
+    });
+
+    const { hospitalId } = await container.getCreateHospital()({
+      name: "Test Hospital",
+      trustId: trustId,
+    });
+
+    const { wardId } = await container.getCreateWard()({
+      name: "Test Ward 1",
+      code: "wardCode1",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    await container.getCreateVisit()({
+      patientName: "Bob Smith",
+      contactEmail: "bob.smith@madetech.com",
+      contactName: "John Smith",
+      contactNumber: "07123456789",
+      callTime: moment(),
+      callId: "1",
+      provider: "jitsi",
+      wardId: wardId,
+      callPassword: "securePassword",
+    });
+
+    await container.getCreateVisit()({
+      patientName: "Bob Smith",
+      contactEmail: "bob.smith@madetech.com",
+      contactName: "John Smith",
+      contactNumber: "07123456789",
+      callTime: moment().subtract(5, "days"),
+      callId: "2",
+      provider: "jitsi",
+      wardId: wardId,
+      callPassword: "securePassword",
+    });
+
+    await container.getCreateVisit()({
+      patientName: "Bob Smith",
+      contactEmail: "bob.smith@madetech.com",
+      contactName: "John Smith",
+      contactNumber: "07123456789",
+      callTime: moment(),
+      callId: "3",
+      provider: "jitsi",
+      wardId: wardId,
+      callPassword: "securePassword",
+    });
+
+    await container.getDeleteVisitByCallId()("3");
+
+    const { wardId: archiveWardId } = await container.getCreateWard()({
+      name: "Test Ward 2",
+      code: "wardCode2",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    await container.getCreateVisit()({
+      patientName: "Bob Smith",
+      contactEmail: "bob.smith@madetech.com",
+      contactName: "John Smith",
+      contactNumber: "07123456789",
+      callTime: moment(),
+      callId: "4",
+      provider: "jitsi",
+      wardId: archiveWardId,
+      callPassword: "securePassword",
+    });
+
+    await container.getArchiveWard()(archiveWardId, trustId);
+
+    const res = await cleanupScheduledCalls();
+    expect(res).toEqual({ archived: 1, cancelled: 1, completed: 1 });
+
+    // future visit still scheduled and can be retrieved
+    const futureVisit = await container.getRetrieveVisitByCallId()("1");
+    expect(futureVisit.error).toBeNull();
+
+    // past visit is now complete and cannot be retrieved
+    const pastVisit = await container.getRetrieveVisitByCallId()("2");
+    expect(pastVisit.scheduledCalls).toBeNull();
+
+    // cancelled visit cannot be retrieved
+    const cancelledVisit = await container.getRetrieveVisitByCallId()("3");
+    expect(cancelledVisit.scheduledCalls).toBeNull();
+
+    // archived visit cannot be retrieved
+    const archivedVisit = await container.getRetrieveVisitByCallId()("4");
+    expect(archivedVisit.scheduledCalls).toBeNull();
+  });
+});

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -5,15 +5,19 @@ async function getDb() {
   dotenv.config();
 
   const pgp = require("pg-promise")({});
-  const connectionURL =
-    process.env.NODE_ENV === "test" || process.env.APP_ENV === "test"
-      ? process.env.TEST_DATABASE_URL
-      : process.env.DATABASE_URL;
 
-  return pgp({
-    connectionString: connectionURL,
-    ssl: { rejectUnauthorized: process.env.NODE_ENV === "production" },
-  });
+  let options = {
+    connectionString:
+      process.env.NODE_ENV === "test" || process.env.APP_ENV === "test"
+        ? process.env.TEST_DATABASE_URL
+        : process.env.DATABASE_URL,
+  };
+
+  if (process.env.NODE_ENV === "production") {
+    options.ssl = { rejectUnauthorized: false };
+  }
+
+  return pgp(options);
 }
 
 async function cleanupScheduledCalls() {

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -6,12 +6,13 @@ async function getDb() {
 
   const pgp = require("pg-promise")({});
   const connectionURL =
-    process.env.NODE_ENV === "test"
+    process.env.NODE_ENV === "test" || process.env.APP_ENV === "test"
       ? process.env.TEST_DATABASE_URL
       : process.env.DATABASE_URL;
+
   return pgp({
     connectionString: connectionURL,
-    ssl: { rejectUnauthorized: false },
+    ssl: { rejectUnauthorized: process.env.NODE_ENV === "production" },
   });
 }
 
@@ -38,6 +39,8 @@ async function cleanupScheduledCalls() {
      WHERE status = $1`,
     status.CANCELLED
   );
+
+  db.$pool.end();
 
   return {
     completed: scheduledCalls.rowCount,

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -5,7 +5,10 @@ async function getDb() {
   dotenv.config();
 
   const pgp = require("pg-promise")({});
-  const connectionURL = process.env.DATABASE_URL;
+  const connectionURL =
+    process.env.NODE_ENV === "test"
+      ? process.env.TEST_DATABASE_URL
+      : process.env.DATABASE_URL;
   return pgp({
     connectionString: connectionURL,
     ssl: { rejectUnauthorized: false },
@@ -14,19 +17,44 @@ async function getDb() {
 
 async function cleanupScheduledCalls() {
   const db = await getDb();
+
   const scheduledCalls = await db.result(
     `UPDATE scheduled_calls_table 
      SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1
-     WHERE call_time < (now() - INTERVAL '1 DAY')`,
-    status.COMPLETE
+     WHERE call_time < (now() - INTERVAL '1 DAY') AND status = $2`,
+    [status.COMPLETE, status.SCHEDULED]
   );
-  return scheduledCalls;
+
+  const archivedCalls = await db.result(
+    `UPDATE scheduled_calls_table 
+     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null
+     WHERE status = $1`,
+    status.ARCHIVED
+  );
+
+  const cancelledCalls = await db.result(
+    `UPDATE scheduled_calls_table 
+     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null
+     WHERE status = $1`,
+    status.CANCELLED
+  );
+
+  return {
+    completed: scheduledCalls.rowCount,
+    archived: archivedCalls.rowCount,
+    cancelled: cancelledCalls.rowCount,
+  };
 }
 
 cleanupScheduledCalls()
   .then(function (result) {
-    console.log(`${result.rowCount} records deleted`);
+    console.log(`
+    ${result.completed} visits completed
+    ${result.archived} visits archived 
+    ${result.cancelled} visits cancelled`);
   })
   .catch((error) => {
     console.error("ERROR:", error);
   });
+
+exports.cleanupScheduledCalls = cleanupScheduledCalls;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -1,6 +1,7 @@
 import Database from "../gateways/Database";
 import GovNotify from "../gateways/GovNotify";
 import createVisit from "../usecases/createVisit";
+import deleteVisitByCallId from "../usecases/deleteVisitByCallId";
 import createWard from "../usecases/createWard";
 import sendTextMessage from "../usecases/sendTextMessage";
 import sendEmail from "../usecases/sendEmail";
@@ -42,6 +43,10 @@ class AppContainer {
 
   getCreateVisit = () => {
     return createVisit(this);
+  };
+
+  getDeleteVisitByCallId = () => {
+    return deleteVisitByCallId(this);
   };
 
   getCreateWard = () => {


### PR DESCRIPTION
# What

Modified db visit cleanup logic to better handle visit status
 - ensure all complete, archived and cancelled visits are redacted
 - only change visit status to complete when currently scheduled 

# Why

To ensure personal data is not retained in any visit record, regardless of status.

# Screenshots

N/A

# Notes

There is currently no easy way to retrieve a visit which is not in the `scheduled` status in tests. Should we implement this, either to support future functional requirements or purely for testing?