### PR TITLE
Show survey link at the end visits page for a key contact

### DIFF
--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,8 +1,8 @@
 INSERT INTO trusts (name, admin_code, password, video_provider) VALUES ('Test Trust', 'admin', crypt('trustpassword', gen_salt('bf', 8)), 'whereby');
 INSERT INTO trusts (name, admin_code, password, video_provider) VALUES ('Test 2 Trust', 'admin2', crypt('trustpassword', gen_salt('bf', 8)), 'jitsi');
-INSERT INTO hospitals (name, trust_id) VALUES ('Test Hospital', (SELECT id FROM trusts WHERE name='Test Trust'));
-INSERT INTO hospitals (name, trust_id) VALUES ('Test Hospital 2', (SELECT id FROM trusts WHERE name='Test Trust'));
-INSERT INTO hospitals (name, trust_id) VALUES ('Test 2 Hospital', (SELECT id FROM trusts WHERE name='Test 2 Trust'));
+INSERT INTO hospitals (name, trust_id, support_url, survey_url) VALUES ('Test Hospital',(SELECT id FROM trusts WHERE name='Test Trust'), 'http://place-puppy.com/', 'https://placekitten.com/');
+INSERT INTO hospitals (name, trust_id, support_url, survey_url) VALUES ('Test Hospital 2',(SELECT id FROM trusts WHERE name='Test Trust'), 'http://place-puppy.com/', 'https://placekitten.com/');
+INSERT INTO hospitals (name, trust_id, support_url, survey_url) VALUES ('Test 2 Hospital',(SELECT id FROM trusts WHERE name='Test 2 Trust'), 'http://place-puppy.com/', 'https://placekitten.com/');
 INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward One', (SELECT id FROM hospitals WHERE name='Test Hospital'), 'TEST1', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward Two', (SELECT id FROM hospitals WHERE name='Test Hospital 2'), 'TEST2', (SELECT id FROM trusts WHERE name='Test Trust'));
 INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test 2 Ward One', (SELECT id FROM hospitals WHERE name='Test 2 Hospital'), 'TEST22', (SELECT id FROM trusts WHERE name='Test 2 Trust'));

--- a/pageTests/visits/end.test.js
+++ b/pageTests/visits/end.test.js
@@ -1,6 +1,9 @@
 import React from "react";
 import { render, queryByAttribute } from "@testing-library/react";
 import EndOfVisit, { getServerSideProps } from "../../pages/visits/end";
+import * as Sentry from "@sentry/node";
+
+jest.mock("@sentry/node");
 
 describe("end", () => {
   describe("for a key contact", () => {
@@ -118,15 +121,16 @@ describe("end", () => {
 
       expect(retrieveSurveyUrlByCallId).toHaveBeenCalledWith(callId);
       expect(props.surveyUrl).toEqual(surveyUrl);
+      expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
-    it("sets an error in props if starting date for events reporting error", async () => {
+    it("send the survey link error to Sentry", async () => {
       const retrieveSurveyUrlByCallIdError = jest.fn().mockResolvedValue({
         surveyUrl: null,
         error: "Error!",
       });
 
-      const { props } = await getServerSideProps({
+      await getServerSideProps({
         req,
         container: {
           ...container,
@@ -135,7 +139,7 @@ describe("end", () => {
         query,
       });
 
-      expect(props.error).toEqual("Error!");
+      expect(Sentry.captureException).toHaveBeenCalledWith("Error!");
     });
   });
 });

--- a/pageTests/visits/end.test.js
+++ b/pageTests/visits/end.test.js
@@ -6,6 +6,7 @@ describe("end", () => {
   it("renders end of visit message", () => {
     const { getByText } = render(<EndOfVisit />);
     const text = getByText(/visit has completed/i);
+
     expect(text).toBeInTheDocument();
   });
 
@@ -13,18 +14,23 @@ describe("end", () => {
     it("has a link back to the ward visits page", () => {
       const { getByText } = render(<EndOfVisit wardId="TEST" />);
       const text = getByText(/return to virtual visits/i);
+
       expect(text).toBeInTheDocument();
     });
+
     it("does not show a link to the help and support page", () => {
       const { queryByText } = render(<EndOfVisit wardId="TEST" />);
       const text = queryByText(/Get further help and support/i);
+
       expect(text).not.toBeInTheDocument();
     });
+
     it("shows the correct rebook link", () => {
       const { getByText } = render(
         <EndOfVisit wardId="TEST" callId="TEST123" />
       );
       const text = getByText(/Rebook another virtual visit/i);
+
       expect(text).toBeInTheDocument();
     });
 
@@ -37,6 +43,7 @@ describe("end", () => {
         container,
         "/wards/book-a-visit?rebookCallId=TEST123"
       );
+
       expect(rebookLink).toBeInTheDocument();
     });
   });
@@ -47,6 +54,7 @@ describe("end", () => {
         cookie: "",
       },
     };
+
     it("provides the call id", async () => {
       const container = {
         getUserIsAuthenticated: () =>
@@ -54,6 +62,7 @@ describe("end", () => {
       };
       const query = { callId: "TEST123" };
       const { props } = await getServerSideProps({ req, container, query });
+
       expect(props.callId).toEqual("TEST123");
     });
 

--- a/pages/visits/end.js
+++ b/pages/visits/end.js
@@ -1,15 +1,11 @@
 import React from "react";
-import Error from "next/error";
 import Layout from "../../src/components/Layout";
 import ActionLink from "../../src/components/ActionLink";
 import AnchorLink from "../../src/components/AnchorLink";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
+import * as Sentry from "@sentry/node";
 
-const End = ({ wardId, callId, surveyUrl, error }) => {
-  if (error) {
-    return <Error error={error} />;
-  }
-
+const End = ({ wardId, callId, surveyUrl }) => {
   return (
     <Layout title="Your virtual visit has completed" isBookService={false}>
       <div className="nhsuk-grid-row">
@@ -87,12 +83,15 @@ export const getServerSideProps = propsWithContainer(
       error: surveyUrlError,
     } = await container.getRetrieveSurveyUrlByCallId()(query.callId);
 
+    if (surveyUrlError) {
+      Sentry.captureException(surveyUrlError);
+    }
+
     return {
       props: {
         wardId: token?.ward || null,
         callId: query.callId,
         surveyUrl,
-        error: surveyUrlError,
       },
     };
   }

--- a/pages/visits/end.js
+++ b/pages/visits/end.js
@@ -1,62 +1,80 @@
 import React from "react";
+import Error from "next/error";
 import Layout from "../../src/components/Layout";
 import ActionLink from "../../src/components/ActionLink";
 import AnchorLink from "../../src/components/AnchorLink";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 
-const End = ({ wardId, callId }) => (
-  <Layout title="Your virtual visit has completed" isBookService={false}>
-    <div className="nhsuk-grid-row">
-      {wardId && (
-        <div className="nhsuk-grid-column-two-thirds">
-          <div
-            className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
-            style={{ textAlign: "center" }}
-          >
-            <h1 className="nhsuk-panel__title">
-              Your virtual visit has completed
-            </h1>
+const End = ({ wardId, callId, surveyUrl, error }) => {
+  if (error) {
+    return <Error error={error} />;
+  }
 
-            <div className="nhsuk-panel__body">
-              <p>
-                Thank you for using the virtual visit service. Please hand the
-                iPad back to a NHS staff member.
-              </p>
+  return (
+    <Layout title="Your virtual visit has completed" isBookService={false}>
+      <div className="nhsuk-grid-row">
+        {wardId && (
+          <div className="nhsuk-grid-column-two-thirds">
+            <div
+              className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+              style={{ textAlign: "center" }}
+            >
+              <h1 className="nhsuk-panel__title">
+                Your virtual visit has completed
+              </h1>
+
+              <div className="nhsuk-panel__body">
+                <p>
+                  Thank you for using the virtual visit service. Please hand the
+                  iPad back to a NHS staff member.
+                </p>
+              </div>
             </div>
+            <h2>What happens next</h2>
+
+            <ActionLink href={`/wards/book-a-visit?rebookCallId=${callId}`}>
+              Rebook another virtual visit
+            </ActionLink>
+
+            <p>
+              <AnchorLink href="/wards/visits">
+                Return to virtual visits
+              </AnchorLink>
+            </p>
           </div>
-          <h2>What happens next</h2>
+        )}
+        {!wardId && (
+          <div className="nhsuk-grid-column-two-thirds">
+            <div
+              className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+              style={{ textAlign: "center" }}
+            >
+              <h1 className="nhsuk-panel__title">
+                Your virtual visit has completed
+              </h1>
 
-          <ActionLink href={`/wards/book-a-visit?rebookCallId=${callId}`}>
-            Rebook another virtual visit
-          </ActionLink>
-
-          <p>
-            <AnchorLink href="/wards/visits">
-              Return to virtual visits
-            </AnchorLink>
-          </p>
-        </div>
-      )}
-      {!wardId && (
-        <div className="nhsuk-grid-column-two-thirds">
-          <div
-            className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
-            style={{ textAlign: "center" }}
-          >
-            <h1 className="nhsuk-panel__title">
-              Your virtual visit has completed
-            </h1>
-
-            <div className="nhsuk-panel__body">
-              <p>Thank you for using the virtual visit service.</p>
-              <p>Your personal data will be removed within 24 hours.</p>
+              <div className="nhsuk-panel__body">
+                <p>Thank you for using the virtual visit service.</p>
+                <p>Your personal data will be removed within 24 hours.</p>
+              </div>
             </div>
+            {surveyUrl && (
+              <>
+                <h2>Help improve virtual visits</h2>
+                <p>
+                  We’d welcome your feedback. Can you answer some questions
+                  about your virtual visit today?
+                </p>
+
+                <ActionLink href={surveyUrl}>Take a survey</ActionLink>
+              </>
+            )}
           </div>
-        </div>
-      )}
-    </div>
-  </Layout>
-);
+        )}
+      </div>
+    </Layout>
+  );
+};
 
 export const getServerSideProps = propsWithContainer(
   async ({ req: { headers }, container, query }) => {
@@ -64,7 +82,19 @@ export const getServerSideProps = propsWithContainer(
 
     const token = await userIsAuthenticated(headers.cookie);
 
-    return { props: { wardId: token?.ward || null, callId: query.callId } };
+    const {
+      surveyUrl,
+      error: surveyUrlError,
+    } = await container.getRetrieveSurveyUrlByCallId()(query.callId);
+
+    return {
+      props: {
+        wardId: token?.ward || null,
+        callId: query.callId,
+        surveyUrl,
+        error: surveyUrlError,
+      },
+    };
   }
 );
 

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -40,6 +40,7 @@ import retrieveAverageVisitTimeByTrustId from "../usecases/retrieveAverageVisitT
 import retrieveWardVisitTotalsStartDateByTrustId from "../usecases/retrieveWardVisitTotalsStartDateByTrustId";
 import retrieveAverageVisitsPerDayByTrustId from "../usecases/retrieveAverageVisitsPerDayByTrustId";
 import retrieveReportingStartDateByTrustId from "../usecases/retrieveReportingStartDateByTrustId";
+import retrieveSurveyUrlByCallId from "../usecases/retrieveSurveyUrlByCallId";
 
 class AppContainer {
   getDb = () => {
@@ -208,6 +209,10 @@ class AppContainer {
 
   getRetrieveReportingStartDateByTrustId = () => {
     return retrieveReportingStartDateByTrustId(this);
+  };
+
+  getRetrieveSurveyUrlByCallId = () => {
+    return retrieveSurveyUrlByCallId(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -107,4 +107,8 @@ describe("AppContainer", () => {
   it("returns getRetrieveReportingStartDateByTrustId", () => {
     expect(container.getRetrieveReportingStartDateByTrustId()).toBeDefined();
   });
+
+  it("returns getRetrieveSurveyUrlByCallId", () => {
+    expect(container.getRetrieveSurveyUrlByCallId()).toBeDefined();
+  });
 });

--- a/src/testUtils/factories.js
+++ b/src/testUtils/factories.js
@@ -14,6 +14,8 @@ export const setupTrust = async (args = {}) => {
 export const setupHospital = async (args = {}) => {
   return await container.getCreateHospital()({
     name: "Test Hospital",
+    supportUrl: "https://www.support.example.com",
+    surveyUrl: "https://www.survey.example.com",
     ...args,
   });
 };

--- a/src/testUtils/factories.js
+++ b/src/testUtils/factories.js
@@ -26,13 +26,22 @@ export const setupWard = async (args = {}) => {
   });
 };
 
-export const setupWardWithinHospitalAndTrust = async ({ index = 1 }) => {
-  const { trustId } = await setupTrust({ adminCode: `TESTCODE${index}` });
-  const { hospitalId } = await setupHospital({ trustId });
+export const setupWardWithinHospitalAndTrust = async ({
+  index = 1,
+  trustArgs = {},
+  hospitalArgs = {},
+  wardArgs = {},
+}) => {
+  const { trustId } = await setupTrust({
+    adminCode: `TESTCODE${index}`,
+    ...trustArgs,
+  });
+  const { hospitalId } = await setupHospital({ trustId, ...hospitalArgs });
   const { wardId } = await setupWard({
     code: `wardCode${index}`,
     trustId,
     hospitalId,
+    ...wardArgs,
   });
 
   return { wardId, hospitalId, trustId };

--- a/src/usecases/retrieveSurveyUrlByCallId.contractTest.js
+++ b/src/usecases/retrieveSurveyUrlByCallId.contractTest.js
@@ -1,0 +1,49 @@
+import AppContainer from "../containers/AppContainer";
+import {
+  setupVisit,
+  setupWardWithinHospitalAndTrust,
+} from "../testUtils/factories";
+
+describe("retrieveSurveyUrlByCallId contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns survey URL for a hospital of a visit", async () => {
+    const callId = "callId1";
+
+    const { wardId } = await setupWardWithinHospitalAndTrust({
+      hospitalArgs: { surveyUrl: "https://www.survey.example.com" },
+    });
+
+    await setupVisit({ wardId, callId });
+
+    const { surveyUrl, error } = await container.getRetrieveSurveyUrlByCallId()(
+      callId
+    );
+
+    expect(surveyUrl).toEqual("https://www.survey.example.com");
+    expect(error).toBeNull();
+  });
+
+  it("returns null if hospital doesn't have a survey link", async () => {
+    const callId = "callId1";
+
+    const { wardId } = await setupWardWithinHospitalAndTrust({
+      hospitalArgs: { surveyUrl: null },
+    });
+
+    await setupVisit({ wardId, callId });
+
+    const { surveyUrl, error } = await container.getRetrieveSurveyUrlByCallId()(
+      callId
+    );
+
+    expect(surveyUrl).toBeNull();
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no callId is provided", async () => {
+    const { error } = await container.getRetrieveSurveyUrlByCallId()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveSurveyUrlByCallId.js
+++ b/src/usecases/retrieveSurveyUrlByCallId.js
@@ -1,0 +1,23 @@
+const retrieveSurveyUrlByCallId = ({ getDb }) => async (callId) => {
+  if (!callId) return { error: "A callId must be provided." };
+
+  const db = await getDb();
+
+  try {
+    const { survey_url: surveyUrl } = await db.one(
+      `SELECT hospitals.survey_url AS survey_url
+      FROM hospitals
+      LEFT JOIN wards ON wards.hospital_id = hospitals.id
+      LEFT JOIN scheduled_calls_table ON scheduled_calls_table.ward_id = wards.id
+      WHERE scheduled_calls_table.call_id = $1
+      LIMIT 1`,
+      callId
+    );
+
+    return { surveyUrl, error: null };
+  } catch (error) {
+    return { surveyUrl: null, error: error.message };
+  }
+};
+
+export default retrieveSurveyUrlByCallId;

--- a/src/usecases/retrieveSurveyUrlByCallId.test.js
+++ b/src/usecases/retrieveSurveyUrlByCallId.test.js
@@ -1,0 +1,20 @@
+import retrieveSurveyUrlByCallId from "./retrieveSurveyUrlByCallId";
+
+describe("retrieveSurveyUrlByCallId", () => {
+  it("returns the error if database throws an error", async () => {
+    const trustId = 1;
+    const container = {
+      async getDb() {
+        return {
+          one: jest.fn().mockImplementation(() => {
+            throw new Error("Error!");
+          }),
+        };
+      },
+    };
+
+    const { error } = await retrieveSurveyUrlByCallId(container)(trustId);
+
+    expect(error).toEqual("Error!");
+  });
+});


### PR DESCRIPTION
# What

Show survey link at the end visits page for a key contact.

# Why

So we can get feedback from visitors.

# Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86268416-10e85d00-bbc0-11ea-8a70-6ee4979eef2a.png)|![image](https://user-images.githubusercontent.com/42817036/86268390-06c65e80-bbc0-11ea-98bb-049cd0a7d097.png)

# Notes

Next step is to allow a trust admin to add a survey URL when creating or editing a hospital.