### PR TITLE
Add other reporting start date on the trust admin dashboard

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -75,11 +75,11 @@ describe("trust-admin", () => {
 
   const retrieveWardVisitTotalsStartDateByTrustId = jest
     .fn()
-    .mockReturnValue({ startDate: new Date("2020-04-01"), error: null });
+    .mockReturnValue({ startDate: "1 April 2020", error: null });
 
   const retrieveReportingStartDateByTrustId = jest
     .fn()
-    .mockReturnValue({ startDate: new Date("2020-05-01"), error: null });
+    .mockReturnValue({ startDate: "1 May 2020", error: null });
 
   const container = {
     getRetrieveWards: () => getRetrieveWardsSpy,
@@ -171,7 +171,7 @@ describe("trust-admin", () => {
     });
 
     it("retrieves usage stats when fewer than 3 hospitals", async () => {
-      const hospitals = {
+      const threeHospitals = {
         hospitals: [{ id: 1, name: "Hospital 1", totalVisits: 5 }],
         leastVisited: [{ id: 1, name: "Hospital 1", totalVisits: 5 }],
         mostVisited: [{ id: 1, name: "Hospital 1", totalVisits: 5 }],
@@ -182,18 +182,18 @@ describe("trust-admin", () => {
         res,
         container: Object.assign({}, container, {
           getRetrieveHospitalVisitTotals: () =>
-            jest.fn().mockReturnValue(hospitals),
+            jest.fn().mockReturnValue(threeHospitals),
         }),
       });
 
       expect(props.leastVisited.length).toBe(1);
       expect(props.mostVisited.length).toBe(1);
-      expect(props.leastVisited).toEqual(hospitals.leastVisited);
-      expect(props.mostVisited).toEqual(hospitals.mostVisited);
+      expect(props.leastVisited).toEqual(threeHospitals.leastVisited);
+      expect(props.mostVisited).toEqual(threeHospitals.mostVisited);
     });
 
     it("sets an error in props if ward error", async () => {
-      const getRetrieveWardsSpy = jest.fn(async () => ({
+      const getRetrieveWardsSpyError = jest.fn(async () => ({
         wards: null,
         error: "Error!",
       }));
@@ -202,7 +202,7 @@ describe("trust-admin", () => {
         req: authenticatedReq,
         res,
         container: Object.assign({}, container, {
-          getRetrieveWards: () => getRetrieveWardsSpy,
+          getRetrieveWards: () => getRetrieveWardsSpyError,
         }),
       });
 
@@ -222,7 +222,7 @@ describe("trust-admin", () => {
     });
 
     it("sets an error in props if trust error", async () => {
-      const retrieveTrustByIdSpy = jest.fn(async () => ({
+      const retrieveTrustByIdSpyError = jest.fn(async () => ({
         trust: null,
         error: "Error!",
       }));
@@ -231,7 +231,7 @@ describe("trust-admin", () => {
         req: authenticatedReq,
         res,
         container: Object.assign({}, container, {
-          getRetrieveTrustById: () => retrieveTrustByIdSpy,
+          getRetrieveTrustById: () => retrieveTrustByIdSpyError,
         }),
       });
 

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -77,6 +77,10 @@ describe("trust-admin", () => {
     .fn()
     .mockReturnValue({ startDate: new Date("2020-04-01"), error: null });
 
+  const retrieveReportingStartDateByTrustId = jest
+    .fn()
+    .mockReturnValue({ startDate: new Date("2020-05-01"), error: null });
+
   const container = {
     getRetrieveWards: () => getRetrieveWardsSpy,
     getRetrieveTrustById: () => retrieveTrustByIdSpy,
@@ -89,6 +93,8 @@ describe("trust-admin", () => {
       retrieveAverageVisitTimeByTrustId,
     getRetrieveWardVisitTotalsStartDateByTrustId: () =>
       retrieveWardVisitTotalsStartDateByTrustId,
+    getRetrieveReportingStartDateByTrustId: () =>
+      retrieveReportingStartDateByTrustId,
     getTokenProvider: () => tokenProvider,
   };
 
@@ -302,6 +308,37 @@ describe("trust-admin", () => {
           ...container,
           getRetrieveWardVisitTotalsStartDateByTrustId: () =>
             retrieveWardVisitTotalsStartDateByTrustIdError,
+        },
+      });
+
+      expect(props.error).toEqual("Error!");
+    });
+
+    it("retrieves the starting date for events reporting", async () => {
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container,
+      });
+
+      expect(retrieveReportingStartDateByTrustId).toHaveBeenCalledWith(trustId);
+      expect(props.reportingStartDate).toEqual("1 May 2020");
+      expect(props.error).toBeNull();
+    });
+
+    it("sets an error in props if starting date for events reporting error", async () => {
+      const retrieveReportingStartDateByTrustIdError = jest.fn(async () => ({
+        startDate: null,
+        error: "Error!",
+      }));
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        container: {
+          ...container,
+          getRetrieveReportingStartDateByTrustId: () =>
+            retrieveReportingStartDateByTrustIdError,
         },
       });
 

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -146,15 +146,17 @@ const TrustAdmin = ({
               </div>
             </GridColumn>
           </GridRow>
-          {(wardVisitTotalsStartDate || reportingStartDate) && (
-            <ReviewDate>
-              {wardVisitTotalsStartDate &&
-                `Start date for booked visits reporting: ${wardVisitTotalsStartDate}`}
-              {wardVisitTotalsStartDate && reportingStartDate && <br />}
-              {reportingStartDate &&
-                `Start date for other reporting: ${reportingStartDate}`}
-            </ReviewDate>
-          )}
+
+          <ReviewDate
+            className="nhsuk-u-margin-bottom-0"
+            beforeDateText="Start date for booked visits reporting: "
+            date={wardVisitTotalsStartDate}
+          />
+          <ReviewDate
+            className="nhsuk-u-margin-0"
+            beforeDateText="Start date for other reporting: "
+            date={reportingStartDate}
+          />
         </GridColumn>
       </GridRow>
     </Layout>

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -10,7 +10,6 @@ import Text from "../src/components/Text";
 import AnchorLink from "../src/components/AnchorLink";
 import ReviewDate from "../src/components/ReviewDate";
 import { TRUST_ADMIN } from "../src/helpers/userTypes";
-import formatDate from "../src/helpers/formatDate";
 
 const TrustAdmin = ({
   error,
@@ -186,20 +185,18 @@ export const getServerSideProps = propsWithContainer(
     } = await container.getRetrieveAverageParticipantsInVisit()(
       authenticationToken.trustId
     );
-    const retrieveWardVisitTotalsStartDateResponse = await container.getRetrieveWardVisitTotalsStartDateByTrustId()(
+    const {
+      startDate: wardVisitTotalsStartDate,
+      error: wardVisitTotalsStartDateError,
+    } = await container.getRetrieveWardVisitTotalsStartDateByTrustId()(
       authenticationToken.trustId
     );
-    const retrieveReportingStartDateResponse = await container.getRetrieveReportingStartDateByTrustId()(
+    const {
+      startDate: reportingStartDate,
+      error: reportingStartDateError,
+    } = await container.getRetrieveReportingStartDateByTrustId()(
       authenticationToken.trustId
     );
-
-    const wardVisitTotalsStartDate = retrieveWardVisitTotalsStartDateResponse.startDate
-      ? formatDate(retrieveWardVisitTotalsStartDateResponse.startDate)
-      : null;
-
-    const reportingStartDate = retrieveReportingStartDateResponse.startDate
-      ? formatDate(retrieveReportingStartDateResponse.startDate)
-      : null;
 
     const {
       averageVisitTime,
@@ -212,8 +209,8 @@ export const getServerSideProps = propsWithContainer(
       wardError ||
       trustError ||
       averageParticipantsInVisitError ||
-      retrieveWardVisitTotalsStartDateResponse.error ||
-      retrieveReportingStartDateResponse.error ||
+      wardVisitTotalsStartDateError ||
+      reportingStartDateError ||
       averageVisitTimeSecondsError;
 
     return {

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -21,6 +21,7 @@ const TrustAdmin = ({
   trust,
   averageParticipantsInVisit,
   wardVisitTotalsStartDate,
+  reportingStartDate,
   visitsScheduled,
   averageVisitTime,
 }) => {
@@ -145,9 +146,13 @@ const TrustAdmin = ({
               </div>
             </GridColumn>
           </GridRow>
-          {wardVisitTotalsStartDate && (
+          {(wardVisitTotalsStartDate || reportingStartDate) && (
             <ReviewDate>
-              Reporting for booked visits start date: {wardVisitTotalsStartDate}
+              {wardVisitTotalsStartDate &&
+                `Start date for booked visits reporting: ${wardVisitTotalsStartDate}`}
+              {wardVisitTotalsStartDate && reportingStartDate && <br />}
+              {reportingStartDate &&
+                `Start date for other reporting: ${reportingStartDate}`}
             </ReviewDate>
           )}
         </GridColumn>
@@ -182,9 +187,16 @@ export const getServerSideProps = propsWithContainer(
     const retrieveWardVisitTotalsStartDateResponse = await container.getRetrieveWardVisitTotalsStartDateByTrustId()(
       authenticationToken.trustId
     );
+    const retrieveReportingStartDateResponse = await container.getRetrieveReportingStartDateByTrustId()(
+      authenticationToken.trustId
+    );
 
     const wardVisitTotalsStartDate = retrieveWardVisitTotalsStartDateResponse.startDate
       ? formatDate(retrieveWardVisitTotalsStartDateResponse.startDate)
+      : null;
+
+    const reportingStartDate = retrieveReportingStartDateResponse.startDate
+      ? formatDate(retrieveReportingStartDateResponse.startDate)
       : null;
 
     const {
@@ -199,6 +211,7 @@ export const getServerSideProps = propsWithContainer(
       trustError ||
       averageParticipantsInVisitError ||
       retrieveWardVisitTotalsStartDateResponse.error ||
+      retrieveReportingStartDateResponse.error ||
       averageVisitTimeSecondsError;
 
     return {
@@ -209,6 +222,7 @@ export const getServerSideProps = propsWithContainer(
         mostVisited: retrieveHospitalVisitTotals.mostVisited,
         trust: { name: trust?.name },
         wardVisitTotalsStartDate,
+        reportingStartDate,
         averageParticipantsInVisit,
         visitsScheduled: retrieveWardVisitTotals.total.toLocaleString(),
         averageVisitTime,

--- a/src/components/ReviewDate/index.js
+++ b/src/components/ReviewDate/index.js
@@ -1,10 +1,17 @@
 import React from "react";
 import classNames from "classnames";
 
-const ReviewDate = ({ children, className }) => (
-  <div className={classNames("nhsuk-review-date", className)}>
-    <p className="nhsuk-body-s">{children}</p>
-  </div>
+const ReviewDate = ({ beforeDateText = "", date, className }) => (
+  <>
+    {date && (
+      <div className={classNames("nhsuk-review-date", className)}>
+        <p className={classNames("nhsuk-body-s", className)}>
+          {beforeDateText}
+          {date}
+        </p>
+      </div>
+    )}
+  </>
 );
 
 export default ReviewDate;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -39,6 +39,7 @@ import retrieveAverageParticipantsInVisit from "../usecases/retrieveAverageParti
 import retrieveAverageVisitTimeByTrustId from "../usecases/retrieveAverageVisitTimeByTrustId";
 import retrieveWardVisitTotalsStartDateByTrustId from "../usecases/retrieveWardVisitTotalsStartDateByTrustId";
 import retrieveAverageVisitsPerDay from "../usecases/retrieveAverageVisitsPerDay";
+import retrieveReportingStartDateByTrustId from "../usecases/retrieveReportingStartDateByTrustId";
 
 class AppContainer {
   getDb = () => {
@@ -203,6 +204,10 @@ class AppContainer {
 
   getRetrieveAverageVisitsPerDay = () => {
     return retrieveAverageVisitsPerDay(this);
+  };
+
+  getRetrieveReportingStartDateByTrustId = () => {
+    return retrieveReportingStartDateByTrustId(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -103,4 +103,8 @@ describe("AppContainer", () => {
       container.getRetrieveWardVisitTotalsStartDateByTrustId()
     ).toBeDefined();
   });
+
+  it("returns getRetrieveReportingStartDateByTrustId", () => {
+    expect(container.getRetrieveReportingStartDateByTrustId()).toBeDefined();
+  });
 });

--- a/src/usecases/retrieveReportingStartDateByTrustId.contractTest.js
+++ b/src/usecases/retrieveReportingStartDateByTrustId.contractTest.js
@@ -74,7 +74,7 @@ describe("retrieveReportingStartDateByTrustId contract tests", () => {
       error,
     } = await container.getRetrieveReportingStartDateByTrustId()(trustId1);
 
-    expect(startDate).toEqual(new Date("2020-06-01 13:00"));
+    expect(startDate).toEqual("1 June 2020");
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveReportingStartDateByTrustId.contractTest.js
+++ b/src/usecases/retrieveReportingStartDateByTrustId.contractTest.js
@@ -1,0 +1,100 @@
+import AppContainer from "../containers/AppContainer";
+import {
+  setupTrust,
+  setupVisit,
+  setupWardWithinHospitalAndTrust,
+} from "../testUtils/factories";
+import { v4 as uuidv4 } from "uuid";
+import MockDate from "mockdate";
+
+describe("retrieveReportingStartDateByTrustId contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns the date of when reporting started for a trust", async () => {
+    // A trust with 2 events
+    const {
+      wardId: wardId1,
+      trustId: trustId1,
+    } = await setupWardWithinHospitalAndTrust({
+      index: 1,
+    });
+
+    const { id: visitId } = await setupVisit({
+      wardId: wardId1,
+      callId: "callId1",
+    });
+
+    const sessionId = uuidv4();
+
+    MockDate.set(new Date("2020-06-01 13:00"));
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId,
+      sessionId,
+    });
+
+    const { id: visitId2 } = await setupVisit({
+      wardId: wardId1,
+      callId: "callId2",
+    });
+
+    const sessionId2 = uuidv4();
+
+    MockDate.set(new Date("2020-06-15 13:00"));
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId2,
+      sessionId: sessionId2,
+    });
+
+    // Another trust with 1 event
+    const { wardId: wardId2 } = await setupWardWithinHospitalAndTrust({
+      index: 2,
+    });
+
+    const { id: visitId3 } = await setupVisit({
+      wardId: wardId2,
+      callId: "callId3",
+    });
+
+    const sessionId3 = uuidv4();
+
+    MockDate.set(new Date("2020-06-01 13:00"));
+
+    await container.getCaptureEvent()({
+      action: "join-visit",
+      visitId: visitId3,
+      sessionId: sessionId3,
+    });
+
+    const {
+      startDate,
+      error,
+    } = await container.getRetrieveReportingStartDateByTrustId()(trustId1);
+
+    expect(startDate).toEqual(new Date("2020-06-01 13:00"));
+    expect(error).toBeNull();
+  });
+
+  it("returns null if there are no events for a trust", async () => {
+    const { trustId } = await setupTrust();
+
+    const {
+      startDate,
+      error,
+    } = await container.getRetrieveReportingStartDateByTrustId()(trustId);
+
+    expect(startDate).toBeNull();
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no trustId is provided", async () => {
+    const {
+      error,
+    } = await container.getRetrieveReportingStartDateByTrustId()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveReportingStartDateByTrustId.js
+++ b/src/usecases/retrieveReportingStartDateByTrustId.js
@@ -1,0 +1,29 @@
+const retrieveReportingStartDateByTrustId = ({ getDb }) => async (trustId) => {
+  if (!trustId) return { error: "A trustId must be provided." };
+
+  const db = await getDb();
+  try {
+    const { start_date: startDate } = await db.one(
+      `SELECT events.time AS start_date
+      FROM events
+      LEFT JOIN scheduled_calls_table ON events.visit_id = scheduled_calls_table.id
+      LEFT JOIN wards ON scheduled_calls_table.ward_id = wards.id
+      LEFT JOIN hospitals ON wards.hospital_id = hospitals.id
+      LEFT JOIN trusts ON hospitals.trust_id = trusts.id
+      WHERE trusts.id = $1
+      ORDER BY time ASC
+      LIMIT 1`,
+      trustId
+    );
+
+    return { startDate, error: null };
+  } catch (error) {
+    if (error.name === "QueryResultError") {
+      return { startDate: null, error: null };
+    } else {
+      return { startDate: null, error: error.message };
+    }
+  }
+};
+
+export default retrieveReportingStartDateByTrustId;

--- a/src/usecases/retrieveReportingStartDateByTrustId.js
+++ b/src/usecases/retrieveReportingStartDateByTrustId.js
@@ -1,3 +1,5 @@
+import formatDate from "../helpers/formatDate";
+
 const retrieveReportingStartDateByTrustId = ({ getDb }) => async (trustId) => {
   if (!trustId) return { error: "A trustId must be provided." };
 
@@ -16,7 +18,7 @@ const retrieveReportingStartDateByTrustId = ({ getDb }) => async (trustId) => {
       trustId
     );
 
-    return { startDate, error: null };
+    return { startDate: formatDate(startDate), error: null };
   } catch (error) {
     if (error.name === "QueryResultError") {
       return { startDate: null, error: null };

--- a/src/usecases/retrieveReportingStartDateByTrustId.test.js
+++ b/src/usecases/retrieveReportingStartDateByTrustId.test.js
@@ -1,0 +1,22 @@
+import retrieveReportingStartDateByTrustId from "./retrieveReportingStartDateByTrustId";
+
+describe("retrieveReportingStartDateByTrustId", () => {
+  it("returns the error if database throws an error", async () => {
+    const trustId = 1;
+    const container = {
+      async getDb() {
+        return {
+          one: jest.fn().mockImplementation(() => {
+            throw new Error("Error!");
+          }),
+        };
+      },
+    };
+
+    const { error } = await retrieveReportingStartDateByTrustId(container)(
+      trustId
+    );
+
+    expect(error).toEqual("Error!");
+  });
+});

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.contractTest.js
@@ -40,7 +40,7 @@ describe("retrieveWardVisitTotalsStartDateByTrustId contract tests", () => {
       trustId1
     );
 
-    expect(startDate).toEqual(new Date(2020, 6, 1));
+    expect(startDate).toEqual("1 July 2020");
     expect(error).toBeNull();
   });
 

--- a/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.js
+++ b/src/usecases/retrieveWardVisitTotalsStartDateByTrustId.js
@@ -1,3 +1,5 @@
+import formatDate from "../helpers/formatDate";
+
 const retrieveWardVisitTotalsStartDateByTrustId = ({ getDb }) => async (
   trustId
 ) => {
@@ -17,7 +19,7 @@ const retrieveWardVisitTotalsStartDateByTrustId = ({ getDb }) => async (
       trustId
     );
 
-    return { startDate, error: null };
+    return { startDate: formatDate(startDate), error: null };
   } catch (error) {
     if (error.name === "QueryResultError") {
       return { startDate: null, error: null };


### PR DESCRIPTION
# What

Add reporting start date on the trust admin dashboard.

# Why

To provide context for when reporting for metrics such as average visit time. average participants, etc. started.

# Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86151798-1e85e000-baf7-11ea-967a-d67f54e56198.png)|![image](https://user-images.githubusercontent.com/42817036/86151756-10d05a80-baf7-11ea-8aae-95032252a5fe.png)

# Notes

N/A