### PR TITLE
Display average participants in a visit on trust admin dashboard

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -65,12 +65,18 @@ describe("trust-admin", () => {
 
   const retrieveHospitalVisitTotals = jest.fn().mockReturnValue(hospitals);
 
+  const retrieveAverageParticipantsInVisit = jest
+    .fn()
+    .mockReturnValue({ averageParticipantsInVisit: 3, error: null });
+
   const container = {
     getRetrieveWards: () => getRetrieveWardsSpy,
     getRetrieveTrustById: () => retrieveTrustByIdSpy,
     getRetrieveHospitalsByTrustId: () => retrieveHospitalsByTrustId,
     getRetrieveWardVisitTotals: () => retrieveWardVisitTotalsSpy,
     getRetrieveHospitalVisitTotals: () => retrieveHospitalVisitTotals,
+    getRetrieveAverageParticipantsInVisit: () =>
+      retrieveAverageParticipantsInVisit,
     getTokenProvider: () => tokenProvider,
   };
 
@@ -194,7 +200,7 @@ describe("trust-admin", () => {
 
       expect(retrieveTrustByIdSpy).toHaveBeenCalledWith(trustId);
       expect(props.trust).toEqual({ name: "Doggo Trust" });
-      expect(props.wardError).toBeNull();
+      expect(props.trustError).toBeNull();
     });
 
     it("sets an error in props if trust error", async () => {
@@ -212,6 +218,35 @@ describe("trust-admin", () => {
       });
 
       expect(props.trustError).toEqual("Error!");
+    });
+
+    it("retrieves the average number of participants in a visit", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveAverageParticipantsInVisit).toHaveBeenCalledWith(trustId);
+      expect(props.averageParticipantsInVisit).toEqual(3);
+      expect(props.averageParticipantsInVisitError).toBeNull();
+    });
+
+    it("sets an error in props if trust error", async () => {
+      const retrieveAverageParticipantsInVisitError = jest.fn(async () => ({
+        error: "Error!",
+      }));
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container: Object.assign({}, container, {
+          getRetrieveAverageParticipantsInVisit: () =>
+            retrieveAverageParticipantsInVisitError,
+        }),
+      });
+
+      expect(props.averageParticipantsInVisitError).toEqual("Error!");
     });
   });
 });

--- a/pages/api/capture-event.js
+++ b/pages/api/capture-event.js
@@ -1,7 +1,8 @@
 import withContainer from "../../src/middleware/withContainer";
 import isGuid from "../../src/helpers/isGuid";
+import { JOIN_VISIT, LEAVE_VISIT } from "../../src/helpers/eventActions";
 
-const actions = ["join-visit", "leave-visit"];
+const actions = [JOIN_VISIT, LEAVE_VISIT];
 
 export default withContainer(
   async ({ headers, body, method }, res, { container }) => {

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -23,7 +23,9 @@ const TrustAdmin = ({
   visitsScheduled,
 }) => {
   if (wardError || trustError || averageParticipantsInVisitError) {
-    return <Error />;
+    return (
+      <Error err={wardError || trustError || averageParticipantsInVisitError} />
+    );
   }
 
   return (

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -18,9 +18,11 @@ const TrustAdmin = ({
   leastVisited,
   mostVisited,
   trust,
+  averageParticipantsInVisit,
+  averageParticipantsInVisitError,
   visitsScheduled,
 }) => {
-  if (wardError || trustError) {
+  if (wardError || trustError || averageParticipantsInVisitError) {
     return <Error />;
   }
 
@@ -40,28 +42,44 @@ const TrustAdmin = ({
             </span>
             Dashboard
           </Heading>
-          <h2>Trust</h2>
+
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
-              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-third"
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
               width="one-third"
             >
               <NumberTile number={visitsScheduled} label="booked visits" />
             </GridColumn>
             <GridColumn
-              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-third"
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
               width="one-third"
             >
-              <NumberTile number={hospitals.length} label="hospitals" />
-            </GridColumn>
-            <GridColumn
-              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-third"
-              width="one-third"
-            >
-              <NumberTile number={wards.length} label="wards" />
+              <NumberTile
+                number={averageParticipantsInVisit}
+                label="average participants in a visit"
+              />
             </GridColumn>
           </GridRow>
-          <h2>Usage</h2>
+
+          <GridRow className="nhsuk-u-padding-bottom-3">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-third"
+            >
+              <NumberTile
+                number={hospitals.length}
+                label="hospitals"
+                small={true}
+              />
+            </GridColumn>
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-third"
+            >
+              <NumberTile number={wards.length} label="wards" small={true} />
+            </GridColumn>
+          </GridRow>
+
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
               className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
@@ -143,6 +161,9 @@ export const getServerSideProps = propsWithContainer(
     const retrieveWardVisitTotals = await container.getRetrieveWardVisitTotals()(
       authenticationToken.trustId
     );
+    const averageParticipantsInVisitResponse = await container.getRetrieveAverageParticipantsInVisit()(
+      authenticationToken.trustId
+    );
 
     return {
       props: {
@@ -151,8 +172,12 @@ export const getServerSideProps = propsWithContainer(
         leastVisited: retrieveHospitalVisitTotals.leastVisited,
         mostVisited: retrieveHospitalVisitTotals.mostVisited,
         trust: { name: trustResponse.trust?.name },
+        averageParticipantsInVisit:
+          averageParticipantsInVisitResponse.averageParticipantsInVisit,
         wardError: wardsResponse.error,
         trustError: trustResponse.error,
+        averageParticipantsInVisitError:
+          averageParticipantsInVisitResponse.error,
         visitsScheduled: retrieveWardVisitTotals.total,
       },
     };

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -6,6 +6,7 @@ import Error from "next/error";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import fetch from "isomorphic-unfetch";
 import { v4 as uuidv4 } from "uuid";
+import { JOIN_VISIT, LEAVE_VISIT } from "../../src/helpers/eventActions";
 
 const Call = ({
   visitId,
@@ -39,11 +40,11 @@ const Call = ({
   };
 
   useEffect(() => {
-    captureEvent("join-visit");
+    captureEvent(JOIN_VISIT);
   }, []);
 
   const leaveVisit = useCallback(async () => {
-    await captureEvent("leave-visit");
+    await captureEvent(LEAVE_VISIT);
   });
 
   return (

--- a/src/components/NumberTile/index.js
+++ b/src/components/NumberTile/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 import "./styles.scss";
 
-const NumberTitle = ({ number, label }) => (
-  <div className="app-number-tile">
+const NumberTitle = ({ number, label, small = false }) => (
+  <div className={small ? "app-number-tile--s" : "app-number-tile"}>
     {number}
-    <span className="app-number-tile-label">{label}</span>
+    <span className="app-number-tile-label"> {label}</span>
   </div>
 );
 

--- a/src/components/NumberTile/styles.scss
+++ b/src/components/NumberTile/styles.scss
@@ -1,6 +1,6 @@
 @import "node_modules/nhsuk-frontend/packages/nhsuk";
 
-.app-number-tile {
+.app-number-tile, .app-number-tile--s {
   @include nhsuk-typography-responsive(48);
 
   background-color: $color_nhsuk-blue;
@@ -14,5 +14,19 @@
 
     font-weight: normal;
     display: block;
+  }
+}
+
+.app-number-tile--s {
+  @include nhsuk-typography-responsive(32);
+
+  background-color: $color_nhsuk-grey-1;
+  padding: 1rem 1rem;
+
+  .app-number-tile-label {
+    @include nhsuk-typography-responsive(19);
+
+    font-weight: normal;
+    display: initial;
   }
 }

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -35,6 +35,7 @@ import retrieveWardsByHospitalId from "../usecases/retrieveWardsByHospitalId";
 import retrieveHospitalVisitTotals from "../usecases/retrieveHospitalVisitTotals";
 import retrieveHospitalWardVisitTotals from "../usecases/retrieveHospitalWardVisitTotals";
 import captureEvent from "../usecases/captureEvent";
+import retrieveAverageParticipantsInVisit from "../usecases/retrieveAverageParticipantsInVisit";
 
 class AppContainer {
   getDb = () => {
@@ -183,6 +184,10 @@ class AppContainer {
 
   getCaptureEvent = () => {
     return captureEvent(this);
+  };
+
+  getRetrieveAverageParticipantsInVisit = () => {
+    return retrieveAverageParticipantsInVisit(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -93,4 +93,8 @@ describe("AppContainer", () => {
   it("returns getCaptureEvent", () => {
     expect(container.getCaptureEvent()).toBeDefined();
   });
+
+  it("returns getRetrieveAverageParticipantsInVisit", () => {
+    expect(container.getRetrieveAverageParticipantsInVisit()).toBeDefined();
+  });
 });

--- a/src/helpers/eventActions.js
+++ b/src/helpers/eventActions.js
@@ -1,0 +1,2 @@
+export const JOIN_VISIT = "join-visit";
+export const LEAVE_VISIT = "leave-visit";

--- a/src/helpers/eventActions.test.js
+++ b/src/helpers/eventActions.test.js
@@ -1,0 +1,11 @@
+import { JOIN_VISIT, LEAVE_VISIT } from "./eventActions";
+
+describe("eventActions", () => {
+  it("returns the wardStaff user type", () => {
+    expect(JOIN_VISIT).toEqual("join-visit");
+  });
+
+  it("returns the trustAdmin user type", () => {
+    expect(LEAVE_VISIT).toEqual("leave-visit");
+  });
+});

--- a/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
@@ -1,0 +1,142 @@
+import AppContainer from "../containers/AppContainer";
+import { setupTrust } from "../testUtils/factories";
+import { v4 as uuidv4 } from "uuid";
+
+describe("retrieveAverageParticipantsInVisit contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns all the average number of participants in a visit for a trust", async () => {
+    // A trust with a visit with 1 participant
+    const { trustId } = await setupTrust();
+
+    const { hospitalId } = await container.getCreateHospital()({
+      name: "Test Hospital",
+      trustId: trustId,
+    });
+
+    const { wardId } = await container.getCreateWard()({
+      name: "Test Ward 1",
+      code: "wardCode1",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const { id: visitId } = await container.getCreateVisit()({
+      patientName: "Glimmer",
+      contactEmail: "bow@example.com",
+      contactName: "Bow",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId",
+      provider: "TESTPROVIDER",
+      wardId: wardId,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId,
+      sessionId,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId,
+      sessionId,
+    });
+
+    // A trust with a visit with 1 participant and another with 2 participants
+    const { trustId: trustId2 } = await setupTrust({ adminCode: "TESTCODE2" });
+
+    const { hospitalId: hospitalId2 } = await container.getCreateHospital()({
+      name: "Test Hospital 2",
+      trustId: trustId2,
+    });
+
+    const { wardId: wardId2 } = await container.getCreateWard()({
+      name: "Test Ward 2",
+      code: "wardCode2",
+      hospitalId: hospitalId2,
+      trustId: trustId2,
+    });
+
+    const { id: visitId2 } = await container.getCreateVisit()({
+      patientName: "Adora",
+      contactEmail: "catra@example.com",
+      contactName: "Catra",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId2",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId2 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    const { id: visitId3 } = await container.getCreateVisit()({
+      patientName: "Scorpia",
+      contactEmail: "perfuma@example.com",
+      contactName: "Perfuma",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId3",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId3 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    const sessionId4 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId4,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId3,
+      sessionId: sessionId4,
+    });
+
+    const {
+      averageParticipantsInVisit,
+      error,
+    } = await container.getRetrieveAverageParticipantsInVisit()(trustId2);
+
+    expect(averageParticipantsInVisit).toEqual(1.5);
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no trustId is provided", async () => {
+    const { error } = await container.getRetrieveAverageParticipantsInVisit()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
@@ -46,7 +46,8 @@ describe("retrieveAverageParticipantsInVisit contract tests", () => {
       sessionId,
     });
 
-    // A trust with a visit with 1 participant and another with 2 participants
+    // A trust with a visit with 1 participant, one with 2 participants and
+    // another with 1 participant
     const { trustId: trustId2 } = await setupTrust({ adminCode: "TESTCODE2" });
 
     const { hospitalId: hospitalId2 } = await container.getCreateHospital()({
@@ -125,12 +126,37 @@ describe("retrieveAverageParticipantsInVisit contract tests", () => {
       sessionId: sessionId4,
     });
 
+    const { id: visitId4 } = await container.getCreateVisit()({
+      patientName: "Mermista",
+      contactEmail: "seahawk@example.com",
+      contactName: "Seahawk",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId4",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId5 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId4,
+      sessionId: sessionId5,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId4,
+      sessionId: sessionId5,
+    });
+
     const {
       averageParticipantsInVisit,
       error,
     } = await container.getRetrieveAverageParticipantsInVisit()(trustId2);
 
-    expect(averageParticipantsInVisit).toEqual(1.5);
+    expect(averageParticipantsInVisit).toEqual(1.3);
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.contractTest.js
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 describe("retrieveAverageParticipantsInVisit contract tests", () => {
   const container = AppContainer.getInstance();
 
-  it("returns all the average number of participants in a visit for a trust", async () => {
+  it("returns the average number of participants in a visit for a trust", async () => {
     // A trust with a visit with 1 participant
     const { trustId } = await setupTrust();
 
@@ -131,6 +131,18 @@ describe("retrieveAverageParticipantsInVisit contract tests", () => {
     } = await container.getRetrieveAverageParticipantsInVisit()(trustId2);
 
     expect(averageParticipantsInVisit).toEqual(1.5);
+    expect(error).toBeNull();
+  });
+
+  it("returns 0 if there are no events for a trust", async () => {
+    const { trustId } = await setupTrust();
+
+    const {
+      averageParticipantsInVisit,
+      error,
+    } = await container.getRetrieveAverageParticipantsInVisit()(trustId);
+
+    expect(averageParticipantsInVisit).toEqual(0);
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveAverageParticipantsInVisit.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.js
@@ -3,7 +3,7 @@ const retrieveAverageParticipantsInVisit = ({ getDb }) => async (trustId) => {
 
   const db = await getDb();
   const [{ average_participants: averageParticipantsInVisit }] = await db.any(
-    `SELECT AVG(participants) as average_participants
+    `SELECT COALESCE(AVG(participants), 0) as average_participants
     FROM (SELECT COUNT ( DISTINCT session_id ) AS participants
           FROM events
           LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id

--- a/src/usecases/retrieveAverageParticipantsInVisit.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.js
@@ -1,0 +1,23 @@
+const retrieveAverageParticipantsInVisit = ({ getDb }) => async (trustId) => {
+  if (!trustId) return { error: "A trustId must be provided." };
+
+  const db = await getDb();
+  const [{ average_participants: averageParticipantsInVisit }] = await db.any(
+    `SELECT AVG(participants) as average_participants
+    FROM (SELECT COUNT ( DISTINCT session_id ) AS participants
+          FROM events
+          LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id
+          LEFT JOIN wards ON scheduled_calls_table.ward_id = wards.id
+          LEFT JOIN trusts ON wards.trust_id = trusts.id
+          WHERE trusts.id = $1
+          GROUP BY events.visit_id) distinct_session_counts_per_visit`,
+    trustId
+  );
+
+  return {
+    averageParticipantsInVisit: parseFloat(averageParticipantsInVisit),
+    error: null,
+  };
+};
+
+export default retrieveAverageParticipantsInVisit;

--- a/src/usecases/retrieveAverageParticipantsInVisit.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.js
@@ -3,7 +3,7 @@ const retrieveAverageParticipantsInVisit = ({ getDb }) => async (trustId) => {
 
   const db = await getDb();
   const [{ average_participants: averageParticipantsInVisit }] = await db.any(
-    `SELECT COALESCE(AVG(participants), 0) as average_participants
+    `SELECT to_char(COALESCE(AVG(participants), 0), '999D9') as average_participants
     FROM (SELECT COUNT ( DISTINCT session_id ) AS participants
           FROM events
           LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id

--- a/src/usecases/retrieveAverageParticipantsInVisit.test.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.test.js
@@ -6,9 +6,7 @@ describe("retrieveAverageParticipantsInVisit", () => {
   let dbAnySpy;
 
   beforeEach(() => {
-    dbAnySpy = jest
-      .fn()
-      .mockResolvedValue([{ average_participants: "3.5000000000000000" }]);
+    dbAnySpy = jest.fn().mockResolvedValue([{ average_participants: "3.5" }]);
   });
 
   it("returns an error if a trustId is not provided", async () => {

--- a/src/usecases/retrieveAverageParticipantsInVisit.test.js
+++ b/src/usecases/retrieveAverageParticipantsInVisit.test.js
@@ -1,0 +1,53 @@
+import retrieveAverageParticipantsInVisit from "./retrieveAverageParticipantsInVisit";
+
+describe("retrieveAverageParticipantsInVisit", () => {
+  const trustId = 1;
+
+  let dbAnySpy;
+
+  beforeEach(() => {
+    dbAnySpy = jest
+      .fn()
+      .mockResolvedValue([{ average_participants: "3.5000000000000000" }]);
+  });
+
+  it("returns an error if a trustId is not provided", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    const { error } = await retrieveAverageParticipantsInVisit(container)();
+
+    expect(error).toEqual("A trustId must be provided.");
+  });
+
+  it("retrieves events from the database with the trustId", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    await retrieveAverageParticipantsInVisit(container)(trustId);
+
+    expect(dbAnySpy).toHaveBeenCalledWith(expect.anything(), trustId);
+  });
+
+  it("returns the average number of participants in a visit", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    const {
+      averageParticipantsInVisit,
+      error,
+    } = await retrieveAverageParticipantsInVisit(container)(trustId);
+
+    expect(averageParticipantsInVisit).toEqual(3.5);
+    expect(error).toBeNull();
+  });
+});


### PR DESCRIPTION
# What

Display average participants in a visit on trust admin dashboard by adding in a `retrieveAverageParticipantsInVisit` usecase.

# Why

So that a trust admin can see the average number of participants in a visit.

# Screenshots

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/85585486-f5b5a480-b637-11ea-905c-9a172e6a62b2.png)|![image](https://user-images.githubusercontent.com/42817036/85585428-e9314c00-b637-11ea-9e9a-63b5766e597c.png)|

# Notes

N/A