### PR TITLE
Average daily visits usecase

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,9 +27,7 @@ module.exports = {
   // coverageDirectory: undefined,
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ["/node_modules/", "/db/docker-data"],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -82,7 +80,7 @@ module.exports = {
   // moduleNameMapper: {},
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ["/db/docker-data"],
 
   // Activates notifications for test results
   // notify: false,
@@ -147,9 +145,7 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ["/node_modules/", "/db/docker-data"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],
@@ -187,7 +183,7 @@ module.exports = {
   // verbose: undefined,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  // watchPathIgnorePatterns: [],
+  watchPathIgnorePatterns: ["/db/docker-data"],
 
   // Whether to use watchman for file crawling
   // watchman: true,

--- a/jest.contract.config.js
+++ b/jest.contract.config.js
@@ -27,9 +27,7 @@ module.exports = {
   // coverageDirectory: undefined,
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ["/node_modules/", "/db/docker-data"],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -82,7 +80,7 @@ module.exports = {
   // moduleNameMapper: {},
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ["/db/docker-data"],
 
   // Activates notifications for test results
   // notify: false,
@@ -147,9 +145,7 @@ module.exports = {
   ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ["/node_modules/", "/db/docker-data"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],
@@ -189,7 +185,7 @@ module.exports = {
   // verbose: undefined,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  // watchPathIgnorePatterns: [],
+  watchPathIgnorePatterns: ["/db/docker-data"],
 
   // Whether to use watchman for file crawling
   // watchman: true,

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -38,6 +38,7 @@ import captureEvent from "../usecases/captureEvent";
 import retrieveAverageParticipantsInVisit from "../usecases/retrieveAverageParticipantsInVisit";
 import retrieveAverageVisitTimeByTrustId from "../usecases/retrieveAverageVisitTimeByTrustId";
 import retrieveWardVisitTotalsStartDateByTrustId from "../usecases/retrieveWardVisitTotalsStartDateByTrustId";
+import retrieveAverageVisitsPerDay from "../usecases/retrieveAverageVisitsPerDay";
 
 class AppContainer {
   getDb = () => {
@@ -198,6 +199,10 @@ class AppContainer {
 
   getRetrieveWardVisitTotalsStartDateByTrustId = () => {
     return retrieveWardVisitTotalsStartDateByTrustId(this);
+  };
+
+  getRetrieveAverageVisitsPerDay = () => {
+    return retrieveAverageVisitsPerDay(this);
   };
 }
 

--- a/src/usecases/retrieveAverageVisitsPerDay.contractTest.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.contractTest.js
@@ -1,5 +1,5 @@
 import AppContainer from "../containers/AppContainer";
-import { setupTrust } from "../testUtils/factories";
+import { setupTrust, setupHospital, setupWard } from "../testUtils/factories";
 import { v4 as uuidv4 } from "uuid";
 
 describe("retrieveAverageVisitsPerDay contract tests", () => {
@@ -9,12 +9,12 @@ describe("retrieveAverageVisitsPerDay contract tests", () => {
     // A trust with a visit with 1 participant
     const { trustId } = await setupTrust();
 
-    const { hospitalId } = await container.getCreateHospital()({
+    const { hospitalId } = await setupHospital({
       name: "Test Hospital",
       trustId: trustId,
     });
 
-    const { wardId } = await container.getCreateWard()({
+    const { wardId } = await setupWard({
       name: "Test Ward 1",
       code: "wardCode1",
       hospitalId: hospitalId,
@@ -49,12 +49,12 @@ describe("retrieveAverageVisitsPerDay contract tests", () => {
     // A trust with a visit with 1 participant, one with 2 participants and
     // another with 1 participant
 
-    const { hospitalId: hospitalId2 } = await container.getCreateHospital()({
+    const { hospitalId: hospitalId2 } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
     });
 
-    const { wardId: wardId2 } = await container.getCreateWard()({
+    const { wardId: wardId2 } = await setupWard({
       name: "Test Ward 2",
       code: "wardCode2",
       hospitalId: hospitalId2,

--- a/src/usecases/retrieveAverageVisitsPerDay.contractTest.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.contractTest.js
@@ -1,0 +1,179 @@
+import AppContainer from "../containers/AppContainer";
+import { setupTrust } from "../testUtils/factories";
+import { v4 as uuidv4 } from "uuid";
+
+describe("retrieveAverageVisitsPerDay contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns the average number of visits per day for a trust", async () => {
+    // A trust with a visit with 1 participant
+    const { trustId } = await setupTrust();
+
+    const { hospitalId } = await container.getCreateHospital()({
+      name: "Test Hospital",
+      trustId: trustId,
+    });
+
+    const { wardId } = await container.getCreateWard()({
+      name: "Test Ward 1",
+      code: "wardCode1",
+      hospitalId: hospitalId,
+      trustId: trustId,
+    });
+
+    const { id: visitId } = await container.getCreateVisit()({
+      patientName: "Glimmer",
+      contactEmail: "bow@example.com",
+      contactName: "Bow",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "testCallId",
+      provider: "TESTPROVIDER",
+      wardId: wardId,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId,
+      sessionId,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId,
+      sessionId,
+    });
+
+    // A trust with a visit with 1 participant, one with 2 participants and
+    // another with 1 participant
+
+    const { hospitalId: hospitalId2 } = await container.getCreateHospital()({
+      name: "Test Hospital 2",
+      trustId: trustId,
+    });
+
+    const { wardId: wardId2 } = await container.getCreateWard()({
+      name: "Test Ward 2",
+      code: "wardCode2",
+      hospitalId: hospitalId2,
+      trustId: trustId,
+    });
+
+    const { id: visitId2 } = await container.getCreateVisit()({
+      patientName: "Adora",
+      contactEmail: "catra@example.com",
+      contactName: "Catra",
+      callTime: new Date("2020-06-02 13:00"),
+      callId: "testCallId2",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId2 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    const { id: visitId3 } = await container.getCreateVisit()({
+      patientName: "Scorpia",
+      contactEmail: "perfuma@example.com",
+      contactName: "Perfuma",
+      callTime: new Date("2020-06-02 13:00"),
+      callId: "testCallId3",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId3 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    const sessionId4 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId4,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId3,
+      sessionId: sessionId4,
+    });
+
+    const { id: visitId4 } = await container.getCreateVisit()({
+      patientName: "Mermista",
+      contactEmail: "seahawk@example.com",
+      contactName: "Seahawk",
+      callTime: new Date("2020-06-03 13:00"),
+      callId: "testCallId4",
+      provider: "TESTPROVIDER",
+      wardId: wardId2,
+      callPassword: "testCallPassword",
+    });
+
+    const sessionId5 = uuidv4();
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId4,
+      sessionId: sessionId5,
+    });
+
+    await container.getCaptureEvent()({
+      action: "leave-visit",
+      visitId: visitId4,
+      sessionId: sessionId5,
+    });
+
+    const {
+      averageVisitsPerDay,
+      error,
+    } = await container.getRetrieveAverageVisitsPerDay()(trustId);
+
+    expect(averageVisitsPerDay).toEqual(1.3);
+    expect(error).toBeNull();
+  });
+
+  it("returns 0 if there are no events for a trust", async () => {
+    const { trustId } = await setupTrust();
+
+    const {
+      averageVisitsPerDay,
+      error,
+    } = await container.getRetrieveAverageVisitsPerDay()(trustId);
+
+    expect(averageVisitsPerDay).toEqual(0);
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no trustId is provided", async () => {
+    const { error } = await container.getRetrieveAverageVisitsPerDay()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveAverageVisitsPerDay.contractTest.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.contractTest.js
@@ -65,7 +65,7 @@ describe("retrieveAverageVisitsPerDay contract tests", () => {
       patientName: "Adora",
       contactEmail: "catra@example.com",
       contactName: "Catra",
-      callTime: new Date("2020-06-02 13:00"),
+      callTime: new Date("2020-06-03 13:00"),
       callId: "testCallId2",
       provider: "TESTPROVIDER",
       wardId: wardId2,
@@ -90,7 +90,7 @@ describe("retrieveAverageVisitsPerDay contract tests", () => {
       patientName: "Scorpia",
       contactEmail: "perfuma@example.com",
       contactName: "Perfuma",
-      callTime: new Date("2020-06-02 13:00"),
+      callTime: new Date("2020-06-03 13:00"),
       callId: "testCallId3",
       provider: "TESTPROVIDER",
       wardId: wardId2,
@@ -125,7 +125,8 @@ describe("retrieveAverageVisitsPerDay contract tests", () => {
       sessionId: sessionId4,
     });
 
-    const { id: visitId4 } = await container.getCreateVisit()({
+    // Has no events so shouldn't be counted
+    await container.getCreateVisit()({
       patientName: "Mermista",
       contactEmail: "seahawk@example.com",
       contactName: "Seahawk",
@@ -136,26 +137,15 @@ describe("retrieveAverageVisitsPerDay contract tests", () => {
       callPassword: "testCallPassword",
     });
 
-    const sessionId5 = uuidv4();
-
-    await container.getCaptureEvent()({
-      action: "join-visit",
-      visitId: visitId4,
-      sessionId: sessionId5,
-    });
-
-    await container.getCaptureEvent()({
-      action: "leave-visit",
-      visitId: visitId4,
-      sessionId: sessionId5,
-    });
-
     const {
       averageVisitsPerDay,
       error,
-    } = await container.getRetrieveAverageVisitsPerDay()(trustId);
+    } = await container.getRetrieveAverageVisitsPerDay()(
+      trustId,
+      new Date("2020-06-03 13:00")
+    );
 
-    expect(averageVisitsPerDay).toEqual(1.3);
+    expect(averageVisitsPerDay).toEqual(1);
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveAverageVisitsPerDay.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.js
@@ -1,22 +1,42 @@
-const retrieveAverageVisitsPerDay = ({ getDb }) => async (trustId) => {
+const retrieveAverageVisitsPerDay = ({ getDb }) => async (trustId, endDate) => {
   if (!trustId) return { error: "A trustId must be provided." };
 
   const db = await getDb();
-  const [{ average_visits_per_day: averageVisitsPerDay }] = await db.any(
-    `SELECT to_char(COALESCE(AVG(visits), 0), '999D9') as average_visits_per_day FROM(
-      SELECT COUNT (distinct events.visit_id ) AS visits
+  const results = await db.any(
+    `SELECT COUNT (distinct events.visit_id) AS visits, date(scheduled_calls_table.call_time) as call_date
       FROM events
       LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id
       LEFT JOIN wards ON scheduled_calls_table.ward_id = wards.id
       LEFT JOIN trusts ON wards.trust_id = trusts.id
       WHERE trusts.id = $1 AND events.action='join-visit'
       GROUP BY date(scheduled_calls_table.call_time)
-    ) daily_visits`,
+      ORDER BY call_date ASC`,
     trustId
   );
 
+  let average = 0;
+  if (results.length > 0) {
+    const startDate = results[0].call_date;
+    startDate.setHours(0);
+    startDate.setMinutes(0);
+    startDate.setSeconds(0);
+
+    endDate = endDate ?? new Date();
+    endDate.setHours(23);
+    endDate.setMinutes(59);
+    endDate.setSeconds(59);
+
+    const totalVisits = results.reduce((total, result) => {
+      return total + parseInt(result.visits);
+    }, 0);
+
+    const numberOfDays = Math.round((endDate - startDate) / 86400000); //86400000 = milliseconds in a day
+
+    average = totalVisits / numberOfDays;
+  }
+
   return {
-    averageVisitsPerDay: parseFloat(averageVisitsPerDay),
+    averageVisitsPerDay: average,
     error: null,
   };
 };

--- a/src/usecases/retrieveAverageVisitsPerDay.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.js
@@ -1,0 +1,24 @@
+const retrieveAverageVisitsPerDay = ({ getDb }) => async (trustId) => {
+  if (!trustId) return { error: "A trustId must be provided." };
+
+  const db = await getDb();
+  const [{ average_visits_per_day: averageVisitsPerDay }] = await db.any(
+    `SELECT to_char(COALESCE(AVG(visits), 0), '999D9') as average_visits_per_day FROM(
+      SELECT COUNT (distinct events.visit_id ) AS visits
+      FROM events
+      LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id
+      LEFT JOIN wards ON scheduled_calls_table.ward_id = wards.id
+      LEFT JOIN trusts ON wards.trust_id = trusts.id
+      WHERE trusts.id = $1 AND events.action='join-visit'
+      GROUP BY date(scheduled_calls_table.call_time)
+    ) daily_visits`,
+    trustId
+  );
+
+  return {
+    averageVisitsPerDay: parseFloat(averageVisitsPerDay),
+    error: null,
+  };
+};
+
+export default retrieveAverageVisitsPerDay;

--- a/src/usecases/retrieveAverageVisitsPerDay.test.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.test.js
@@ -1,0 +1,50 @@
+import retrieveAverageVisitsPerDay from "./retrieveAverageVisitsPerDay";
+
+describe("retrieveAverageVisitsPerDay", () => {
+  const trustId = 1;
+
+  let dbAnySpy;
+
+  beforeEach(() => {
+    dbAnySpy = jest.fn().mockResolvedValue([{ average_visits_per_day: "3.5" }]);
+  });
+
+  it("returns an error if a trustId is not provided", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    const { error } = await retrieveAverageVisitsPerDay(container)();
+
+    expect(error).toEqual("A trustId must be provided.");
+  });
+
+  it("retrieves events from the database with the trustId", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    await retrieveAverageVisitsPerDay(container)(trustId);
+
+    expect(dbAnySpy).toHaveBeenCalledWith(expect.anything(), trustId);
+  });
+
+  it("returns the average number of participants in a visit", async () => {
+    const container = {
+      async getDb() {
+        return { any: dbAnySpy };
+      },
+    };
+
+    const { averageVisitsPerDay, error } = await retrieveAverageVisitsPerDay(
+      container
+    )(trustId);
+
+    expect(averageVisitsPerDay).toEqual(3.5);
+    expect(error).toBeNull();
+  });
+});

--- a/src/usecases/retrieveAverageVisitsPerDay.test.js
+++ b/src/usecases/retrieveAverageVisitsPerDay.test.js
@@ -6,7 +6,11 @@ describe("retrieveAverageVisitsPerDay", () => {
   let dbAnySpy;
 
   beforeEach(() => {
-    dbAnySpy = jest.fn().mockResolvedValue([{ average_visits_per_day: "3.5" }]);
+    dbAnySpy = jest.fn().mockResolvedValue([
+      { visits: "3", call_date: new Date(2020, 6, 1) },
+      { visits: "2", call_date: new Date(2020, 6, 2) },
+      { visits: "1", call_date: new Date(2020, 6, 3) },
+    ]);
   });
 
   it("returns an error if a trustId is not provided", async () => {
@@ -42,9 +46,9 @@ describe("retrieveAverageVisitsPerDay", () => {
 
     const { averageVisitsPerDay, error } = await retrieveAverageVisitsPerDay(
       container
-    )(trustId);
+    )(trustId, new Date(2020, 6, 3));
 
-    expect(averageVisitsPerDay).toEqual(3.5);
+    expect(averageVisitsPerDay).toEqual(2);
     expect(error).toBeNull();
   });
 });


### PR DESCRIPTION
# What
Adds a usecase for calculating the average daily visits
# Why
To retrieve the average daily visits for a trust on the metrics page
# Screenshots

# Notes
This includes the jest config changes to ignore the docker-data directory because I couldn't do a PR earlier.