### PR TITLE
Ensure that the visits page errors out when an incorrect call password is used

### DIFF
--- a/pageTests/api/book-a-visit.test.js
+++ b/pageTests/api/book-a-visit.test.js
@@ -15,11 +15,11 @@ describe("/api/book-a-visit", () => {
   let container;
   let createVisitSpy;
 
-  const validUserIsAuthenticatedSpy = jest.fn(() => ({
+  const validUserIsAuthenticatedSpy = jest.fn().mockResolvedValue({
     wardId: 10,
     ward: "MEOW",
     trustId: 1,
-  }));
+  });
 
   const updateWardVisitTotalsSpy = jest.fn(() => ({
     success: true,
@@ -255,7 +255,7 @@ describe("/api/book-a-visit", () => {
   });
 
   it("returns a 401 when there is no token provided", async () => {
-    const userIsAuthenticatedSpy = jest.fn().mockReturnValue(false);
+    const userIsAuthenticatedSpy = jest.fn().mockResolvedValue(false);
 
     await bookAVisit(
       {

--- a/pageTests/api/capture-event.test.js
+++ b/pageTests/api/capture-event.test.js
@@ -7,11 +7,11 @@ describe("/api/capture-event", () => {
   let response;
   let container;
 
-  const validUserIsAuthenticatedSpy = jest.fn().mockReturnValue(() => ({
+  const validUserIsAuthenticatedSpy = jest.fn().mockResolvedValue({
     wardId: 10,
     ward: "MEOW",
     trustId: 1,
-  }));
+  });
 
   const verifyCallPassword = jest.fn((callId, password) => ({
     validCallPassword: password === "securePassword" && callId === "123",
@@ -49,7 +49,7 @@ describe("/api/capture-event", () => {
       body: jest.fn(),
     };
     container = {
-      getUserIsAuthenticated: validUserIsAuthenticatedSpy,
+      getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
       getCaptureEvent: mockCaptureEvent,
       getVerifyCallPassword: () => verifyCallPassword,
     };
@@ -66,7 +66,7 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if no token provided", async () => {
-    const userIsAuthenticatedMock = jest.fn().mockReturnValue(false);
+    const userIsAuthenticatedMock = jest.fn().mockResolvedValue(false);
 
     await captureEvent(
       {
@@ -87,7 +87,7 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if no callId provided", async () => {
-    const userIsAuthenticated = jest.fn().mockReturnValue(false);
+    const userIsAuthenticated = jest.fn().mockResolvedValue(false);
 
     await captureEvent(
       {
@@ -107,7 +107,7 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if no callPassword provided", async () => {
-    const userIsAuthenticated = jest.fn().mockReturnValue(false);
+    const userIsAuthenticated = jest.fn().mockResolvedValue(false);
 
     await captureEvent(
       {
@@ -127,7 +127,7 @@ describe("/api/capture-event", () => {
   });
 
   it("returns a 401 if invalid call password", async () => {
-    const userIsAuthenticated = jest.fn().mockReturnValue(false);
+    const userIsAuthenticated = jest.fn().mockResolvedValue(false);
 
     await captureEvent(
       {

--- a/pageTests/api/send-visit-ready-notification.test.js
+++ b/pageTests/api/send-visit-ready-notification.test.js
@@ -7,11 +7,11 @@ describe("send-visit-ready-notification", () => {
     end: jest.fn(),
     writeHead: jest.fn().mockReturnValue({ end: () => {} }),
   };
-  const validUserIsAuthenticatedSpy = jest.fn(() => ({
+  const validUserIsAuthenticatedSpy = jest.fn().mockResolvedValue({
     wardId: 10,
     ward: "MEOW",
     trustId: 1,
-  }));
+  });
   const retrieveWardByIdSpy = jest.fn(() => ({
     ward: {
       id: 1,
@@ -47,10 +47,11 @@ describe("send-visit-ready-notification", () => {
         headers: {},
       };
 
-      container.getUserIsAuthenticated = jest.fn(() => () => false);
-
       await sendVisitReadyNotification(requestWithoutToken, response, {
-        container,
+        container: {
+          ...container,
+          getUserIsAuthenticated: () => jest.fn().mockResolvedValue(false),
+        },
       });
 
       expect(response.status).toHaveBeenCalledWith(401);

--- a/pageTests/visits/[id].test.js
+++ b/pageTests/visits/[id].test.js
@@ -23,7 +23,7 @@ describe("call", () => {
         validCallPassword: password === "securePassword",
         error: null,
       }));
-      getUserIsAuthenticatedSpy = jest.fn().mockReturnValue(false);
+      getUserIsAuthenticatedSpy = jest.fn().mockResolvedValue(false);
       container = {
         getVerifyCallPassword: () => getVerifyCallPasswordSpy,
         getUserIsAuthenticated: () => getUserIsAuthenticatedSpy,
@@ -55,7 +55,7 @@ describe("call", () => {
     });
 
     it("returns callId when the password is invalid, but the user is authenticated", async () => {
-      getUserIsAuthenticatedSpy.mockReturnValueOnce(true);
+      getUserIsAuthenticatedSpy.mockResolvedValue(true);
       const { props } = await getServerSideProps({
         query: {
           callPassword: undefined,
@@ -79,6 +79,8 @@ describe("call", () => {
         res,
         req,
       });
+
+      expect(getUserIsAuthenticatedSpy).toHaveBeenCalled();
       expect(getVerifyCallPasswordSpy).toHaveBeenCalledWith(1, "fakeCode");
       expect(res.writeHead).toHaveBeenCalledWith(307, { Location: "/error" });
     });

--- a/pageTests/visits/end.test.js
+++ b/pageTests/visits/end.test.js
@@ -49,7 +49,8 @@ describe("end", () => {
     };
     it("provides the call id", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => ({ ward: "test-ward-id" }),
+        getUserIsAuthenticated: () =>
+          jest.fn().mockResolvedValue({ ward: "test-ward-id" }),
       };
       const query = { callId: "TEST123" };
       const { props } = await getServerSideProps({ req, container, query });
@@ -58,7 +59,8 @@ describe("end", () => {
 
     it("provides the ward id if the user is authenticated", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => ({ ward: "test-ward-id" }),
+        getUserIsAuthenticated: () =>
+          jest.fn().mockResolvedValue({ ward: "test-ward-id" }),
       };
 
       const query = { callId: "TEST123" };
@@ -69,7 +71,7 @@ describe("end", () => {
 
     it("does not provides the ward id if the user is unauthenticated", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => false,
+        getUserIsAuthenticated: () => jest.fn().mockResolvedValue(false),
       };
       const query = { callId: "TEST123" };
       const { props } = await getServerSideProps({ req, container, query });

--- a/pageTests/wards/book-a-visit.test.js
+++ b/pageTests/wards/book-a-visit.test.js
@@ -31,7 +31,8 @@ describe("ward/book-a-visit", () => {
     container = {
       getTokenProvider: () => tokenProvider,
       getRetrieveWardById: () => jest.fn().mockReturnValue({}),
-      getUserIsAuthenticated: () => (token) => token && { ward: "123" },
+      getUserIsAuthenticated: () =>
+        jest.fn().mockResolvedValue("token=123" && { ward: "123" }),
       getRetrieveVisitByCallId: () => () => ({
         scheduledCall: {
           id: 1,

--- a/pageTests/wards/login.test.js
+++ b/pageTests/wards/login.test.js
@@ -18,7 +18,7 @@ describe("login", () => {
 
     it("does not redirect if not logged in", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => false,
+        getUserIsAuthenticated: () => jest.fn().mockResolvedValue(false),
         getTrustAdminIsAuthenticated: () => () => false,
         getAdminIsAuthenticated: () => () => false,
       };
@@ -30,7 +30,8 @@ describe("login", () => {
 
     it("redirects to the ward list page if user logged in", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => ({ ward: "my-test-ward" }),
+        getUserIsAuthenticated: () =>
+          jest.fn().mockResolvedValue({ ward: "my-test-ward" }),
         getTrustAdminIsAuthenticated: () => () => false,
         getAdminIsAuthenticated: () => () => false,
       };
@@ -45,7 +46,7 @@ describe("login", () => {
 
     it("redirects to the trust admin index page if trust admin logged in", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => false,
+        getUserIsAuthenticated: () => jest.fn().mockResolvedValue(false),
         getTrustAdminIsAuthenticated: () => () => ({ type: "trustAdmin" }),
         getAdminIsAuthenticated: () => () => false,
       };
@@ -60,7 +61,7 @@ describe("login", () => {
 
     it("redirects to the admin index page if admin logged in", async () => {
       const container = {
-        getUserIsAuthenticated: () => () => false,
+        getUserIsAuthenticated: () => jest.fn().mockResolvedValue(false),
         getTrustAdminIsAuthenticated: () => () => false,
         getAdminIsAuthenticated: () => () => ({ type: "admin" }),
       };

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -69,7 +69,8 @@ export const getServerSideProps = propsWithContainer(
       callId,
       callPassword
     );
-    const authenticationToken = userIsAuthenticated(headers.cookie);
+
+    const authenticationToken = await userIsAuthenticated(headers.cookie);
 
     if (validCallPassword || authenticationToken) {
       const { scheduledCall, error } = await retrieveVisitByCallId(callId);


### PR DESCRIPTION
# What

Ensure that the visits page errors out when an incorrect call password is used. This was due to the fact that we didn't `await` the `userIsAuthenticated` usecase which meant that it
returned a `Promise { false }` which was inherently true.

Also update tests to ensure `userIsAuthenticated` is stubbed correctly.

# Why

To ensure that visits are secure.

# Screenshots

N/A

# Notes

N/A