### PR TITLE
Display the support URL on the list of hospitals page

### DIFF
--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -19,6 +19,9 @@ const HospitalsTable = ({ hospitals }) => (
           <th className="nhsuk-table__header" scope="col">
             Survey URL
           </th>
+          <th className="nhsuk-table__header" scope="col">
+            Support URL
+          </th>
           <th className="nhsuk-table__header" scope="col" colSpan="2">
             <span className="nhsuk-u-visually-hidden">Actions</span>
           </th>
@@ -37,6 +40,19 @@ const HospitalsTable = ({ hospitals }) => (
                   <span className="nhsuk-u-visually-hidden">
                     {" "}
                     for {hospital.name} survey
+                  </span>
+                </a>
+              ) : (
+                "None"
+              )}
+            </td>
+            <td className="nhsuk-table__cell">
+              {hospital.supportUrl ? (
+                <a href={hospital.supportUrl}>
+                  Link
+                  <span className="nhsuk-u-visually-hidden">
+                    {" "}
+                    for {hospital.name} support
                   </span>
                 </a>
               ) : (

--- a/src/components/HospitalsTable/index.js
+++ b/src/components/HospitalsTable/index.js
@@ -19,7 +19,7 @@ const HospitalsTable = ({ hospitals }) => (
           <th className="nhsuk-table__header" scope="col">
             Survey URL
           </th>
-          <th className="nhsuk-table__header" scope="col">
+          <th className="nhsuk-table__header" scope="col" colSpan="2">
             <span className="nhsuk-u-visually-hidden">Actions</span>
           </th>
         </tr>
@@ -43,17 +43,16 @@ const HospitalsTable = ({ hospitals }) => (
                 "None"
               )}
             </td>
-            <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
-              <AnchorLink
-                href={`/trust-admin/hospitals/${hospital.id}`}
-                className="nhsuk-u-margin-right-4"
-              >
+            <td className="nhsuk-table__cell">
+              <AnchorLink href={`/trust-admin/hospitals/${hospital.id}`}>
                 View
                 <span className="nhsuk-u-visually-hidden">
                   {" "}
                   {hospital.name}
                 </span>
               </AnchorLink>
+            </td>
+            <td className="nhsuk-table__cell">
               <AnchorLink href={`/trust-admin/hospitals/${hospital.id}/edit`}>
                 Edit
                 <span className="nhsuk-u-visually-hidden">

--- a/src/usecases/retrieveHospitalsByTrustId.contractTest.js
+++ b/src/usecases/retrieveHospitalsByTrustId.contractTest.js
@@ -11,12 +11,14 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
       name: "Test Hospital",
       trustId: trustId,
       surveyUrl: "https://www.survey.example.com",
+      supportUrl: "https://www.support.example.com",
     });
 
     const { hospitalId: hospital2Id } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
       surveyUrl: null,
+      supportUrl: null,
     });
 
     const {
@@ -29,8 +31,14 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
         id: hospitalId,
         name: "Test Hospital",
         surveyUrl: "https://www.survey.example.com",
+        supportUrl: "https://www.support.example.com",
       },
-      { id: hospital2Id, name: "Test Hospital 2", surveyUrl: null },
+      {
+        id: hospital2Id,
+        name: "Test Hospital 2",
+        surveyUrl: null,
+        supportUrl: null,
+      },
     ]);
     expect(error).toBeNull();
   });
@@ -42,12 +50,14 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
       name: "Test Hospital",
       trustId: trustId,
       surveyUrl: "https://www.survey.example.com",
+      supportUrl: "https://www.support.example.com",
     });
 
     const { hospitalId: hospital2Id } = await setupHospital({
       name: "Test Hospital 2",
       trustId: trustId,
       surveyUrl: null,
+      supportUrl: null,
     });
 
     const { wardId: ward1Id } = await setupWard({
@@ -92,6 +102,7 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
         id: hospitalId,
         name: "Test Hospital",
         surveyUrl: "https://www.survey.example.com",
+        supportUrl: "https://www.support.example.com",
         wards: [
           { id: ward1Id, name: "Test Ward 1" },
           { id: ward2Id, name: "Test Ward 2" },
@@ -101,6 +112,7 @@ describe("retrieveHospitalsByTrustId contract tests", () => {
         id: hospital2Id,
         name: "Test Hospital 2",
         surveyUrl: null,
+        supportUrl: null,
         wards: [{ id: ward3Id, name: "Test Ward 3" }],
       },
     ]);

--- a/src/usecases/retrieveHospitalsByTrustId.js
+++ b/src/usecases/retrieveHospitalsByTrustId.js
@@ -14,6 +14,7 @@ const retrieveHospitalsByTrustId = ({ getDb }) => async (
       id: row.id,
       name: row.name,
       surveyUrl: row.survey_url,
+      supportUrl: row.support_url,
     }));
 
     if (options.withWards) {
@@ -28,6 +29,7 @@ const retrieveHospitalsByTrustId = ({ getDb }) => async (
             id: hospital.id,
             name: hospital.name,
             surveyUrl: hospital.surveyUrl,
+            supportUrl: hospital.supportUrl,
             wards: wards.map((ward) => ({ id: ward.id, name: ward.name })),
           };
         })


### PR DESCRIPTION
# What

Display the support URL on the list of hospitals page and use 2 colspan for the actions column of the table.

# Why

So a trust admin can view the support URL from the hospitals page and no weird styling.

# Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86597044-1a444180-bf93-11ea-8aca-76ae124519ea.png)|![image](https://user-images.githubusercontent.com/42817036/86597018-11537000-bf93-11ea-95c7-96097a0fbc38.png)

# Notes

N/A