### PR TITLE
Add survey URL support to hospital usecases

### DIFF
--- a/src/usecases/createHospital.contractTest.js
+++ b/src/usecases/createHospital.contractTest.js
@@ -11,6 +11,7 @@ describe("createHospital contract tests", () => {
       trustId,
       name: "Test Hospital",
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     });
 
     const { hospital, error } = await container.getRetrieveHospitalById()(
@@ -23,6 +24,7 @@ describe("createHospital contract tests", () => {
       id: hospitalId,
       name: "Test Hospital",
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     });
   });
 });

--- a/src/usecases/createHospital.js
+++ b/src/usecases/createHospital.js
@@ -2,6 +2,7 @@ const createHospital = ({ getDb }) => async ({
   name,
   trustId,
   supportUrl = null,
+  surveyUrl = null,
 }) => {
   const db = await getDb();
 
@@ -9,11 +10,11 @@ const createHospital = ({ getDb }) => async ({
     console.log("Creating hospital for", name);
     const createdHospital = await db.one(
       `INSERT INTO hospitals
-          (id, name, trust_id, support_url)
-          VALUES (default, $1, $2, $3)
+          (id, name, trust_id, support_url, survey_url)
+          VALUES (default, $1, $2, $3, $4)
           RETURNING id
         `,
-      [name, trustId, supportUrl]
+      [name, trustId, supportUrl, surveyUrl]
     );
 
     return {

--- a/src/usecases/createHospital.test.js
+++ b/src/usecases/createHospital.test.js
@@ -23,6 +23,7 @@ describe("createHospital", () => {
       "Defoe Hospital",
       2,
       null,
+      null,
     ]);
   });
 
@@ -40,6 +41,7 @@ describe("createHospital", () => {
       name: "Defoe Hospital",
       trustId: 2,
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     };
 
     const { hospitalId, error } = await createHospital(container)(request);
@@ -49,6 +51,7 @@ describe("createHospital", () => {
       "Defoe Hospital",
       2,
       "https://www.support.example.com",
+      "https://www.survey.example.com",
     ]);
   });
 

--- a/src/usecases/retrieveHospitalById.js
+++ b/src/usecases/retrieveHospitalById.js
@@ -12,6 +12,7 @@ const retrieveHospitalById = ({ getDb }) => async (hospitalId, trustId) => {
         id: hospital.id,
         name: hospital.name,
         supportUrl: hospital.support_url,
+        surveyUrl: hospital.survey_url,
       },
       error: null,
     };

--- a/src/usecases/retrieveHospitalById.test.js
+++ b/src/usecases/retrieveHospitalById.test.js
@@ -9,6 +9,7 @@ describe("retrieveHospitalById", () => {
             id: 1,
             name: "Test Hospital",
             support_url: "https://www.support.example.com",
+            survey_url: "https://www.survey.example.com",
           }),
         };
       },
@@ -27,6 +28,7 @@ describe("retrieveHospitalById", () => {
       id: hospitalId,
       name: "Test Hospital",
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     });
   });
 

--- a/src/usecases/updateHospital.contractTest.js
+++ b/src/usecases/updateHospital.contractTest.js
@@ -17,6 +17,7 @@ describe("updateHospital contract tests", () => {
       name: "Test Hospital 2",
       id: hospitalId,
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     };
 
     const { id: updatedHospitalId, error } = await updateHospital(container)(
@@ -32,6 +33,7 @@ describe("updateHospital contract tests", () => {
       id: hospitalId,
       name: "Test Hospital 2",
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     });
 
     expect(error).toBeNull();

--- a/src/usecases/updateHospital.js
+++ b/src/usecases/updateHospital.js
@@ -1,15 +1,20 @@
-export default ({ getDb }) => async ({ name, id, supportUrl = null }) => {
+export default ({ getDb }) => async ({
+  name,
+  id,
+  supportUrl = null,
+  surveyUrl = null,
+}) => {
   const db = await getDb();
 
   try {
     const updatedHospital = await db.one(
       `UPDATE hospitals
-      SET name = $1, support_url = $3
+      SET name = $1, support_url = $3, survey_url = $4
       WHERE
         id = $2
       RETURNING id
 			`,
-      [name, id, supportUrl]
+      [name, id, supportUrl, surveyUrl]
     );
     return {
       id: updatedHospital.id,

--- a/src/usecases/updateHospital.test.js
+++ b/src/usecases/updateHospital.test.js
@@ -21,6 +21,7 @@ describe("updateHospital", () => {
       request.name,
       request.id,
       null,
+      null,
     ]);
   });
 
@@ -37,6 +38,7 @@ describe("updateHospital", () => {
       id: 10,
       name: "Hospital",
       supportUrl: "https://www.support.example.com",
+      surveyUrl: "https://www.survey.example.com",
     };
     const { id, error } = await updateHospital(container)(request);
     expect(id).toEqual(10);
@@ -45,6 +47,7 @@ describe("updateHospital", () => {
       request.name,
       request.id,
       "https://www.support.example.com",
+      "https://www.survey.example.com",
     ]);
   });
 


### PR DESCRIPTION
# What

Add survey URL support to hospital usecases i.e. retrieving, creating and updating a hospital.

# Why

So that we can allow a hospital to add a survey link at the end of a visit.

# Screenshots

N/A

# Notes

N/A