### PR TITLE
Ensure mock notify client does not break production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16678,8 +16678,7 @@
     "uuid-validate": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.3.tgz",
-      "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==",
-      "dev": true
+      "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "pg-promise": "^10.5.2",
     "query-string": "^6.12.1",
     "react": "16.13.1",
-    "react-dom": "16.13.1"
+    "react-dom": "16.13.1",
+    "uuid-validate": "0.0.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.10.1",
@@ -68,8 +69,7 @@
     "jest": "^26.0.1",
     "jest-css-modules-transform": "^4.0.0",
     "lint-staged": "^10.2.10",
-    "prettier": "^2.0.5",
-    "uuid-validate": "0.0.3"
+    "prettier": "^2.0.5"
   },
   "husky": {
     "hooks": {

--- a/src/gateways/GovNotify/index.js
+++ b/src/gateways/GovNotify/index.js
@@ -1,8 +1,6 @@
 import { NotifyClient } from "notifications-node-client";
 
-const {
-  NotifyClient: FakeNotifyClient,
-} = require("../../../__mocks__/notifications-node-client");
+import { NotifyClient as FakeNotifyClient } from "../../../__mocks__/notifications-node-client";
 
 export default (() => {
   let instance;


### PR DESCRIPTION
# What
Makes the uuid-validate package a normal dependency

# Why
The mock notify client is loaded in the gov notify gateway and used a dev dependency that broke the staging build

# Screenshots

# Notes
