### PR TITLE
Update GovNotify gateway to return fake NotifyClient when test env

### DIFF
--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -60,7 +60,7 @@ export class NotifyClient {
     );
   };
 
-  sendSms = jest.fn((templateId, mobileNumber, { personalisation }) => {
+  sendSms = (templateId, mobileNumber, { personalisation }) => {
     const requestValidationError = this._validateRequest(
       templateId,
       personalisation
@@ -80,9 +80,9 @@ export class NotifyClient {
     return Promise.resolve({
       id: "test-sms-return-response-id",
     });
-  });
+  };
 
-  sendEmail = jest.fn((templateId, emailAddress, { personalisation }) => {
+  sendEmail = (templateId, emailAddress, { personalisation }) => {
     const requestValidationError = this._validateRequest(
       templateId,
       personalisation
@@ -102,5 +102,5 @@ export class NotifyClient {
     return Promise.resolve({
       id: "740e5834-3a29-46b4-9a6f-16142fde533a",
     });
-  });
+  };
 }

--- a/cypress/integration/visitor/attendingAVisit.js
+++ b/cypress/integration/visitor/attendingAVisit.js
@@ -1,4 +1,4 @@
-describe.skip("As a patient's key contact, I want to attend a virtual visit so that I can speak with my loved one.", () => {
+describe("As a patient's key contact, I want to attend a virtual visit so that I can speak with my loved one.", () => {
   before(() => {
     // reset and seed the database
     cy.exec(

--- a/cypress/integration/wards/bookingAVisit.js
+++ b/cypress/integration/wards/bookingAVisit.js
@@ -1,4 +1,4 @@
-describe.skip("As a ward staff, I want to schedule a virtual visit so that patients can speak with their loved ones.", () => {
+describe("As a ward staff, I want to schedule a virtual visit so that patients can speak with their loved ones.", () => {
   before(() => {
     // reset and seed the database
     cy.exec(

--- a/cypress/integration/wards/startingAVisit.js
+++ b/cypress/integration/wards/startingAVisit.js
@@ -1,4 +1,4 @@
-describe.skip("As a ward staff, I want to start a virtual visit so that patients can speak with their loved ones.", () => {
+describe("As a ward staff, I want to start a virtual visit so that patients can speak with their loved ones.", () => {
   before(() => {
     // reset and seed the database
     cy.exec(

--- a/src/gateways/GovNotify/index.js
+++ b/src/gateways/GovNotify/index.js
@@ -1,5 +1,9 @@
 import { NotifyClient } from "notifications-node-client";
 
+const {
+  NotifyClient: FakeNotifyClient,
+} = require("../../../__mocks__/notifications-node-client");
+
 export default (() => {
   let instance;
 
@@ -8,7 +12,11 @@ export default (() => {
       if (!instance) {
         const apiKey = process.env.API_KEY;
 
-        instance = new NotifyClient(apiKey);
+        if (process.env.APP_ENV === "test") {
+          instance = new FakeNotifyClient(apiKey);
+        } else {
+          instance = new NotifyClient(apiKey);
+        }
 
         delete instance.constructor;
       }

--- a/src/gateways/GovNotify/index.test.js
+++ b/src/gateways/GovNotify/index.test.js
@@ -1,4 +1,9 @@
+import { NotifyClient } from "notifications-node-client";
 import GovNotify from "./";
+
+const {
+  NotifyClient: FakeNotifyClient,
+} = require("../../../__mocks__/notifications-node-client");
 
 describe("GovNotify", () => {
   it("Produces a singleton", () => {
@@ -9,5 +14,29 @@ describe("GovNotify", () => {
     const instanceTwo = GovNotify.getInstance();
 
     expect(instanceOne).toEqual(instanceTwo);
+  });
+
+  describe("when using production environment", () => {
+    it("returns the real Notify client", async () => {
+      const instance = await GovNotify.getInstance();
+
+      expect(instance).toBeInstanceOf(NotifyClient);
+    });
+  });
+
+  describe("when using test environment", () => {
+    beforeEach(() => {
+      process.env.APP_ENV = "test";
+    });
+
+    afterEach(() => {
+      process.env.APP_ENV = "";
+    });
+
+    it("returns the fake Notify client", async () => {
+      const instance = await GovNotify.getInstance();
+
+      expect(instance).toBeInstanceOf(FakeNotifyClient);
+    });
   });
 });

--- a/src/gateways/GovNotify/index.test.js
+++ b/src/gateways/GovNotify/index.test.js
@@ -16,7 +16,7 @@ describe("GovNotify", () => {
     expect(instanceOne).toEqual(instanceTwo);
   });
 
-  describe("when using production environment", () => {
+  describe("when we are not running a test server", () => {
     it("returns the real Notify client", async () => {
       const instance = await GovNotify.getInstance();
 

--- a/src/usecases/sendEmail.test.js
+++ b/src/usecases/sendEmail.test.js
@@ -4,7 +4,7 @@ import sendEmail from "./sendEmail";
 import fillObjectWithStrings from "../testUtils/fillObjectWithStrings";
 
 describe("sendEmail", () => {
-  const { templateId, personalisationKeys } = TemplateStore.firstText;
+  const { templateId, personalisationKeys } = TemplateStore.firstEmail;
   const personalisation = fillObjectWithStrings(personalisationKeys);
 
   const emailAddress = "test@example.com";
@@ -15,6 +15,7 @@ describe("sendEmail", () => {
 
   beforeEach(() => {
     notifyClient = new NotifyClient();
+    notifyClient.sendEmail = jest.fn(notifyClient.sendEmail);
     container = {
       getNotifyClient: () => notifyClient,
     };

--- a/src/usecases/sendTextMessage.test.js
+++ b/src/usecases/sendTextMessage.test.js
@@ -15,6 +15,7 @@ describe("sendTextMessage", () => {
 
   beforeEach(() => {
     notifyClient = new NotifyClient();
+    notifyClient.sendSms = jest.fn(notifyClient.sendSms);
     container = {
       getNotifyClient: () => notifyClient,
     };


### PR DESCRIPTION
# What

Update `GovNotify` gateway to return the fake `NotifyClient` when test env and no longer skip the booking, starting and attending a visit Cypress tests. 

# Why

We added Cypress tests to cover booking, starting and attending a visit however, they were causing tests to be flakey because they call Notify and sometimes it would take longer than Cypress was willing to wait. As a result, they were skipped (https://github.com/madetech/nhs-virtual-visit/pull/421) to avoid CI from failing.

This PR means that when Cypress tests are run, we won't be calling Notify anymore and means that tests are more reliable.

# Screenshots

N/A

# Notes

- Best reviewed commit by commit.
- Doing `notifyClient.sendEmail = jest.fn(notifyClient.sendEmail);` feels a bit weird but feels like a fair compromise to allow us to use the fake Notify in the app. What do you think?