### PR TITLE
Update update-a-hospital API to allow support URL

### DIFF
--- a/pageTests/api/update-a-hospital.test.js
+++ b/pageTests/api/update-a-hospital.test.js
@@ -263,4 +263,26 @@ describe("update-a-hospital", () => {
       surveyUrl: "https://www.survey.example.com",
     });
   });
+
+  it("updates hospital with support URL", async () => {
+    const updateHospitalSpy = jest
+      .fn()
+      .mockReturnValue({ id: 123, error: null });
+
+    validRequest.body.supportUrl = "https://www.support.example.com";
+
+    await updateAHospital(validRequest, response, {
+      container: { ...container, getUpdateHospital: () => updateHospitalSpy },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ hospitalId: 123 })
+    );
+    expect(updateHospitalSpy).toHaveBeenCalledWith({
+      id: 123,
+      name: "Hospital Name",
+      supportUrl: "https://www.support.example.com",
+    });
+  });
 });

--- a/pageTests/trust-admin/hospitals/[id]/edit.test.js
+++ b/pageTests/trust-admin/hospitals/[id]/edit.test.js
@@ -1,0 +1,66 @@
+import { getServerSideProps } from "../../../../pages/trust-admin/hospitals/[id]/edit";
+
+describe("/trust-admin/hospitals/[id]/edit", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  const authenticatedReq = {
+    headers: {
+      cookie: "token=123",
+    },
+  };
+
+  let res;
+
+  const trustId = 1;
+
+  const tokenProvider = {
+    validate: jest.fn(() => ({ type: "trustAdmin", trustId })),
+  };
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/trust-admin/login",
+      });
+    });
+
+    it("retrieves the hospital by ID", async () => {
+      const hospitalId = 2;
+      const retrieveHospitalByIdSpy = jest.fn().mockResolvedValue({
+        hospital: {
+          id: hospitalId,
+          name: "Northwick Park Hospital",
+          surveyUrl: "https://www.survey.example.com",
+          supportUrl: "https://www.support.example.com",
+        },
+        error: null,
+      });
+
+      const container = {
+        getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
+        getTokenProvider: () => tokenProvider,
+      };
+
+      await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: { id: hospitalId },
+        container,
+      });
+
+      expect(retrieveHospitalByIdSpy).toHaveBeenCalledWith(hospitalId, trustId);
+    });
+  });
+});

--- a/pages/api/update-a-hospital.js
+++ b/pages/api/update-a-hospital.js
@@ -45,6 +45,7 @@ export default withContainer(
       id: body.id,
       name: body.name,
       surveyUrl: body.surveyUrl,
+      supportUrl: body.supportUrl,
     });
 
     if (error) {


### PR DESCRIPTION
# What

Update `update-a-hospital` API to allow support URL and tests for the edit hospital page.

# Why

So that we can edit the support URL when editing a hospital through the form and add coverage to the edit hospital page.

# Screenshots

N/A

# Notes

We've already updated the `create-hospital` API endpoint in https://github.com/madetech/nhs-virtual-visit/pull/486.