### PR TITLE
Update WardsTable to use 2 colspan for actions column

### DIFF
--- a/src/components/WardsTable/index.js
+++ b/src/components/WardsTable/index.js
@@ -23,7 +23,7 @@ const WardsTable = ({ wards, wardVisitTotals }) => (
               Booked visits
             </th>
           )}
-          <th className="nhsuk-table__header" scope="col">
+          <th className="nhsuk-table__header" scope="col" colSpan="2">
             <span className="nhsuk-u-visually-hidden">Actions</span>
           </th>
         </tr>
@@ -39,14 +39,13 @@ const WardsTable = ({ wards, wardVisitTotals }) => (
             {wardVisitTotals && (
               <td className="nhsuk-table__cell">{wardVisitTotals[ward.id]}</td>
             )}
-            <td className="nhsuk-table__cell" style={{ textAlign: "center" }}>
-              <AnchorLink
-                href={`/trust-admin/wards/${ward.id}/edit`}
-                className="nhsuk-u-margin-right-4"
-              >
+            <td className="nhsuk-table__cell">
+              <AnchorLink href={`/trust-admin/wards/${ward.id}/edit`}>
                 Edit
                 <span className="nhsuk-u-visually-hidden"> {ward.name}</span>
               </AnchorLink>
+            </td>
+            <td className="nhsuk-table__cell">
               <AnchorLink
                 href={`/trust-admin/wards/${ward.id}/archive-confirmation`}
               >


### PR DESCRIPTION
# What

Update WardsTable to use 2 colspan for actions column and use separate table cells for the Edit and Delete links.

# Why

This is to prevent the Delete link displaying underneath the Edit when there is a long ward name or ward code.

# Screenshots

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/86766631-b8431500-c042-11ea-9ee4-a322acdbdf50.png)|![image](https://user-images.githubusercontent.com/42817036/86766623-b37e6100-c042-11ea-8d19-059105439c49.png)

# Notes

N/A