### PR TITLE
Add reporting for booked visits start date to trust admin dashboard

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -69,6 +69,10 @@ describe("trust-admin", () => {
     .fn()
     .mockReturnValue({ averageParticipantsInVisit: 3, error: null });
 
+  const retrieveWardVisitTotalsStartDateByTrustId = jest
+    .fn()
+    .mockReturnValue({ startDate: new Date("2020-04-01"), error: null });
+
   const container = {
     getRetrieveWards: () => getRetrieveWardsSpy,
     getRetrieveTrustById: () => retrieveTrustByIdSpy,
@@ -77,6 +81,8 @@ describe("trust-admin", () => {
     getRetrieveHospitalVisitTotals: () => retrieveHospitalVisitTotals,
     getRetrieveAverageParticipantsInVisit: () =>
       retrieveAverageParticipantsInVisit,
+    getRetrieveWardVisitTotalsStartDateByTrustId: () =>
+      retrieveWardVisitTotalsStartDateByTrustId,
     getTokenProvider: () => tokenProvider,
   };
 
@@ -232,7 +238,7 @@ describe("trust-admin", () => {
       expect(props.averageParticipantsInVisitError).toBeNull();
     });
 
-    it("sets an error in props if trust error", async () => {
+    it("sets an error in props if average participants in visit error", async () => {
       const retrieveAverageParticipantsInVisitError = jest.fn(async () => ({
         error: "Error!",
       }));
@@ -247,6 +253,41 @@ describe("trust-admin", () => {
       });
 
       expect(props.averageParticipantsInVisitError).toEqual("Error!");
+    });
+
+    it("retrieves the starting date for booked visits reporting", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveWardVisitTotalsStartDateByTrustId).toHaveBeenCalledWith(
+        trustId
+      );
+      expect(props.wardVisitTotalsStartDate).toEqual("1 April 2020");
+      expect(props.wardVisitTotalsStartDateError).toBeNull();
+    });
+
+    it("sets an error in props if starting date for booked visits reporting error", async () => {
+      const retrieveWardVisitTotalsStartDateByTrustIdError = jest.fn(
+        async () => ({
+          startDate: null,
+          error: "Error!",
+        })
+      );
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container: {
+          ...container,
+          getRetrieveWardVisitTotalsStartDateByTrustId: () =>
+            retrieveWardVisitTotalsStartDateByTrustIdError,
+        },
+      });
+
+      expect(props.wardVisitTotalsStartDateError).toEqual("Error!");
     });
   });
 });

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -8,7 +8,9 @@ import Heading from "../src/components/Heading";
 import NumberTile from "../src/components/NumberTile";
 import Text from "../src/components/Text";
 import AnchorLink from "../src/components/AnchorLink";
+import ReviewDate from "../src/components/ReviewDate";
 import { TRUST_ADMIN } from "../src/helpers/userTypes";
+import formatDate from "../src/helpers/formatDate";
 
 const TrustAdmin = ({
   wardError,
@@ -20,11 +22,20 @@ const TrustAdmin = ({
   trust,
   averageParticipantsInVisit,
   averageParticipantsInVisitError,
+  wardVisitTotalsStartDate,
+  wardVisitTotalsStartDateError,
   visitsScheduled,
 }) => {
   if (wardError || trustError || averageParticipantsInVisitError) {
     return (
-      <Error err={wardError || trustError || averageParticipantsInVisitError} />
+      <Error
+        err={
+          wardError ||
+          trustError ||
+          averageParticipantsInVisitError ||
+          wardVisitTotalsStartDateError
+        }
+      />
     );
   }
 
@@ -44,6 +55,12 @@ const TrustAdmin = ({
             </span>
             Dashboard
           </Heading>
+
+          {wardVisitTotalsStartDate && (
+            <ReviewDate>
+              Reporting for booked visits start date: {wardVisitTotalsStartDate}
+            </ReviewDate>
+          )}
 
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
@@ -166,6 +183,13 @@ export const getServerSideProps = propsWithContainer(
     const averageParticipantsInVisitResponse = await container.getRetrieveAverageParticipantsInVisit()(
       authenticationToken.trustId
     );
+    const retrieveWardVisitTotalsStartDateResponse = await container.getRetrieveWardVisitTotalsStartDateByTrustId()(
+      authenticationToken.trustId
+    );
+
+    const wardVisitTotalsStartDate = retrieveWardVisitTotalsStartDateResponse.startDate
+      ? formatDate(retrieveWardVisitTotalsStartDateResponse.startDate)
+      : null;
 
     return {
       props: {
@@ -176,10 +200,13 @@ export const getServerSideProps = propsWithContainer(
         trust: { name: trustResponse.trust?.name },
         averageParticipantsInVisit:
           averageParticipantsInVisitResponse.averageParticipantsInVisit,
+        wardVisitTotalsStartDate: wardVisitTotalsStartDate,
         wardError: wardsResponse.error,
         trustError: trustResponse.error,
         averageParticipantsInVisitError:
           averageParticipantsInVisitResponse.error,
+        wardVisitTotalsStartDateError:
+          retrieveWardVisitTotalsStartDateResponse.error,
         visitsScheduled: retrieveWardVisitTotals.total,
       },
     };

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -56,12 +56,6 @@ const TrustAdmin = ({
             Dashboard
           </Heading>
 
-          {wardVisitTotalsStartDate && (
-            <ReviewDate>
-              Reporting for booked visits start date: {wardVisitTotalsStartDate}
-            </ReviewDate>
-          )}
-
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
               className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
@@ -99,12 +93,9 @@ const TrustAdmin = ({
             </GridColumn>
           </GridRow>
 
-          <GridRow className="nhsuk-u-padding-bottom-3">
-            <GridColumn
-              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
-              width="one-half"
-            >
-              <div className="nhsuk-panel nhsuk-u-margin-top-1">
+          <GridRow>
+            <GridColumn className="nhsuk-u-one-half" width="one-half">
+              <div className="nhsuk-panel nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0">
                 <h3>Most booked visits</h3>
                 {mostVisited.length > 0 ? (
                   <ol>
@@ -128,11 +119,8 @@ const TrustAdmin = ({
                 )}
               </div>
             </GridColumn>
-            <GridColumn
-              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
-              width="one-half"
-            >
-              <div className="nhsuk-panel nhsuk-u-margin-top-1">
+            <GridColumn className="nhsuk-u-one-half" width="one-half">
+              <div className="nhsuk-panel nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0">
                 <h3>Least booked visits</h3>
                 {leastVisited.length > 0 ? (
                   <ol>
@@ -157,6 +145,11 @@ const TrustAdmin = ({
               </div>
             </GridColumn>
           </GridRow>
+          {wardVisitTotalsStartDate && (
+            <ReviewDate>
+              Reporting for booked visits start date: {wardVisitTotalsStartDate}
+            </ReviewDate>
+          )}
         </GridColumn>
       </GridRow>
     </Layout>

--- a/src/components/ReviewDate/index.js
+++ b/src/components/ReviewDate/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+import classNames from "classnames";
+
+const ReviewDate = ({ children, className }) => (
+  <div className={classNames("nhsuk-review-date", className)}>
+    <p className="nhsuk-body-s">{children}</p>
+  </div>
+);
+
+export default ReviewDate;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -37,6 +37,7 @@ import retrieveHospitalWardVisitTotals from "../usecases/retrieveHospitalWardVis
 import captureEvent from "../usecases/captureEvent";
 import retrieveAverageParticipantsInVisit from "../usecases/retrieveAverageParticipantsInVisit";
 import retrieveAverageVisitTimeByTrustId from "../usecases/retrieveAverageVisitTimeByTrustId";
+import retrieveWardVisitTotalsStartDateByTrustId from "../usecases/retrieveWardVisitTotalsStartDateByTrustId";
 
 class AppContainer {
   getDb = () => {
@@ -193,6 +194,10 @@ class AppContainer {
 
   getRetrieveAverageVisitTimeByTrustId = () => {
     return retrieveAverageVisitTimeByTrustId(this);
+  };
+
+  getRetrieveWardVisitTotalsStartDateByTrustId = () => {
+    return retrieveWardVisitTotalsStartDateByTrustId(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -97,4 +97,10 @@ describe("AppContainer", () => {
   it("returns getRetrieveAverageParticipantsInVisit", () => {
     expect(container.getRetrieveAverageParticipantsInVisit()).toBeDefined();
   });
+
+  it("returns getRetrieveWardVisitTotalsStartDateByTrustId", () => {
+    expect(
+      container.getRetrieveWardVisitTotalsStartDateByTrustId()
+    ).toBeDefined();
+  });
 });

--- a/src/testUtils/factories.js
+++ b/src/testUtils/factories.js
@@ -26,6 +26,18 @@ export const setupWard = async (args = {}) => {
   });
 };
 
+export const setupWardWithinHospitalAndTrust = async ({ index = 1 }) => {
+  const { trustId } = await setupTrust({ adminCode: `TESTCODE${index}` });
+  const { hospitalId } = await setupHospital({ trustId });
+  const { wardId } = await setupWard({
+    code: `wardCode${index}`,
+    trustId,
+    hospitalId,
+  });
+
+  return { wardId, hospitalId, trustId };
+};
+
 export const setupVisit = async (args = {}) => {
   return await container.getCreateVisit()({
     patientName: "Patient Name",

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
@@ -1,20 +1,18 @@
 import AppContainer from "../containers/AppContainer";
-import { setupTrust, setupHospital, setupWard } from "../testUtils/factories";
+import {
+  setupTrust,
+  setupWardWithinHospitalAndTrust,
+} from "../testUtils/factories";
 
 describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
   const container = AppContainer.getInstance();
 
   it("returns the date of when reporting started for a trust", async () => {
-    // A trust with booked visits
-    const { trustId: trustId1 } = await setupTrust({ adminCode: "TESTCODE1" });
-    const { hospitalId: hospitalId1 } = await setupHospital({
+    // A trust with ward visit totals
+    const {
+      wardId: wardId1,
       trustId: trustId1,
-    });
-    const { wardId: wardId1 } = await setupWard({
-      code: "wardCode1",
-      hospitalId: hospitalId1,
-      trustId: trustId1,
-    });
+    } = await setupWardWithinHospitalAndTrust({ index: 1 });
 
     await container.getUpdateWardVisitTotals()({
       wardId: wardId1,
@@ -25,15 +23,9 @@ describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
       date: new Date("2020-06-01T23:00:00.000Z"),
     });
 
-    // Another trust with booked visits
-    const { trustId: trustId2 } = await setupTrust({ adminCode: "TESTCODE2" });
-    const { hospitalId: hospitalId2 } = await setupHospital({
-      trustId: trustId2,
-    });
-    const { wardId: wardId2 } = await setupWard({
-      code: "wardCode2",
-      hospitalId: hospitalId2,
-      trustId: trustId2,
+    // Another trust with ward visit totals
+    const { wardId: wardId2 } = await setupWardWithinHospitalAndTrust({
+      index: 2,
     });
 
     await container.getUpdateWardVisitTotals()({

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
@@ -1,0 +1,74 @@
+import AppContainer from "../containers/AppContainer";
+import { setupTrust, setupHospital, setupWard } from "../testUtils/factories";
+
+describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns the date of when reporting started for a trust", async () => {
+    // A trust with booked visits
+    const { trustId: trustId1 } = await setupTrust({ adminCode: "TESTCODE1" });
+    const { hospitalId: hospitalId1 } = await setupHospital({
+      trustId: trustId1,
+    });
+    const { wardId: wardId1 } = await setupWard({
+      code: "wardCode1",
+      hospitalId: hospitalId1,
+      trustId: trustId1,
+    });
+
+    await container.getUpdateWardVisitTotals()({
+      wardId: wardId1,
+      date: new Date("2020-12-01T23:00:00.000Z"),
+    });
+    await container.getUpdateWardVisitTotals()({
+      wardId: wardId1,
+      date: new Date("2020-06-01T23:00:00.000Z"),
+    });
+
+    // Another trust with booked visits
+    const { trustId: trustId2 } = await setupTrust({ adminCode: "TESTCODE2" });
+    const { hospitalId: hospitalId2 } = await setupHospital({
+      trustId: trustId2,
+    });
+    const { wardId: wardId2 } = await setupWard({
+      code: "wardCode2",
+      hospitalId: hospitalId2,
+      trustId: trustId2,
+    });
+
+    await container.getUpdateWardVisitTotals()({
+      wardId: wardId2,
+      date: new Date("2020-01-01T23:00:00.000Z"),
+    });
+
+    const {
+      startDate,
+      error,
+    } = await container.getRetrieveWardVisitTotalsStartDateByTrustId()(
+      trustId1
+    );
+
+    expect(startDate).toEqual(new Date("2020-06-01T23:00:00.000Z"));
+    expect(error).toBeNull();
+  });
+
+  it("returns null if there are no ward visit totals for a trust", async () => {
+    const { trustId } = await setupTrust();
+
+    const {
+      startDate,
+      error,
+    } = await container.getRetrieveWardVisitTotalsStartDateByTrustId()(trustId);
+
+    expect(startDate).toBeNull();
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no trustId is provided", async () => {
+    const {
+      error,
+    } = await container.getRetrieveWardVisitTotalsStartDateByTrustId()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
@@ -16,11 +16,11 @@ describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
 
     await container.getUpdateWardVisitTotals()({
       wardId: wardId1,
-      date: new Date("2020-12-01T23:00:00.000Z"),
+      date: new Date(2020, 12, 1),
     });
     await container.getUpdateWardVisitTotals()({
       wardId: wardId1,
-      date: new Date("2020-06-01T23:00:00.000Z"),
+      date: new Date(2020, 6, 1),
     });
 
     // Another trust with ward visit totals
@@ -30,7 +30,7 @@ describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
 
     await container.getUpdateWardVisitTotals()({
       wardId: wardId2,
-      date: new Date("2020-01-01T23:00:00.000Z"),
+      date: new Date(2020, 1, 1),
     });
 
     const {
@@ -40,7 +40,7 @@ describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
       trustId1
     );
 
-    expect(startDate).toEqual(new Date("2020-06-01T23:00:00.000Z"));
+    expect(startDate).toEqual(new Date(2020, 6, 1));
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.js
@@ -1,0 +1,30 @@
+const retrieveWardVisitTotalsStartDateByTrustId = ({ getDb }) => async (
+  trustId
+) => {
+  if (!trustId) return { error: "A trustId must be provided." };
+
+  const db = await getDb();
+  try {
+    const { start_date: startDate } = await db.one(
+      `SELECT ward_visit_totals.total_date AS start_date
+      FROM ward_visit_totals
+      LEFT JOIN wards ON ward_visit_totals.ward_id = wards.id
+      LEFT JOIN hospitals ON wards.hospital_id = hospitals.id
+      LEFT JOIN trusts ON hospitals.trust_id = trusts.id
+      WHERE trusts.id = $1
+      ORDER BY total_date ASC
+      LIMIT 1`,
+      trustId
+    );
+
+    return { startDate, error: null };
+  } catch (error) {
+    if (error.name === "QueryResultError") {
+      return { startDate: null, error: null };
+    } else {
+      return { startDate: null, error: error.message };
+    }
+  }
+};
+
+export default retrieveWardVisitTotalsStartDateByTrustId;

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.test.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.test.js
@@ -1,0 +1,22 @@
+import retrieveWardVisitTotalsStartDateByTrustId from "./retrieveWardVisitTotalsStartDateByTrustId";
+
+describe("retrieveWardVisitTotalsStartDateByTrustId", () => {
+  it("returns the error if database throws an error", async () => {
+    const trustId = 1;
+    const container = {
+      async getDb() {
+        return {
+          one: jest.fn().mockImplementation(() => {
+            throw new Error("Error!");
+          }),
+        };
+      },
+    };
+
+    const { error } = await retrieveWardVisitTotalsStartDateByTrustId(
+      container
+    )(trustId);
+
+    expect(error).toEqual("Error!");
+  });
+});


### PR DESCRIPTION
# What

Add reporting for booked visits start date to trust admin dashboard.

# Why

We received feedback that "Without a date reference, the number of bookings isn’t particularly helpful." so by adding the start date they'll be able to know how many scheduled visits since a given date.

# Screenshots

Without any booked visits | With booked visits
-- | --
![image](https://user-images.githubusercontent.com/42817036/85995651-ee581780-b9f8-11ea-8dbb-56616f1793e5.png)|![image](https://user-images.githubusercontent.com/42817036/85999560-3466a880-ba04-11ea-8575-04c31e7c266a.png)

# Notes

Would like feedback on the last two commits which adds a new factory call `setupWardWithinHospitalAndTrust` and uses it in the contract test for the new usecase.