### PR TITLE
Add comma separator to number of booked visits on trust admin dashboard

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -61,7 +61,7 @@ describe("trust-admin", () => {
     ],
   });
 
-  const retrieveWardVisitTotalsSpy = jest.fn().mockReturnValue({ total: 5 });
+  const retrieveWardVisitTotalsSpy = jest.fn().mockReturnValue({ total: 1234 });
 
   const retrieveHospitalVisitTotals = jest.fn().mockReturnValue(hospitals);
 
@@ -139,7 +139,7 @@ describe("trust-admin", () => {
       });
 
       expect(retrieveWardVisitTotalsSpy).toHaveBeenCalledWith(trustId);
-      expect(props.visitsScheduled).toEqual(5);
+      expect(props.visitsScheduled).toEqual("1,234");
     });
 
     it("retrieves usage stats", async () => {

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -210,7 +210,7 @@ export const getServerSideProps = propsWithContainer(
         trust: { name: trust?.name },
         wardVisitTotalsStartDate,
         averageParticipantsInVisit,
-        visitsScheduled: retrieveWardVisitTotals.total,
+        visitsScheduled: retrieveWardVisitTotals.total.toLocaleString(),
         averageVisitTime,
         error,
       },


### PR DESCRIPTION
# What

Add comma separator to number of booked visits on trust admin dashboard.

# Why

This improves readability and is the recommended way of displaying
numbers over 999 in the NHS Design System - Content Style Guide.

See https://service-manual.nhs.uk/content/numbers-measurements-dates-time#numbers

# Screenshots

_Fudged the screenshots but gives you an idea._

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86112217-96d0af00-babf-11ea-94e8-7222bc506ef3.png)|![image](https://user-images.githubusercontent.com/42817036/86112167-88829300-babf-11ea-8ac3-bf91a3dfe3cc.png)

# Notes

N/A