### PR TITLE
Fix visits page not capturing events when a key contact

### DIFF
--- a/pageTests/api/capture-event.test.js
+++ b/pageTests/api/capture-event.test.js
@@ -14,7 +14,7 @@ describe("/api/capture-event", () => {
   }));
 
   const verifyCallPassword = jest.fn((callId, password) => ({
-    validCallPassword: password === "securePassword",
+    validCallPassword: password === "securePassword" && callId === "123",
     error: null,
   }));
 
@@ -87,6 +87,8 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if no callId provided", async () => {
+    const userIsAuthenticated = jest.fn().mockReturnValue(false);
+
     await captureEvent(
       {
         method: "POST",
@@ -94,7 +96,10 @@ describe("/api/capture-event", () => {
       },
       response,
       {
-        container,
+        container: {
+          ...container,
+          getUserIsAuthenticated: () => userIsAuthenticated,
+        },
       }
     );
 
@@ -102,6 +107,8 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if no callPassword provided", async () => {
+    const userIsAuthenticated = jest.fn().mockReturnValue(false);
+
     await captureEvent(
       {
         method: "POST",
@@ -109,7 +116,10 @@ describe("/api/capture-event", () => {
       },
       response,
       {
-        container,
+        container: {
+          ...container,
+          getUserIsAuthenticated: () => userIsAuthenticated,
+        },
       }
     );
 
@@ -117,6 +127,8 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if invalid call password", async () => {
+    const userIsAuthenticated = jest.fn().mockReturnValue(false);
+
     await captureEvent(
       {
         method: "POST",
@@ -124,7 +136,10 @@ describe("/api/capture-event", () => {
       },
       response,
       {
-        container,
+        container: {
+          ...container,
+          getUserIsAuthenticated: () => userIsAuthenticated,
+        },
       }
     );
 

--- a/pages/api/capture-event.js
+++ b/pages/api/capture-event.js
@@ -11,30 +11,18 @@ export default withContainer(
       return;
     }
 
-    if (headers?.cookie) {
-      const userIsAuthenticated = container.getUserIsAuthenticated();
-      const userIsAuthenticatedResponse = await userIsAuthenticated(
-        headers.cookie
-      );
+    const userIsAuthenticated = container.getUserIsAuthenticated();
+    const userIsAuthenticatedResponse = await userIsAuthenticated(
+      headers?.cookie
+    );
 
-      if (!userIsAuthenticatedResponse) {
-        res.status(401);
-        res.end(JSON.stringify({ err: "Unauthorized" }));
-        return;
-      }
-    } else if (body?.callId && body?.callPassword) {
-      const verifyCallPassword = container.getVerifyCallPassword();
-      const { validCallPassword } = await verifyCallPassword(
-        body.callId,
-        body.callPassword
-      );
+    const verifyCallPassword = container.getVerifyCallPassword();
+    const { validCallPassword } = await verifyCallPassword(
+      body.callId,
+      body.callPassword
+    );
 
-      if (!validCallPassword) {
-        res.status(401);
-        res.end(JSON.stringify({ err: "Invalid call password" }));
-        return;
-      }
-    } else {
+    if (!userIsAuthenticatedResponse && !validCallPassword) {
       res.status(401);
       res.end(JSON.stringify({ err: "Unauthorized" }));
       return;

--- a/pages/api/capture-event.js
+++ b/pages/api/capture-event.js
@@ -11,12 +11,30 @@ export default withContainer(
       return;
     }
 
-    const userIsAuthenticated = container.getUserIsAuthenticated();
-    const userIsAuthenticatedResponse = await userIsAuthenticated(
-      headers.cookie
-    );
+    if (headers?.cookie) {
+      const userIsAuthenticated = container.getUserIsAuthenticated();
+      const userIsAuthenticatedResponse = await userIsAuthenticated(
+        headers.cookie
+      );
 
-    if (!userIsAuthenticatedResponse) {
+      if (!userIsAuthenticatedResponse) {
+        res.status(401);
+        res.end(JSON.stringify({ err: "Unauthorized" }));
+        return;
+      }
+    } else if (body?.callId && body?.callPassword) {
+      const verifyCallPassword = container.getVerifyCallPassword();
+      const { validCallPassword } = await verifyCallPassword(
+        body.callId,
+        body.callPassword
+      );
+
+      if (!validCallPassword) {
+        res.status(401);
+        res.end(JSON.stringify({ err: "Invalid call password" }));
+        return;
+      }
+    } else {
       res.status(401);
       res.end(JSON.stringify({ err: "Unauthorized" }));
       return;

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -7,7 +7,15 @@ import propsWithContainer from "../../src/middleware/propsWithContainer";
 import fetch from "isomorphic-unfetch";
 import { v4 as uuidv4 } from "uuid";
 
-const Call = ({ visitId, callId, sessionId, name, provider, error }) => {
+const Call = ({
+  visitId,
+  callId,
+  callPassword,
+  sessionId,
+  name,
+  provider,
+  error,
+}) => {
   if (error) {
     return <Error />;
   }
@@ -17,6 +25,8 @@ const Call = ({ visitId, callId, sessionId, name, provider, error }) => {
       action: action,
       visitId: visitId,
       sessionId: sessionId,
+      callId,
+      callPassword,
     };
 
     await fetch("/api/capture-event", {
@@ -67,7 +77,17 @@ export const getServerSideProps = propsWithContainer(
       const sessionId = uuidv4();
       const visitId = scheduledCall.id;
 
-      return { props: { visitId, callId, sessionId, name, provider, error } };
+      return {
+        props: {
+          visitId,
+          callId,
+          callPassword: callPassword || "",
+          sessionId,
+          name,
+          provider,
+          error,
+        },
+      };
     } else {
       res.writeHead(307, {
         Location: "/error",


### PR DESCRIPTION
# What

Fix the visits page not capturing events when a key contact by updating the `api/capture-event` endpoint to allow authentication via the `callId` and `callPassword`.

# Why

Because we need events from a key contact's perspective for metrics.

# Screenshots

N/A

# Notes

N/a