### PR TITLE
Show average visit time metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12112,6 +12112,11 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
+    "moment-duration-format": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
+    },
     "mongodb-uri": {
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jsonwebtoken": "^8.5.1",
     "mockdate": "^2.0.5",
     "moment": "^2.24.0",
+    "moment-duration-format": "^2.3.2",
     "nanoid": "^3.1.3",
     "next": "9.3.6",
     "next-env": "^1.1.1",

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -71,7 +71,7 @@ describe("trust-admin", () => {
 
   const retrieveAverageVisitTimeByTrustId = jest
     .fn()
-    .mockReturnValue({ averageVisitTimeSeconds: 4200, error: null });
+    .mockReturnValue({ averageVisitTime: "1hr, 10mins", error: null });
 
   const retrieveWardVisitTotalsStartDateByTrustId = jest
     .fn()

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -269,7 +269,7 @@ describe("trust-admin", () => {
       });
 
       expect(retrieveAverageVisitTimeByTrustId).toHaveBeenCalledWith(trustId);
-      expect(props.averageVisitTime).toEqual("1 hour, 10 minutes");
+      expect(props.averageVisitTime).toEqual("1hr, 10mins");
       expect(props.error).toBeNull();
     });
 

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -110,7 +110,7 @@ describe("trust-admin", () => {
 
       expect(getRetrieveWardsSpy).toHaveBeenCalledWith(1);
       expect(props.wards).toEqual(wards);
-      expect(props.wardError).toBeNull();
+      expect(props.error).toBeNull();
     });
 
     it("retrieves hospitals", async () => {
@@ -194,7 +194,7 @@ describe("trust-admin", () => {
         }),
       });
 
-      expect(props.wardError).toEqual("Error!");
+      expect(props.error).toEqual("Error!");
     });
 
     it("retrieves the trust of the trustAdmin", async () => {
@@ -206,7 +206,7 @@ describe("trust-admin", () => {
 
       expect(retrieveTrustByIdSpy).toHaveBeenCalledWith(trustId);
       expect(props.trust).toEqual({ name: "Doggo Trust" });
-      expect(props.trustError).toBeNull();
+      expect(props.error).toBeNull();
     });
 
     it("sets an error in props if trust error", async () => {
@@ -223,7 +223,7 @@ describe("trust-admin", () => {
         }),
       });
 
-      expect(props.trustError).toEqual("Error!");
+      expect(props.error).toEqual("Error!");
     });
 
     it("retrieves the average number of participants in a visit", async () => {
@@ -235,7 +235,7 @@ describe("trust-admin", () => {
 
       expect(retrieveAverageParticipantsInVisit).toHaveBeenCalledWith(trustId);
       expect(props.averageParticipantsInVisit).toEqual(3);
-      expect(props.averageParticipantsInVisitError).toBeNull();
+      expect(props.error).toBeNull();
     });
 
     it("sets an error in props if average participants in visit error", async () => {
@@ -252,7 +252,7 @@ describe("trust-admin", () => {
         }),
       });
 
-      expect(props.averageParticipantsInVisitError).toEqual("Error!");
+      expect(props.error).toEqual("Error!");
     });
 
     it("retrieves the starting date for booked visits reporting", async () => {
@@ -266,7 +266,7 @@ describe("trust-admin", () => {
         trustId
       );
       expect(props.wardVisitTotalsStartDate).toEqual("1 April 2020");
-      expect(props.wardVisitTotalsStartDateError).toBeNull();
+      expect(props.error).toBeNull();
     });
 
     it("sets an error in props if starting date for booked visits reporting error", async () => {
@@ -287,7 +287,7 @@ describe("trust-admin", () => {
         },
       });
 
-      expect(props.wardVisitTotalsStartDateError).toEqual("Error!");
+      expect(props.error).toEqual("Error!");
     });
   });
 });

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -69,6 +69,10 @@ describe("trust-admin", () => {
     .fn()
     .mockReturnValue({ averageParticipantsInVisit: 3, error: null });
 
+  const retrieveAverageVisitTimeByTrustId = jest
+    .fn()
+    .mockReturnValue({ averageVisitTimeSeconds: 4200, error: null });
+
   const retrieveWardVisitTotalsStartDateByTrustId = jest
     .fn()
     .mockReturnValue({ startDate: new Date("2020-04-01"), error: null });
@@ -81,6 +85,8 @@ describe("trust-admin", () => {
     getRetrieveHospitalVisitTotals: () => retrieveHospitalVisitTotals,
     getRetrieveAverageParticipantsInVisit: () =>
       retrieveAverageParticipantsInVisit,
+    getRetrieveAverageVisitTimeByTrustId: () =>
+      retrieveAverageVisitTimeByTrustId,
     getRetrieveWardVisitTotalsStartDateByTrustId: () =>
       retrieveWardVisitTotalsStartDateByTrustId,
     getTokenProvider: () => tokenProvider,
@@ -253,6 +259,18 @@ describe("trust-admin", () => {
       });
 
       expect(props.error).toEqual("Error!");
+    });
+
+    it("retrieves the average visit duration", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveAverageVisitTimeByTrustId).toHaveBeenCalledWith(trustId);
+      expect(props.averageVisitTime).toEqual("1 hour, 10 minutes");
+      expect(props.error).toBeNull();
     });
 
     it("retrieves the starting date for booked visits reporting", async () => {

--- a/pages/admin/login.js
+++ b/pages/admin/login.js
@@ -92,7 +92,7 @@ const Login = () => {
                 className="nhsuk-input--width-10"
                 onChange={(event) => setPassword(event.target.value)}
                 name="password"
-                autocomplete="off"
+                autoComplete="off"
               />
               <br />
             </FormGroup>

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -200,7 +200,7 @@ export const getServerSideProps = propsWithContainer(
 
     const averageVisitTime = moment
       .duration(averageVisitTimeSeconds, "seconds")
-      .format("h [hours], m [minutes]");
+      .format("h[hr], m[min]");
 
     const error =
       wardError ||

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -11,9 +11,6 @@ import AnchorLink from "../src/components/AnchorLink";
 import ReviewDate from "../src/components/ReviewDate";
 import { TRUST_ADMIN } from "../src/helpers/userTypes";
 import formatDate from "../src/helpers/formatDate";
-import moment from "moment";
-import momentDurationFormatSetup from "moment-duration-format";
-momentDurationFormatSetup(moment);
 
 const TrustAdmin = ({
   error,
@@ -192,15 +189,11 @@ export const getServerSideProps = propsWithContainer(
       : null;
 
     const {
-      averageVisitTimeSeconds,
+      averageVisitTime,
       error: averageVisitTimeSecondsError,
     } = await container.getRetrieveAverageVisitTimeByTrustId()(
       authenticationToken.trustId
     );
-
-    const averageVisitTime = moment
-      .duration(averageVisitTimeSeconds, "seconds")
-      .format("h[hr], m[min]");
 
     const error =
       wardError ||

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -11,6 +11,9 @@ import AnchorLink from "../src/components/AnchorLink";
 import ReviewDate from "../src/components/ReviewDate";
 import { TRUST_ADMIN } from "../src/helpers/userTypes";
 import formatDate from "../src/helpers/formatDate";
+import moment from "moment";
+import momentDurationFormatSetup from "moment-duration-format";
+momentDurationFormatSetup(moment);
 
 const TrustAdmin = ({
   error,
@@ -22,6 +25,7 @@ const TrustAdmin = ({
   averageParticipantsInVisit,
   wardVisitTotalsStartDate,
   visitsScheduled,
+  averageVisitTime,
 }) => {
   if (error) {
     return <Error err={error} />;
@@ -58,6 +62,18 @@ const TrustAdmin = ({
               <NumberTile
                 number={averageParticipantsInVisit}
                 label="average participants in a visit"
+              />
+            </GridColumn>
+          </GridRow>
+
+          <GridRow className="nhsuk-u-padding-bottom-3">
+            <GridColumn
+              className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
+              width="one-third"
+            >
+              <NumberTile
+                number={averageVisitTime}
+                label="average visit time"
               />
             </GridColumn>
           </GridRow>
@@ -175,11 +191,23 @@ export const getServerSideProps = propsWithContainer(
       ? formatDate(retrieveWardVisitTotalsStartDateResponse.startDate)
       : null;
 
+    const {
+      averageVisitTimeSeconds,
+      error: averageVisitTimeSecondsError,
+    } = await container.getRetrieveAverageVisitTimeByTrustId()(
+      authenticationToken.trustId
+    );
+
+    const averageVisitTime = moment
+      .duration(averageVisitTimeSeconds, "seconds")
+      .format("h [hours], m [minutes]");
+
     const error =
       wardError ||
       trustError ||
       averageParticipantsInVisitError ||
-      retrieveWardVisitTotalsStartDateResponse.error;
+      retrieveWardVisitTotalsStartDateResponse.error ||
+      averageVisitTimeSecondsError;
 
     return {
       props: {
@@ -191,6 +219,7 @@ export const getServerSideProps = propsWithContainer(
         wardVisitTotalsStartDate,
         averageParticipantsInVisit,
         visitsScheduled: retrieveWardVisitTotals.total,
+        averageVisitTime,
         error,
       },
     };

--- a/pages/trust-admin/login.js
+++ b/pages/trust-admin/login.js
@@ -92,7 +92,7 @@ const Login = () => {
                 className="nhsuk-input--width-10"
                 onChange={(event) => setPassword(event.target.value)}
                 name="password"
-                autocomplete="off"
+                autoComplete="off"
               />
               <br />
             </FormGroup>

--- a/src/usecases/retrieveAverageVisitTimeByTrustId.contractTest.js
+++ b/src/usecases/retrieveAverageVisitTimeByTrustId.contractTest.js
@@ -79,13 +79,13 @@ describe("retrieveAverageVisitTimeByTrustId contract tests", () => {
 
     expect(error2).toBeNull();
 
-    // (90 + 80) minutes / 2 = 5100 seconds
     const {
-      averageVisitTimeSeconds,
+      averageVisitTime,
       error,
     } = await container.getRetrieveAverageVisitTimeByTrustId()(trustId);
 
-    expect(averageVisitTimeSeconds).toEqual(5100);
+    // (90 + 80) minutes / 2 = 1 hr, 25 mins
+    expect(averageVisitTime).toEqual("1 hr, 25 mins");
     expect(error).toBeNull();
   });
 
@@ -116,11 +116,11 @@ describe("retrieveAverageVisitTimeByTrustId contract tests", () => {
     });
 
     const {
-      averageVisitTimeSeconds,
+      averageVisitTime,
       error,
     } = await container.getRetrieveAverageVisitTimeByTrustId()(trustId);
 
-    expect(averageVisitTimeSeconds).toEqual(0);
+    expect(averageVisitTime).toEqual("0 mins");
     expect(error).toBeNull();
   });
 
@@ -147,11 +147,11 @@ describe("retrieveAverageVisitTimeByTrustId contract tests", () => {
     });
 
     const {
-      averageVisitTimeSeconds,
+      averageVisitTime,
       error,
     } = await container.getRetrieveAverageVisitTimeByTrustId()(trustId);
 
-    expect(averageVisitTimeSeconds).toEqual(0);
+    expect(averageVisitTime).toEqual("0 mins");
     expect(error).toBeNull();
   });
 
@@ -195,11 +195,11 @@ describe("retrieveAverageVisitTimeByTrustId contract tests", () => {
     });
 
     const {
-      averageVisitTimeSeconds,
+      averageVisitTime,
       error,
     } = await container.getRetrieveAverageVisitTimeByTrustId()(trustId);
 
-    expect(averageVisitTimeSeconds).toEqual(5400);
+    expect(averageVisitTime).toEqual("1 hr, 30 mins");
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveAverageVisitTimeByTrustId.js
+++ b/src/usecases/retrieveAverageVisitTimeByTrustId.js
@@ -1,3 +1,7 @@
+import moment from "moment";
+import momentDurationFormatSetup from "moment-duration-format";
+momentDurationFormatSetup(moment);
+
 const retrieveAverageVisitTimeByTrustId = ({ getDb }) => async (trustId) => {
   if (!trustId) return { error: "A trustId must be provided." };
 
@@ -31,8 +35,13 @@ const retrieveAverageVisitTimeByTrustId = ({ getDb }) => async (trustId) => {
     [trustId]
   );
 
+  const averageVisitTime = moment
+    .duration(parseFloat(averageVisitTimeSeconds), "seconds")
+    .format("h[hr], m[min]");
+
   return {
     averageVisitTimeSeconds: parseFloat(averageVisitTimeSeconds),
+    averageVisitTime,
     error: null,
   };
 };

--- a/src/usecases/retrieveAverageVisitTimeByTrustId.js
+++ b/src/usecases/retrieveAverageVisitTimeByTrustId.js
@@ -37,7 +37,7 @@ const retrieveAverageVisitTimeByTrustId = ({ getDb }) => async (trustId) => {
 
   const averageVisitTime = moment
     .duration(parseFloat(averageVisitTimeSeconds), "seconds")
-    .format("h[hr], m[min]");
+    .format("h [hr], m [min]");
 
   return {
     averageVisitTimeSeconds: parseFloat(averageVisitTimeSeconds),

--- a/src/usecases/retrieveAverageVisitTimeByTrustId.test.js
+++ b/src/usecases/retrieveAverageVisitTimeByTrustId.test.js
@@ -1,0 +1,48 @@
+import retrieveAverageVisitTimeByTrustId from "./retrieveAverageVisitTimeByTrustId";
+
+describe("retrieveAverageVisitTimeByTrustId", () => {
+  const trustId = 1;
+  it("formats the average visit time", async () => {
+    const dbSpy = jest
+      .fn()
+      .mockResolvedValue([{ average_visit_duration_seconds: 12300 }]);
+
+    const container = {
+      async getDb() {
+        return { any: dbSpy };
+      },
+    };
+
+    const { averageVisitTime } = await retrieveAverageVisitTimeByTrustId(
+      container
+    )(trustId);
+
+    expect(averageVisitTime).toEqual("3hrs, 25mins");
+  });
+
+  it("formats the average visit time when the average visit time is NULL", async () => {
+    const dbSpy = jest
+      .fn()
+      .mockResolvedValue([{ average_visit_duration_seconds: null }]);
+
+    const container = {
+      async getDb() {
+        return { any: dbSpy };
+      },
+    };
+
+    const { averageVisitTime } = await retrieveAverageVisitTimeByTrustId(
+      container
+    )(trustId);
+
+    expect(averageVisitTime).toEqual("0mins");
+  });
+
+  it("returns an error if no trustId is provided", async () => {
+    const { error } = await retrieveAverageVisitTimeByTrustId({
+      getDb: jest.fn(),
+    })();
+
+    expect(error).toEqual("A trustId must be provided.");
+  });
+});

--- a/src/usecases/retrieveAverageVisitTimeByTrustId.test.js
+++ b/src/usecases/retrieveAverageVisitTimeByTrustId.test.js
@@ -17,7 +17,7 @@ describe("retrieveAverageVisitTimeByTrustId", () => {
       container
     )(trustId);
 
-    expect(averageVisitTime).toEqual("3hrs, 25mins");
+    expect(averageVisitTime).toEqual("3 hrs, 25 mins");
   });
 
   it("formats the average visit time when the average visit time is NULL", async () => {
@@ -35,7 +35,7 @@ describe("retrieveAverageVisitTimeByTrustId", () => {
       container
     )(trustId);
 
-    expect(averageVisitTime).toEqual("0mins");
+    expect(averageVisitTime).toEqual("0 mins");
   });
 
   it("returns an error if no trustId is provided", async () => {


### PR DESCRIPTION
# What
Shows the average visit time metric on the trust admin dashboard

# Why
So that trust admins can get an overview of their trusts performance

# Screenshots
![ScreenShot 2020-06-29 at 17 10 49](https://user-images.githubusercontent.com/7527178/86029779-8242d700-ba2b-11ea-8d2a-dc95b9cb1a79.png)

# Notes
