### PR TITLE
Round average daily visits to one decimal place

### DIFF
--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -296,7 +296,7 @@ describe("trust-admin", () => {
       expect(retrieveAverageVisitsPerDayByTrustId).toHaveBeenCalledWith(
         trustId
       );
-      expect(props.averageVisitsPerDay).toEqual(1);
+      expect(props.averageVisitsPerDay).toEqual("1.0");
       expect(props.error).toBeNull();
     });
 

--- a/pages/trust-admin.js
+++ b/pages/trust-admin.js
@@ -243,7 +243,7 @@ export const getServerSideProps = propsWithContainer(
         averageParticipantsInVisit,
         visitsScheduled: retrieveWardVisitTotals.total.toLocaleString(),
         averageVisitTime,
-        averageVisitsPerDay,
+        averageVisitsPerDay: averageVisitsPerDay.toFixed(1),
         error,
       },
     };


### PR DESCRIPTION
# What
Round average daily visits to one decimal place
# Why
So we don't get numbers like 1.181818181818181818189
# Screenshots

# Notes
