### PR TITLE
Add video provider to trusts

### DIFF
--- a/cypress/integration/admin/addingATrust.js
+++ b/cypress/integration/admin/addingATrust.js
@@ -50,6 +50,7 @@ describe("As an admin, I want to add a trust so that a trust can use the virtual
     cy.get("input[name=trust-admin-code]").type("bowcode");
     cy.get("input[name=trust-password]").type("bowpassword");
     cy.get("input[name=trust-password-confirmation]").type("bowpassword");
+    cy.get("select").select("whereby");
   }
 
   function AndISubmitTheForm() {

--- a/cypress/integration/admin/addingATrust.js
+++ b/cypress/integration/admin/addingATrust.js
@@ -47,10 +47,10 @@ describe("As an admin, I want to add a trust so that a trust can use the virtual
 
   function WhenIFillOutTheForm() {
     cy.get("input[name=trust-name]").type("Bow Trust");
+    cy.get("select[name=video-provider]").select("whereby");
     cy.get("input[name=trust-admin-code]").type("bowcode");
     cy.get("input[name=trust-password]").type("bowpassword");
     cy.get("input[name=trust-password-confirmation]").type("bowpassword");
-    cy.get("select").select("whereby");
   }
 
   function AndISubmitTheForm() {

--- a/db/migrations/20200618160333-add-video-provider-to-trusts.js
+++ b/db/migrations/20200618160333-add-video-provider-to-trusts.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var fs = require("fs");
+var path = require("path");
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20200618160333-add-video-provider-to-trusts-up.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      console.log("received data: " + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20200618160333-add-video-provider-to-trusts-down.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      console.log("received data: " + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/sqls/20200618160333-add-video-provider-to-trusts-down.sql
+++ b/db/migrations/sqls/20200618160333-add-video-provider-to-trusts-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE trusts DROP COLUMN video_provider;

--- a/db/migrations/sqls/20200618160333-add-video-provider-to-trusts-up.sql
+++ b/db/migrations/sqls/20200618160333-add-video-provider-to-trusts-up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE trusts ADD video_provider varchar(255);
+
+UPDATE trusts SET video_provider='whereby' WHERE video_provider IS NULL;
+
+ALTER TABLE trusts ALTER COLUMN video_provider SET NOT NUll;

--- a/db/scripts/cleanup_scheduled_calls.contractTest.js
+++ b/db/scripts/cleanup_scheduled_calls.contractTest.js
@@ -1,16 +1,13 @@
 const { cleanupScheduledCalls } = require("./cleanup_scheduled_calls");
 import AppContainer from "../../src/containers/AppContainer";
 import moment from "moment";
+import { setupTrust } from "../../src/testUtils/factories";
 
 describe("test cleanup script", () => {
   it("updates visit states and data correctly", async () => {
     const container = AppContainer.getInstance();
 
-    const { trustId } = await container.getCreateTrust()({
-      name: "Test Trust",
-      adminCode: "TEST",
-      password: "password",
-    });
+    const { trustId } = await setupTrust();
 
     const { hospitalId } = await container.getCreateHospital()({
       name: "Test Hospital",

--- a/db/scripts/seed_database.js
+++ b/db/scripts/seed_database.js
@@ -15,7 +15,7 @@ async function seedDatabase() {
     "INSERT INTO admins (code, password) VALUES ('super', crypt('adminpassword', gen_salt('bf', 8)))"
   );
   await db.result(
-    "INSERT INTO trusts (name, admin_code, password) VALUES ('Test Trust', 'admin', crypt('trustpassword', gen_salt('bf', 8)))"
+    "INSERT INTO trusts (name, admin_code, password, video_provider) VALUES ('Test Trust', 'admin', crypt('trustpassword', gen_salt('bf', 8)), 'whereby')"
   );
   await db.result(
     "INSERT INTO hospitals (name, trust_id) VALUES ('Test Hospital', (SELECT id FROM trusts WHERE name='Test Trust'))"

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,5 +1,5 @@
-INSERT INTO trusts (name, admin_code, password) VALUES ('Test Trust', 'admin', crypt('trustpassword', gen_salt('bf', 8)));
-INSERT INTO trusts (name, admin_code, password) VALUES ('Test 2 Trust', 'admin2', crypt('trustpassword', gen_salt('bf', 8)));
+INSERT INTO trusts (name, admin_code, password, video_provider) VALUES ('Test Trust', 'admin', crypt('trustpassword', gen_salt('bf', 8)), 'whereby');
+INSERT INTO trusts (name, admin_code, password, video_provider) VALUES ('Test 2 Trust', 'admin2', crypt('trustpassword', gen_salt('bf', 8)), 'jitsi');
 INSERT INTO hospitals (name, trust_id) VALUES ('Test Hospital', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO hospitals (name, trust_id) VALUES ('Test Hospital 2', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO hospitals (name, trust_id) VALUES ('Test 2 Hospital', (SELECT id FROM trusts WHERE name='Test 2 Trust'));

--- a/pageTests/api/create-trust.test.js
+++ b/pageTests/api/create-trust.test.js
@@ -248,4 +248,55 @@ describe("create-trust", () => {
       JSON.stringify({ err: "password must be present" })
     );
   });
+
+  it("returns a 409 if the video provider is not provided", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+        adminCode: "admincode",
+        password: "password",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "video provider must be present" })
+    );
+  });
+
+  it("returns a 409 if the video provider is an empty string", async () => {
+    const invalidRequest = {
+      method: "POST",
+      body: {
+        name: "Test Trust",
+        adminCode: "admincode",
+        password: "password",
+        videoProvider: "",
+      },
+      headers: {
+        cookie: "token=valid.token.value",
+      },
+    };
+
+    await createTrust(invalidRequest, response, {
+      container: {
+        ...container,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ err: "video provider must be present" })
+    );
+  });
 });

--- a/pageTests/api/create-trust.test.js
+++ b/pageTests/api/create-trust.test.js
@@ -14,6 +14,7 @@ describe("create-trust", () => {
         name: "Test Trust",
         adminCode: "admincode",
         password: "password",
+        videoProvider: "whereby",
       },
       headers: {
         cookie: "token=valid.token.value",

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -10,8 +10,14 @@ import Heading from "../../src/components/Heading";
 import Input from "../../src/components/Input";
 import Label from "../../src/components/Label";
 import Button from "../../src/components/Button";
+import Select from "../../src/components/Select";
 import Router from "next/router";
 import { ADMIN } from "../../src/helpers/userTypes";
+
+const VIDEO_PROVIDER_OPTIONS = [
+  { id: "whereby", name: "Whereby" },
+  { id: "jitsi", name: "Jitsi" },
+];
 
 const AddATrust = () => {
   const [errors, setErrors] = useState([]);
@@ -19,6 +25,7 @@ const AddATrust = () => {
   const [adminCode, setAdminCode] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [videoProvider, setVideoProvider] = useState("");
 
   const hasError = (field) =>
     errors.find((error) => error.id === `${field}-error`);
@@ -81,6 +88,13 @@ const AddATrust = () => {
       });
     };
 
+    const setVideoProviderError = (errors) => {
+      errors.push({
+        id: "video-provider-error",
+        message: "Select a video provider",
+      });
+    };
+
     if (name.length === 0) {
       setNameError(onSubmitErrors);
     }
@@ -103,6 +117,10 @@ const AddATrust = () => {
       setPasswordConfirmationError(onSubmitErrors);
     }
 
+    if (videoProvider.length === 0) {
+      setVideoProviderError(onSubmitErrors);
+    }
+
     if (onSubmitErrors.length === 0) {
       const submitAnswers = async (name) => {
         const response = await fetch("/api/create-trust", {
@@ -114,6 +132,7 @@ const AddATrust = () => {
             name,
             adminCode,
             password,
+            videoProvider,
           }),
         });
 
@@ -169,6 +188,22 @@ const AddATrust = () => {
                 name="trust-name"
                 autoComplete="off"
                 value={name || ""}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Label htmlFor="video-provider" className="nhsuk-label--l">
+                Which video provider would you like to use?
+              </Label>
+              <Select
+                id="video-provider"
+                className="nhsuk-input--width-10 nhsuk-u-width-one-half"
+                prompt="Choose a provider"
+                options={VIDEO_PROVIDER_OPTIONS}
+                onChange={(event) => {
+                  setVideoProvider(event.target.value);
+                }}
+                hasError={hasError("video-provider")}
+                errorMessage={errorMessage("video-provider")}
               />
             </FormGroup>
             <FormGroup>

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -204,6 +204,7 @@ const AddATrust = () => {
                 }}
                 hasError={hasError("video-provider")}
                 errorMessage={errorMessage("video-provider")}
+                name="video-provider"
               />
             </FormGroup>
             <FormGroup>

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -99,6 +99,10 @@ const AddATrust = () => {
       setNameError(onSubmitErrors);
     }
 
+    if (videoProvider.length === 0) {
+      setVideoProviderError(onSubmitErrors);
+    }
+
     if (adminCode.length === 0) {
       setAdminCodeError(onSubmitErrors);
     }
@@ -115,10 +119,6 @@ const AddATrust = () => {
       }
     } else {
       setPasswordConfirmationError(onSubmitErrors);
-    }
-
-    if (videoProvider.length === 0) {
-      setVideoProviderError(onSubmitErrors);
     }
 
     if (onSubmitErrors.length === 0) {

--- a/pages/api/create-trust.js
+++ b/pages/api/create-trust.js
@@ -34,6 +34,12 @@ export default withContainer(
       return;
     }
 
+    if (!body.videoProvider) {
+      res.status(409);
+      res.end(JSON.stringify({ err: "video provider must be present" }));
+      return;
+    }
+
     res.setHeader("Content-Type", "application/json");
 
     const createTrust = container.getCreateTrust();
@@ -42,6 +48,7 @@ export default withContainer(
       name: body.name,
       adminCode: body.adminCode,
       password: body.password,
+      videoProvider: body.videoProvider,
     });
 
     if (error) {

--- a/src/testUtils/factories.js
+++ b/src/testUtils/factories.js
@@ -6,6 +6,7 @@ export const setupTrust = async (args = {}) => {
     name: "Test Trust",
     adminCode: "TESTCODE",
     password: "TESTPASSWORD",
+    videoProvider: "TESTPROVIDER",
     ...args,
   });
 };

--- a/src/usecases/createTrust.contractTest.js
+++ b/src/usecases/createTrust.contractTest.js
@@ -20,6 +20,7 @@ describe("createTrust contract tests", () => {
     expect(trust).toEqual({
       id: trustId,
       name: request.name,
+      videoProvider: "provider",
     });
 
     expect(error).toBeNull();

--- a/src/usecases/createTrust.contractTest.js
+++ b/src/usecases/createTrust.contractTest.js
@@ -10,6 +10,7 @@ describe("createTrust contract tests", () => {
       name: "Defoe Trust",
       adminCode: "adminCode",
       password: "trustpassword",
+      videoProvider: "provider",
     };
 
     const { trustId, error } = await createTrust(container)(request);
@@ -29,12 +30,14 @@ describe("createTrust contract tests", () => {
       name: "Test Trust",
       adminCode: "adminCode",
       password: "trustpassword",
+      videoProvider: "provider",
     });
 
     const request = {
       name: "Test Trust 2",
       adminCode: "adminCode",
       password: "trustpassword",
+      videoProvider: "provider",
     };
 
     const { trustId, error } = await createTrust(container)(request);
@@ -42,6 +45,19 @@ describe("createTrust contract tests", () => {
     expect(trustId).toBeNull();
     expect(error.toString()).toEqual(
       'error: duplicate key value violates unique constraint "trusts_admin_code_key"'
+    );
+  });
+
+  it("returns an error if the video provider is not present", async () => {
+    const { trustId, error } = await createTrust(container)({
+      name: "Test Trust 2",
+      adminCode: "adminCode",
+      password: "trustpassword",
+    });
+
+    expect(trustId).toBeNull();
+    expect(error.toString()).toEqual(
+      'error: null value in column "video_provider" violates not-null constraint'
     );
   });
 });

--- a/src/usecases/createTrust.js
+++ b/src/usecases/createTrust.js
@@ -1,6 +1,11 @@
 import bcrypt from "bcryptjs";
 
-const createTrust = ({ getDb }) => async ({ name, adminCode, password }) => {
+const createTrust = ({ getDb }) => async ({
+  name,
+  adminCode,
+  password,
+  videoProvider,
+}) => {
   const db = await getDb();
 
   if (!password) {
@@ -18,11 +23,11 @@ const createTrust = ({ getDb }) => async ({ name, adminCode, password }) => {
 
     const createdTrust = await db.one(
       `INSERT INTO trusts
-            (id, name, admin_code, password)
-            VALUES (default, $1, $2, $3)
+            (id, name, admin_code, password, video_provider)
+            VALUES (default, $1, $2, $3, $4)
             RETURNING id
           `,
-      [name, adminCode, hashedPassword]
+      [name, adminCode, hashedPassword, videoProvider]
     );
 
     return {

--- a/src/usecases/createTrust.test.js
+++ b/src/usecases/createTrust.test.js
@@ -15,6 +15,7 @@ describe("createTrust", () => {
       name: "Defoe Trust",
       adminCode: "adminCode",
       password: "password",
+      videoProvider: "whereby",
     };
 
     const { trustId, error } = await createTrust(container)(request);
@@ -24,6 +25,7 @@ describe("createTrust", () => {
       "Defoe Trust",
       "adminCode",
       expect.anything(),
+      "whereby",
     ]);
   });
 

--- a/src/usecases/retrieveTrustById.js
+++ b/src/usecases/retrieveTrustById.js
@@ -11,6 +11,7 @@ const retrieveTrustById = ({ getDb }) => async (trustId) => {
       trust: {
         id: trust.id,
         name: trust.name,
+        videoProvider: trust.video_provider,
       },
       error: null,
     };

--- a/src/usecases/retrieveTrustById.test.js
+++ b/src/usecases/retrieveTrustById.test.js
@@ -8,6 +8,7 @@ describe("retrieveTrustById", () => {
           oneOrNone: jest.fn().mockReturnValue({
             id: 1,
             name: "Doggo Trust",
+            video_provider: "testprovider",
           }),
         };
       },
@@ -20,6 +21,7 @@ describe("retrieveTrustById", () => {
     expect(trust).toEqual({
       id: 1,
       name: "Doggo Trust",
+      videoProvider: "testprovider",
     });
   });
 


### PR DESCRIPTION
# What
Allows Admins to select a video provider when creating a new Trust. This change also updates all existing trusts to use the whereby provider as that is currently the default provider for all current trusts.

# Why
To give the Admins the choice of which video provider to use

# Screenshots

# Notes
This change focuses on storing the preference in the database. A later PR will hook the video provider preference up to the visit booking logic