### PR TITLE
Move admin pages to use appropriate folders

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,14 +1,14 @@
 import React from "react";
-import Layout from "../src/components/Layout";
-import propsWithContainer from "../src/middleware/propsWithContainer";
-import verifyAdminToken from "../src/usecases/verifyAdminToken";
-import { GridRow, GridColumn } from "../src/components/Grid";
-import Heading from "../src/components/Heading";
-import ActionLink from "../src/components/ActionLink";
-import TrustsTable from "../src/components/TrustsTable";
-import Text from "../src/components/Text";
+import Layout from "../../src/components/Layout";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+import verifyAdminToken from "../../src/usecases/verifyAdminToken";
+import { GridRow, GridColumn } from "../../src/components/Grid";
+import Heading from "../../src/components/Heading";
+import ActionLink from "../../src/components/ActionLink";
+import TrustsTable from "../../src/components/TrustsTable";
+import Text from "../../src/components/Text";
 import Error from "next/error";
-import { ADMIN } from "../src/helpers/userTypes";
+import { ADMIN } from "../../src/helpers/userTypes";
 
 const Admin = ({ trusts, error }) => {
   if (error) {

--- a/pages/trust-admin/index.js
+++ b/pages/trust-admin/index.js
@@ -1,15 +1,15 @@
 import React from "react";
 import Error from "next/error";
-import Layout from "../src/components/Layout";
-import propsWithContainer from "../src/middleware/propsWithContainer";
-import verifyTrustAdminToken from "../src/usecases/verifyTrustAdminToken";
-import { GridRow, GridColumn } from "../src/components/Grid";
-import Heading from "../src/components/Heading";
-import NumberTile from "../src/components/NumberTile";
-import Text from "../src/components/Text";
-import AnchorLink from "../src/components/AnchorLink";
-import ReviewDate from "../src/components/ReviewDate";
-import { TRUST_ADMIN } from "../src/helpers/userTypes";
+import Layout from "../../src/components/Layout";
+import propsWithContainer from "../../src/middleware/propsWithContainer";
+import verifyTrustAdminToken from "../../src/usecases/verifyTrustAdminToken";
+import { GridRow, GridColumn } from "../../src/components/Grid";
+import Heading from "../../src/components/Heading";
+import NumberTile from "../../src/components/NumberTile";
+import Text from "../../src/components/Text";
+import AnchorLink from "../../src/components/AnchorLink";
+import ReviewDate from "../../src/components/ReviewDate";
+import { TRUST_ADMIN } from "../../src/helpers/userTypes";
 
 const TrustAdmin = ({
   error,


### PR DESCRIPTION
# What
Moves the trust admin and admin pages to their respective folders to keep in the NextJS page structure
# Why
Code quality and consistency
# Screenshots

# Notes
