### PR TITLE
Show support link at the end visits page for a key contact

### DIFF
--- a/pages/visits/end.js
+++ b/pages/visits/end.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Layout from "../../src/components/Layout";
+import ActionLinkSection from "../../src/components/ActionLinkSection";
 import ActionLink from "../../src/components/ActionLink";
 import AnchorLink from "../../src/components/AnchorLink";
 import InsetText from "../../src/components/InsetText";
@@ -61,27 +62,22 @@ const End = ({ wardId, callId, surveyUrl, supportUrl }) => {
               Your personal data will be removed within 24 hours.
             </InsetText>
 
-            {supportUrl && (
-              <>
-                <h2>What happens next</h2>
+            <ActionLinkSection
+              heading="What happens next"
+              link={supportUrl}
+              linkText="Get support from this hospital"
+            />
 
-                <ActionLink href={supportUrl}>
-                  Get support from this hospital
-                </ActionLink>
-              </>
-            )}
-
-            {surveyUrl && (
-              <>
-                <h2>Help improve virtual visits</h2>
-                <p>
-                  We’d welcome your feedback. Can you answer some questions
-                  about your virtual visit today?
-                </p>
-
-                <ActionLink href={surveyUrl}>Take a survey</ActionLink>
-              </>
-            )}
+            <ActionLinkSection
+              heading="Help improve virtual visits"
+              link={surveyUrl}
+              linkText="Take a survey"
+            >
+              <p>
+                We’d welcome your feedback. Can you answer some questions about
+                your virtual visit today?
+              </p>
+            </ActionLinkSection>
           </div>
         )}
       </div>

--- a/pages/visits/end.js
+++ b/pages/visits/end.js
@@ -2,10 +2,11 @@ import React from "react";
 import Layout from "../../src/components/Layout";
 import ActionLink from "../../src/components/ActionLink";
 import AnchorLink from "../../src/components/AnchorLink";
+import InsetText from "../../src/components/InsetText";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import * as Sentry from "@sentry/node";
 
-const End = ({ wardId, callId, surveyUrl }) => {
+const End = ({ wardId, callId, surveyUrl, supportUrl }) => {
   return (
     <Layout title="Your virtual visit has completed" isBookService={false}>
       <div className="nhsuk-grid-row">
@@ -50,10 +51,26 @@ const End = ({ wardId, callId, surveyUrl }) => {
               </h1>
 
               <div className="nhsuk-panel__body">
-                <p>Thank you for using the virtual visit service.</p>
-                <p>Your personal data will be removed within 24 hours.</p>
+                <p className="nhsuk-u-margin-bottom-0">
+                  Thank you for using the virtual visit service.
+                </p>
               </div>
             </div>
+
+            <InsetText>
+              Your personal data will be removed within 24 hours.
+            </InsetText>
+
+            {supportUrl && (
+              <>
+                <h2>What happens next</h2>
+
+                <ActionLink href={supportUrl}>
+                  Get support from this hospital
+                </ActionLink>
+              </>
+            )}
+
             {surveyUrl && (
               <>
                 <h2>Help improve virtual visits</h2>
@@ -83,8 +100,15 @@ export const getServerSideProps = propsWithContainer(
       error: surveyUrlError,
     } = await container.getRetrieveSurveyUrlByCallId()(query.callId);
 
-    if (surveyUrlError) {
-      Sentry.captureException(surveyUrlError);
+    const {
+      supportUrl,
+      error: supportUrlError,
+    } = await container.getRetrieveSupportUrlByCallId()(query.callId);
+
+    const error = surveyUrlError || supportUrlError;
+
+    if (error) {
+      Sentry.captureException(error);
     }
 
     return {
@@ -92,6 +116,7 @@ export const getServerSideProps = propsWithContainer(
         wardId: token?.ward || null,
         callId: query.callId,
         surveyUrl,
+        supportUrl,
       },
     };
   }

--- a/src/components/ActionLinkSection/index.js
+++ b/src/components/ActionLinkSection/index.js
@@ -1,0 +1,18 @@
+import React from "react";
+import ActionLink from "../ActionLink";
+
+const ActionLinkSection = ({ heading, link, linkText, children }) => {
+  if (link) {
+    return (
+      <>
+        <h2>{heading}</h2>
+        {children}
+        <ActionLink href={link}>{linkText}</ActionLink>
+      </>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default ActionLinkSection;

--- a/src/components/InsetText/index.js
+++ b/src/components/InsetText/index.js
@@ -1,0 +1,11 @@
+import React from "react";
+import classnames from "classnames";
+
+const InsetText = ({ className, children }) => (
+  <div className={classnames("nhsuk-inset-text", className)}>
+    <span className="nhsuk-u-visually-hidden">Information: </span>
+    <p>{children}</p>
+  </div>
+);
+
+export default InsetText;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -41,6 +41,7 @@ import retrieveWardVisitTotalsStartDateByTrustId from "../usecases/retrieveWardV
 import retrieveAverageVisitsPerDayByTrustId from "../usecases/retrieveAverageVisitsPerDayByTrustId";
 import retrieveReportingStartDateByTrustId from "../usecases/retrieveReportingStartDateByTrustId";
 import retrieveSurveyUrlByCallId from "../usecases/retrieveSurveyUrlByCallId";
+import retrieveSupportUrlByCallId from "../usecases/retrieveSupportUrlByCallId";
 
 class AppContainer {
   getDb = () => {
@@ -213,6 +214,10 @@ class AppContainer {
 
   getRetrieveSurveyUrlByCallId = () => {
     return retrieveSurveyUrlByCallId(this);
+  };
+
+  getRetrieveSupportUrlByCallId = () => {
+    return retrieveSupportUrlByCallId(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -111,4 +111,8 @@ describe("AppContainer", () => {
   it("returns getRetrieveSurveyUrlByCallId", () => {
     expect(container.getRetrieveSurveyUrlByCallId()).toBeDefined();
   });
+
+  it("returns getRetrieveSupportUrlByCallId", () => {
+    expect(container.getRetrieveSupportUrlByCallId()).toBeDefined();
+  });
 });

--- a/src/usecases/retrieveSupportUrlByCallId.contractTest.js
+++ b/src/usecases/retrieveSupportUrlByCallId.contractTest.js
@@ -1,0 +1,51 @@
+import AppContainer from "../containers/AppContainer";
+import {
+  setupVisit,
+  setupWardWithinHospitalAndTrust,
+} from "../testUtils/factories";
+
+describe("retrieveSupportUrlByCallId contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns support URL for a hospital of a visit", async () => {
+    const callId = "callId1";
+
+    const { wardId } = await setupWardWithinHospitalAndTrust({
+      hospitalArgs: { supportUrl: "https://www.support.example.com" },
+    });
+
+    await setupVisit({ wardId, callId });
+
+    const {
+      supportUrl,
+      error,
+    } = await container.getRetrieveSupportUrlByCallId()(callId);
+
+    expect(supportUrl).toEqual("https://www.support.example.com");
+    expect(error).toBeNull();
+  });
+
+  it("returns null if hospital doesn't have a support link", async () => {
+    const callId = "callId1";
+
+    const { wardId } = await setupWardWithinHospitalAndTrust({
+      hospitalArgs: { supportUrl: null },
+    });
+
+    await setupVisit({ wardId, callId });
+
+    const {
+      supportUrl,
+      error,
+    } = await container.getRetrieveSupportUrlByCallId()(callId);
+
+    expect(supportUrl).toBeNull();
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no callId is provided", async () => {
+    const { error } = await container.getRetrieveSupportUrlByCallId()();
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/retrieveSupportUrlByCallId.js
+++ b/src/usecases/retrieveSupportUrlByCallId.js
@@ -1,0 +1,23 @@
+const retrieveSupportUrlByCallId = ({ getDb }) => async (callId) => {
+  if (!callId) return { error: "A callId must be provided." };
+
+  const db = await getDb();
+
+  try {
+    const { support_url: supportUrl } = await db.one(
+      `SELECT hospitals.support_url AS support_url
+      FROM hospitals
+      LEFT JOIN wards ON wards.hospital_id = hospitals.id
+      LEFT JOIN scheduled_calls_table ON scheduled_calls_table.ward_id = wards.id
+      WHERE scheduled_calls_table.call_id = $1
+      LIMIT 1`,
+      callId
+    );
+
+    return { supportUrl, error: null };
+  } catch (error) {
+    return { supportUrl: null, error: error.message };
+  }
+};
+
+export default retrieveSupportUrlByCallId;

--- a/src/usecases/retrieveSupportUrlByCallId.test.js
+++ b/src/usecases/retrieveSupportUrlByCallId.test.js
@@ -1,0 +1,20 @@
+import retrieveSupportUrlByCallId from "./retrieveSupportUrlByCallId";
+
+describe("retrieveSupportUrlByCallId", () => {
+  it("returns the error if database throws an error", async () => {
+    const trustId = 1;
+    const container = {
+      async getDb() {
+        return {
+          one: jest.fn().mockImplementation(() => {
+            throw new Error("Error!");
+          }),
+        };
+      },
+    };
+
+    const { error } = await retrieveSupportUrlByCallId(container)(trustId);
+
+    expect(error).toEqual("Error!");
+  });
+});


### PR DESCRIPTION
# What

Show support link at the end visits page for a key contact.

# Why

So that a key contact can get support if they need it.

# Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86346680-31162b80-bc55-11ea-9d46-beb3bb232452.png)|![screencapture-localhost-3000-visits-end-2020-07-02-11_55_57](https://user-images.githubusercontent.com/42817036/86353671-8a835800-bc5f-11ea-94a6-0f0ed3fdd1ff.png)

# Notes

Have dropped a number of screenshots for different content and design variations I tried on Slack.
