### PR TITLE
Add display of survey and support URL on hospital page

### DIFF
--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -10,6 +10,7 @@ import Layout from "../../../src/components/Layout";
 import WardsTable from "../../../src/components/WardsTable";
 import NumberTile from "../../../src/components/NumberTile";
 import Panel from "../../../src/components/Panel";
+import HospitalSummaryList from "../../../src/components/HospitalSummaryList";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
 
 const ShowHospital = ({
@@ -69,7 +70,21 @@ const ShowHospital = ({
               />
             </GridColumn>
           </GridRow>
+
+          <HospitalSummaryList
+            name={hospital.name}
+            surveyUrl={hospital.surveyUrl}
+            supportUrl={hospital.supportUrl}
+            withActions={true}
+            actionLinkOnClick={() => {
+              Router.push({
+                pathname: `/trust-admin/hospitals/${hospital.id}/edit`,
+              });
+            }}
+          />
+
           <WardsTable wards={wards} wardVisitTotals={wardVisitTotals} />
+
           <Button
             className="nhsuk-button"
             onClick={() => {

--- a/src/components/HospitalSummaryList/index.js
+++ b/src/components/HospitalSummaryList/index.js
@@ -1,0 +1,50 @@
+import React from "react";
+import SummaryList from "../SummaryList";
+import AnchorLink from "../AnchorLink";
+
+const HospitalSummaryList = ({
+  name,
+  surveyUrl,
+  supportUrl,
+  withActions = false,
+  actionLinkOnClick = null,
+}) => {
+  const visit = [
+    {
+      key: "Hospital name",
+      value: name,
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "hospital name",
+    },
+    {
+      key: "Key contact survey URL",
+      value:
+        (surveyUrl && (
+          <AnchorLink href={surveyUrl}>
+            Link
+            <span className="nhsuk-u-visually-hidden"> for {name} survey</span>
+          </AnchorLink>
+        )) ||
+        "None",
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "key contact survey URL",
+    },
+    {
+      key: "Support URL",
+      value:
+        (supportUrl && (
+          <AnchorLink href={supportUrl}>
+            Link
+            <span className="nhsuk-u-visually-hidden"> for {name} support</span>
+          </AnchorLink>
+        )) ||
+        "None",
+      actionLinkOnClick: actionLinkOnClick,
+      hiddenActionText: "support URL",
+    },
+  ];
+
+  return <SummaryList list={visit} withActions={withActions} />;
+};
+
+export default HospitalSummaryList;

--- a/src/components/HospitalSummaryList/index.test.js
+++ b/src/components/HospitalSummaryList/index.test.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import HospitalSummaryList from "./index";
+
+describe("HospitalSummaryList", () => {
+  const name = "Test Hospital";
+  const surveyUrl = "https://www.survey.example.com";
+  const supportUrl = "https://www.support.example.com";
+
+  it("renders the details of a hospital", () => {
+    render(
+      <HospitalSummaryList
+        name={name}
+        surveyUrl={surveyUrl}
+        supportUrl={supportUrl}
+      />
+    );
+
+    expect(screen.getByText(name)).toBeVisible();
+    expect(screen.queryAllByText("Link")[0]).toHaveAttribute("href", surveyUrl);
+    expect(screen.queryAllByText("Link")[1]).toHaveAttribute(
+      "href",
+      supportUrl
+    );
+  });
+
+  it("renders 'None' if no survey URL", () => {
+    render(<HospitalSummaryList name={name} supportUrl={supportUrl} />);
+
+    expect(screen.getByText("None")).toBeVisible();
+  });
+
+  it("renders 'None' if no support URL", () => {
+    render(<HospitalSummaryList name={name} surveyUrl={surveyUrl} />);
+
+    expect(screen.getByText("None")).toBeVisible();
+  });
+
+  it("does not render Change links by default", () => {
+    render(
+      <HospitalSummaryList
+        name={name}
+        surveyUrl={surveyUrl}
+        supportUrl={supportUrl}
+      />
+    );
+
+    expect(screen.queryAllByText("Change")).toEqual([]);
+  });
+
+  it("render Change links if withActions is true", () => {
+    render(
+      <HospitalSummaryList
+        name={name}
+        surveyUrl={surveyUrl}
+        supportUrl={supportUrl}
+        withActions={true}
+      />
+    );
+
+    expect(screen.queryAllByText("Change")).not.toEqual([]);
+  });
+});


### PR DESCRIPTION
# What

Add display of survey and support URL on hospital page.

# Why

Currently we don't show all information of a hospital on their individual pages.

# Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86455617-c62e2880-bd18-11ea-8e29-dc121c982378.png)|![image](https://user-images.githubusercontent.com/42817036/86455591-bf9fb100-bd18-11ea-91f9-4d31179402af.png)

# Notes

N/A