### PR TITLE
Update cancel visit success to use correct book a visit link

### DIFF
--- a/pages/wards/cancel-visit-success.js
+++ b/pages/wards/cancel-visit-success.js
@@ -46,7 +46,7 @@ const deleteVisitSuccess = ({
           </div>
           <h2>What happens next</h2>
 
-          <ActionLink href={`/admin/add-a-ward`}>
+          <ActionLink href={`/wards/book-a-visit`}>
             Book a virtual visit
           </ActionLink>
 


### PR DESCRIPTION
# What

Update cancel visit success page to use the correct book a visit link.

# Why

It currently takes them to the trust admin's add a ward page which is not correct. 🤦‍♀️ 

# Screenshots

N/A

# Notes

N/A