### PR TITLE
Validate survey URL on submit when updating a hospital

### DIFF
--- a/src/components/EditHospitalForm/index.js
+++ b/src/components/EditHospitalForm/index.js
@@ -9,7 +9,7 @@ import Router from "next/router";
 import validateUrl from "../../helpers/validateUrl";
 
 const isPresent = (input) => {
-  if (input.length !== 0) {
+  if (input && input.length !== 0) {
     return input;
   }
 };

--- a/src/components/EditHospitalForm/index.js
+++ b/src/components/EditHospitalForm/index.js
@@ -6,6 +6,7 @@ import Input from "../Input";
 import ErrorSummary from "../ErrorSummary";
 import Label from "../Label";
 import Router from "next/router";
+import validateUrl from "../../helpers/validateUrl";
 
 const isPresent = (input) => {
   if (input.length !== 0) {
@@ -67,8 +68,19 @@ const EditHospitalForm = ({ errors, setErrors, hospital }) => {
       });
     };
 
+    const setHospitalSurveyUrlInvalidError = (errors) => {
+      errors.push({
+        id: "hospital-survey-url-error",
+        message: "Enter a valid survey URL",
+      });
+    };
+
     if (!isPresent(hospitalName)) {
       setHospitalNameError(onSubmitErrors);
+    }
+
+    if (isPresent(hospitalSurveyUrl) && !validateUrl(hospitalSurveyUrl)) {
+      setHospitalSurveyUrlInvalidError(onSubmitErrors);
     }
 
     if (onSubmitErrors.length === 0) {


### PR DESCRIPTION
# What
Validates the survey URL with our validateUrl helper before submitting to the update hospital API

# Why
To ensure that we are displaying valid survey URLs to the key contacts so that we can collect feedback

# Screenshots
![ScreenShot 2020-07-03 at 10 50 22](https://user-images.githubusercontent.com/7527178/86457097-08f10000-bd1b-11ea-9c0e-dfe86c02c71a.png)

# Notes
I tried setting the Input pattern to URL_VALIDATION_STRING but I wasn't happy with the message returned : 

![ScreenShot 2020-07-03 at 10 50 04](https://user-images.githubusercontent.com/7527178/86457148-1a3a0c80-bd1b-11ea-9287-63c6ac2ff920.png)


