### PR TITLE
Validate the survey URL when adding a hospital

### DIFF
--- a/cypress/integration/trust-admin/addingAHospital.js
+++ b/cypress/integration/trust-admin/addingAHospital.js
@@ -34,6 +34,19 @@ describe("As a trust admin, I want to add a hospital so that I can manage virtua
     ThenISeeErrors();
   });
 
+  it("displays errors when survey url is invalid", () => {
+    GivenIAmLoggedInAsATrustAdmin();
+    WhenIClickHospitalsOnTheNavigationBar();
+    ThenISeeTheHospitalsPage();
+
+    WhenIClickAddAHospital();
+    ThenISeeTheAddAHospitalForm();
+
+    WhenIFillOutTheFormWithBadSurveyUrl();
+    AndISubmitTheForm();
+    ThenISeeErrors();
+  });
+
   // Allows a trust admin to add a hospital
   function GivenIAmLoggedInAsATrustAdmin() {
     cy.visit(Cypress.env("baseUrl") + "/trust-admin/login");
@@ -65,6 +78,11 @@ describe("As a trust admin, I want to add a hospital so that I can manage virtua
     cy.get("input[name=hospital-survey-url]").type(
       "https://www.survey.example.com"
     );
+  }
+
+  function WhenIFillOutTheFormWithBadSurveyUrl() {
+    cy.get("input[name=hospital-name]").type("Scorpia Hospital");
+    cy.get("input[name=hospital-survey-url]").type("https://www");
   }
 
   function AndISubmitTheForm() {

--- a/pages/trust-admin/hospitals/add.js
+++ b/pages/trust-admin/hospitals/add.js
@@ -12,6 +12,13 @@ import Label from "../../../src/components/Label";
 import Button from "../../../src/components/Button";
 import Router from "next/router";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
+import validateUrl from "../../../src/helpers/validateUrl";
+
+const isPresent = (input) => {
+  if (input && input.length !== 0) {
+    return input;
+  }
+};
 
 const AddAHospital = ({ error, trustId }) => {
   if (error) {
@@ -47,8 +54,19 @@ const AddAHospital = ({ error, trustId }) => {
       });
     };
 
-    if (hospitalName.length === 0) {
+    const setHospitalSurveyUrlInvalidError = (errors) => {
+      errors.push({
+        id: "hospital-survey-url-error",
+        message: "Enter a valid survey URL",
+      });
+    };
+
+    if (!isPresent(hospitalName)) {
       setHospitalNameError(onSubmitErrors);
+    }
+
+    if (isPresent(hospitalSurveyUrl) && !validateUrl(hospitalSurveyUrl)) {
+      setHospitalSurveyUrlInvalidError(onSubmitErrors);
     }
 
     if (onSubmitErrors.length === 0) {
@@ -135,7 +153,7 @@ const AddAHospital = ({ error, trustId }) => {
                 style={{ padding: "16px!important", height: "64px" }}
                 onChange={(event) => setHospitalSurveyUrl(event.target.value)}
                 name="hospital-survey-url"
-                value={hospitalSurveyUrl || null}
+                value={hospitalSurveyUrl || ""}
               />
             </FormGroup>
 


### PR DESCRIPTION
# What
Validate the survey URL when adding a hospital
# Why
To ensure a valid survey URL is supplied when creating a hospital
# Screenshots

# Notes
The create and edit forms need to be refactored to use the same component