### PR TITLE
Add survey url to the update-a-hospital api

### DIFF
--- a/pageTests/api/update-a-hospital.test.js
+++ b/pageTests/api/update-a-hospital.test.js
@@ -221,12 +221,10 @@ describe("update-a-hospital", () => {
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify({ hospitalId: 123 })
     );
-    expect(updateHospitalSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 123,
-        name: "Hospital Name",
-      })
-    );
+    expect(updateHospitalSpy).toHaveBeenCalledWith({
+      id: 123,
+      name: "Hospital Name",
+    });
   });
 
   it("returns a 500 if hospital fails to update", async () => {

--- a/pageTests/api/update-a-hospital.test.js
+++ b/pageTests/api/update-a-hospital.test.js
@@ -243,4 +243,26 @@ describe("update-a-hospital", () => {
       JSON.stringify({ error: "failed to update hospital" })
     );
   });
+
+  it("updates hospital with survey URL", async () => {
+    const updateHospitalSpy = jest
+      .fn()
+      .mockReturnValue({ id: 123, error: null });
+
+    validRequest.body.surveyUrl = "https://www.survey.example.com";
+
+    await updateAHospital(validRequest, response, {
+      container: { ...container, getUpdateHospital: () => updateHospitalSpy },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ hospitalId: 123 })
+    );
+    expect(updateHospitalSpy).toHaveBeenCalledWith({
+      id: 123,
+      name: "Hospital Name",
+      surveyUrl: "https://www.survey.example.com",
+    });
+  });
 });

--- a/pages/api/update-a-hospital.js
+++ b/pages/api/update-a-hospital.js
@@ -44,6 +44,7 @@ export default withContainer(
     const { id, error } = await updateHospital({
       id: body.id,
       name: body.name,
+      surveyUrl: body.surveyUrl,
     });
 
     if (error) {


### PR DESCRIPTION
# What

Adds a surveyUrl param to the update-a-hospital api

# Why

To support the addition of a surveyUrl field in the update hospital form

# Screenshots

# Notes
