### PR TITLE
Update create-hospital api with supportUrl param

### DIFF
--- a/pageTests/api/create-hospital.test.js
+++ b/pageTests/api/create-hospital.test.js
@@ -83,12 +83,10 @@ describe("create-hospital", () => {
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify({ hospitalId: 123 })
     );
-    expect(createHospitalSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "Yugi Muto Hospital",
-        trustId: "1",
-      })
-    );
+    expect(createHospitalSpy).toHaveBeenCalledWith({
+      name: "Yugi Muto Hospital",
+      trustId: "1",
+    });
   });
 
   it("creates a new hospital with a support url if valid", async () => {

--- a/pageTests/api/create-hospital.test.js
+++ b/pageTests/api/create-hospital.test.js
@@ -67,7 +67,7 @@ describe("create-hospital", () => {
     expect(trustAdminIsAuthenticatedSpy).toHaveBeenCalled();
   });
 
-  it("creates a new ward if valid", async () => {
+  it("creates a new hospital if valid", async () => {
     const createHospitalSpy = jest
       .fn()
       .mockReturnValue({ hospitalId: 123, error: null });

--- a/pageTests/api/create-hospital.test.js
+++ b/pageTests/api/create-hospital.test.js
@@ -91,6 +91,35 @@ describe("create-hospital", () => {
     );
   });
 
+  it("creates a new hospital with a support url if valid", async () => {
+    const createHospitalSpy = jest
+      .fn()
+      .mockReturnValue({ hospitalId: 123, error: null });
+
+    validRequest.body = {
+      name: "Yugi Muto Hospital",
+      trustId: "1",
+      supportUrl: "https://www.support.example.com",
+    };
+
+    await createHospital(validRequest, response, {
+      container: {
+        ...container,
+        getCreateHospital: () => createHospitalSpy,
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ hospitalId: 123 })
+    );
+    expect(createHospitalSpy).toHaveBeenCalledWith({
+      name: "Yugi Muto Hospital",
+      trustId: "1",
+      supportUrl: "https://www.support.example.com",
+    });
+  });
+
   it("returns a 400 status if errors", async () => {
     const createHospitalStub = jest
       .fn()

--- a/pages/api/create-hospital.js
+++ b/pages/api/create-hospital.js
@@ -35,6 +35,7 @@ export default withContainer(
     const { hospitalId, error } = await createHospital({
       name: body.name,
       trustId: body.trustId,
+      supportUrl: body.supportUrl,
     });
 
     if (error) {


### PR DESCRIPTION
# What
Updates the create-hospital API to include a supportUrl param that gets passed to the createHospital usecase

# Why
Working towards updating the create hospital form to include a support URL field

# Screenshots

# Notes
