### PR TITLE
Show survey url in hospitals table

### DIFF
--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -17,6 +17,9 @@ const HospitalsTable = ({ hospitals }) => (
             Booked visits
           </th>
           <th className="nhsuk-table__header" scope="col">
+            Survey URL
+          </th>
+          <th className="nhsuk-table__header" scope="col">
             <span className="nhsuk-u-visually-hidden">Actions</span>
           </th>
         </tr>
@@ -27,6 +30,13 @@ const HospitalsTable = ({ hospitals }) => (
             <td className="nhsuk-table__cell">{hospital.name}</td>
             <td className="nhsuk-table__cell">{hospital.wards.length}</td>
             <td className="nhsuk-table__cell">{hospital.bookedVisits}</td>
+            <td className="nhsuk-table__cell">
+              {hospital.surveyUrl ? (
+                <a href={hospital.surveyUrl}>Link</a>
+              ) : (
+                "None"
+              )}
+            </td>
             <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
               <AnchorLink
                 href={`/trust-admin/hospitals/${hospital.id}`}

--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -32,7 +32,13 @@ const HospitalsTable = ({ hospitals }) => (
             <td className="nhsuk-table__cell">{hospital.bookedVisits}</td>
             <td className="nhsuk-table__cell">
               {hospital.surveyUrl ? (
-                <a href={hospital.surveyUrl}>Link</a>
+                <a href={hospital.surveyUrl}>
+                  Link
+                  <span className="nhsuk-u-visually-hidden">
+                    {" "}
+                    for {hospital.name} survey
+                  </span>
+                </a>
               ) : (
                 "None"
               )}

--- a/src/usecases/retrieveHospitalsByTrustId.contractTest.js
+++ b/src/usecases/retrieveHospitalsByTrustId.contractTest.js
@@ -10,11 +10,13 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
     const { hospitalId } = await setupHospital({
       name: "Test Hospital",
       trustId: trustId,
+      surveyUrl: "https://www.survey.example.com",
     });
 
     const { hospitalId: hospital2Id } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
+      surveyUrl: null,
     });
 
     const {
@@ -23,8 +25,12 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
     } = await container.getRetrieveHospitalsByTrustId()(trustId);
 
     expect(hospitals).toEqual([
-      { id: hospitalId, name: "Test Hospital" },
-      { id: hospital2Id, name: "Test Hospital 2" },
+      {
+        id: hospitalId,
+        name: "Test Hospital",
+        surveyUrl: "https://www.survey.example.com",
+      },
+      { id: hospital2Id, name: "Test Hospital 2", surveyUrl: null },
     ]);
     expect(error).toBeNull();
   });
@@ -35,11 +41,13 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
     const { hospitalId } = await setupHospital({
       name: "Test Hospital",
       trustId: trustId,
+      surveyUrl: "https://www.survey.example.com",
     });
 
     const { hospitalId: hospital2Id } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
+      surveyUrl: null,
     });
 
     const { wardId: ward1Id } = await setupWard({
@@ -83,6 +91,7 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
       {
         id: hospitalId,
         name: "Test Hospital",
+        surveyUrl: "https://www.survey.example.com",
         wards: [
           { id: ward1Id, name: "Test Ward 1" },
           { id: ward2Id, name: "Test Ward 2" },
@@ -91,6 +100,7 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
       {
         id: hospital2Id,
         name: "Test Hospital 2",
+        surveyUrl: null,
         wards: [{ id: ward3Id, name: "Test Ward 3" }],
       },
     ]);

--- a/src/usecases/retrieveHospitalsByTrustId.contractTest.js
+++ b/src/usecases/retrieveHospitalsByTrustId.contractTest.js
@@ -1,5 +1,5 @@
 import AppContainer from "../containers/AppContainer";
-import { setupTrust } from "../testUtils/factories";
+import { setupTrust, setupHospital, setupWard } from "../testUtils/factories";
 
 describe("retrieveHospitalsByTrustId contract tests", () => {
   const container = AppContainer.getInstance();
@@ -7,12 +7,12 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
   it("returns all the hospitals for a trust", async () => {
     const { trustId } = await setupTrust();
 
-    const { hospitalId } = await container.getCreateHospital()({
+    const { hospitalId } = await setupHospital({
       name: "Test Hospital",
       trustId: trustId,
     });
 
-    const { hospitalId: hospital2Id } = await container.getCreateHospital()({
+    const { hospitalId: hospital2Id } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
     });
@@ -32,38 +32,38 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
   it("returns all the hospitals with their wards for a trust ", async () => {
     const { trustId } = await setupTrust();
 
-    const { hospitalId } = await container.getCreateHospital()({
+    const { hospitalId } = await setupHospital({
       name: "Test Hospital",
       trustId: trustId,
     });
 
-    const { hospitalId: hospital2Id } = await container.getCreateHospital()({
+    const { hospitalId: hospital2Id } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
     });
 
-    const { wardId: ward1Id } = await container.getCreateWard()({
+    const { wardId: ward1Id } = await setupWard({
       name: "Test Ward 1",
       code: "wardCode1",
       hospitalId: hospitalId,
       trustId: trustId,
     });
 
-    const { wardId: ward2Id } = await container.getCreateWard()({
+    const { wardId: ward2Id } = await setupWard({
       name: "Test Ward 2",
       code: "wardCode2",
       hospitalId: hospitalId,
       trustId: trustId,
     });
 
-    const { wardId: ward3Id } = await container.getCreateWard()({
+    const { wardId: ward3Id } = await setupWard({
       name: "Test Ward 3",
       code: "wardCode3",
       hospitalId: hospital2Id,
       trustId: trustId,
     });
 
-    const { wardId: ward4Id } = await container.getCreateWard()({
+    const { wardId: ward4Id } = await setupWard({
       name: "Archived ward",
       code: "wardCode4",
       hospitalId: hospital2Id,

--- a/src/usecases/retrieveHospitalsByTrustId.js
+++ b/src/usecases/retrieveHospitalsByTrustId.js
@@ -13,6 +13,7 @@ const retrieveHospitalsByTrustId = ({ getDb }) => async (
     hospitals = hospitals.map((row) => ({
       id: row.id,
       name: row.name,
+      surveyUrl: row.survey_url,
     }));
 
     if (options.withWards) {
@@ -26,6 +27,7 @@ const retrieveHospitalsByTrustId = ({ getDb }) => async (
           return {
             id: hospital.id,
             name: hospital.name,
+            surveyUrl: hospital.surveyUrl,
             wards: wards.map((ward) => ({ id: ward.id, name: ward.name })),
           };
         })


### PR DESCRIPTION
# What
Shows the survey URL for a hospital in the hospitals table if one is set

# Why
So that the TrustAdmin can easily review the survey URLs set on their hospitals

# Screenshots
![ScreenShot 2020-07-02 at 14 58 55](https://user-images.githubusercontent.com/7527178/86368045-a34a3880-bc74-11ea-9789-bf7e4fae7d12.png)

# Notes
