### PR TITLE
Add usecase to get the average number of participants in a visit

### DIFF
--- a/pages/api/capture-event.js
+++ b/pages/api/capture-event.js
@@ -1,7 +1,8 @@
 import withContainer from "../../src/middleware/withContainer";
 import isGuid from "../../src/helpers/isGuid";
+import { JOIN_VISIT, LEAVE_VISIT } from "../../src/helpers/eventActions";
 
-const actions = ["join-visit", "leave-visit"];
+const actions = [JOIN_VISIT, LEAVE_VISIT];
 
 export default withContainer(
   async ({ headers, body, method }, res, { container }) => {

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -6,6 +6,7 @@ import Error from "next/error";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import fetch from "isomorphic-unfetch";
 import { v4 as uuidv4 } from "uuid";
+import { JOIN_VISIT, LEAVE_VISIT } from "../../src/helpers/eventActions";
 
 const Call = ({
   visitId,
@@ -39,11 +40,11 @@ const Call = ({
   };
 
   useEffect(() => {
-    captureEvent("join-visit");
+    captureEvent(JOIN_VISIT);
   }, []);
 
   const leaveVisit = useCallback(async () => {
-    await captureEvent("leave-visit");
+    await captureEvent(LEAVE_VISIT);
   });
 
   return (

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -35,6 +35,7 @@ import retrieveWardsByHospitalId from "../usecases/retrieveWardsByHospitalId";
 import retrieveHospitalVisitTotals from "../usecases/retrieveHospitalVisitTotals";
 import retrieveHospitalWardVisitTotals from "../usecases/retrieveHospitalWardVisitTotals";
 import captureEvent from "../usecases/captureEvent";
+import retrieveAverageParticipantsInVisit from "../usecases/retrieveAverageParticipantsInVisit";
 
 class AppContainer {
   getDb = () => {
@@ -183,6 +184,10 @@ class AppContainer {
 
   getCaptureEvent = () => {
     return captureEvent(this);
+  };
+
+  getRetrieveAverageParticipantsInVisit = () => {
+    return retrieveAverageParticipantsInVisit(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -93,4 +93,8 @@ describe("AppContainer", () => {
   it("returns getCaptureEvent", () => {
     expect(container.getCaptureEvent()).toBeDefined();
   });
+
+  it("returns getRetrieveAverageParticipantsInVisit", () => {
+    expect(container.getRetrieveAverageParticipantsInVisit()).toBeDefined();
+  });
 });

--- a/src/helpers/eventActions.js
+++ b/src/helpers/eventActions.js
@@ -1,0 +1,2 @@
+export const JOIN_VISIT = "join-visit";
+export const LEAVE_VISIT = "leave-visit";

--- a/src/helpers/eventActions.test.js
+++ b/src/helpers/eventActions.test.js
@@ -1,0 +1,11 @@
+import { JOIN_VISIT, LEAVE_VISIT } from "./eventActions";
+
+describe("eventActions", () => {
+  it("returns the wardStaff user type", () => {
+    expect(JOIN_VISIT).toEqual("join-visit");
+  });
+
+  it("returns the trustAdmin user type", () => {
+    expect(LEAVE_VISIT).toEqual("leave-visit");
+  });
+});

--- a/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
@@ -1,0 +1,142 @@
+import AppContainer from "../containers/AppContainer";
+import { setupTrust } from "../testUtils/factories";
+import { v4 as uuidv4 } from "uuid";
+
+describe("retrieveAverageParticipantsInVisit contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns all the average number of participants in a visit for a trust", async () => {
+    // A trust with a visit with 1 participant
+    const { trustId } = await setupTrust();
+
+    const { hospitalId } = await container.getCreateHospital()({
+      name: "Test Hospital",
+      trustId: trustId,
+    });
+
+    const { wardId } = await container.getCreateWard()({
+      name: "Test Ward 1",
+      code: "wardCode1",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const { id: visitId } = await container.getCreateVisit()({
+      patientName: "Glimmer",
+      contactEmail: "bow@example.com",
+      contactName: "Bow",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId",
+      provider: "TESTPROVIDER",
+      wardId: wardId,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId,
+      sessionId,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId,
+      sessionId,
+    });
+
+    // A trust with a visit with 1 participant and another with 2 participants
+    const { trustId: trustId2 } = await setupTrust({ adminCode: "TESTCODE2" });
+
+    const { hospitalId: hospitalId2 } = await container.getCreateHospital()({
+      name: "Test Hospital 2",
+      trustId: trustId2,
+    });
+
+    const { wardId: wardId2 } = await container.getCreateWard()({
+      name: "Test Ward 2",
+      code: "wardCode2",
+      hospitalId: hospitalId2,
+      trustId: trustId2,
+    });
+
+    const { id: visitId2 } = await container.getCreateVisit()({
+      patientName: "Adora",
+      contactEmail: "catra@example.com",
+      contactName: "Catra",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId2",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId2 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    const { id: visitId3 } = await container.getCreateVisit()({
+      patientName: "Scorpia",
+      contactEmail: "perfuma@example.com",
+      contactName: "Perfuma",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId3",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId3 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    const sessionId4 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId4,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId3,
+      sessionId: sessionId4,
+    });
+
+    const {
+      averageParticipantsInVisit,
+      error,
+    } = await container.getRetrieveAverageParticipantsInVisit()(trustId2);
+
+    expect(averageParticipantsInVisit).toEqual(1.5);
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no trustId is provided", async () => {
+    const { error } = await container.getRetrieveAverageParticipantsInVisit()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveAverageParticipantsInVisit.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.js
@@ -1,0 +1,23 @@
+const retrieveAverageParticipantsInVisit = ({ getDb }) => async (trustId) => {
+  if (!trustId) return { error: "A trustId must be provided." };
+
+  const db = await getDb();
+  const [{ average_participants: averageParticipantsInVisit }] = await db.any(
+    `SELECT AVG(participants) as average_participants
+    FROM (SELECT COUNT ( DISTINCT session_id ) AS participants
+          FROM events
+          LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id
+          LEFT JOIN wards ON scheduled_calls_table.ward_id = wards.id
+          LEFT JOIN trusts ON wards.trust_id = trusts.id
+          WHERE trusts.id = $1
+          GROUP BY events.visit_id) distinct_session_counts_per_visit`,
+    trustId
+  );
+
+  return {
+    averageParticipantsInVisit: parseFloat(averageParticipantsInVisit),
+    error: null,
+  };
+};
+
+export default retrieveAverageParticipantsInVisit;

--- a/src/usecases/retrieveAverageParticipantsInVisit.test.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.test.js
@@ -1,0 +1,53 @@
+import retrieveAverageParticipantsInVisit from "./retrieveAverageParticipantsInVisit";
+
+describe("retrieveAverageParticipantsInVisit", () => {
+  const trustId = 1;
+
+  let dbAnySpy;
+
+  beforeEach(() => {
+    dbAnySpy = jest
+      .fn()
+      .mockResolvedValue([{ average_participants: "3.5000000000000000" }]);
+  });
+
+  it("returns an error if a trustId is not provided", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    const { error } = await retrieveAverageParticipantsInVisit(container)();
+
+    expect(error).toEqual("A trustId must be provided.");
+  });
+
+  it("retrieves events from the database with the trustId", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    await retrieveAverageParticipantsInVisit(container)(trustId);
+
+    expect(dbAnySpy).toHaveBeenCalledWith(expect.anything(), trustId);
+  });
+
+  it("returns the average number of participants in a visit", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    const {
+      averageParticipantsInVisit,
+      error,
+    } = await retrieveAverageParticipantsInVisit(container)(trustId);
+
+    expect(averageParticipantsInVisit).toEqual(3.5);
+    expect(error).toBeNull();
+  });
+});


### PR DESCRIPTION
# What

Add usecase to get the average number of participants in a visit for a trust as well as small refactoring to use a helper for the event action names.

# Why

So we can display the metric on the trust admin dashboard.

# Screenshots

N/A

# Notes

Best reviewed commit by commit.

Would like feedback on:

- How do deal with the long contract test.
- Are there any edge cases I'm missing?