### PR TITLE
Add updated visit text and email to TemplateStore

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -21,10 +21,14 @@ DATABASE_URL=
 TEST_DATABASE_URL=
 # GovNotify SMS Initial Template ID
 SMS_INITIAL_TEMPLATE_ID=
+# GovNotify SMS Updated Visit Template ID
+SMS_UPDATED_VISIT_TEMPLATE_ID=
 # GovNotify SMS Join Template ID
 SMS_JOIN_TEMPLATE_ID=
 # GovNotify Email Initial Template ID
 EMAIL_INITIAL_TEMPLATE_ID=
+# GovNotify Email Updated Visit Template ID
+EMAIL_UPDATED_VISIT_TEMPLATE_ID=
 # GovNotify Email Join Template ID
 EMAIL_JOIN_TEMPLATE_ID=
 # Valid Ward Codes

--- a/src/gateways/GovNotify/TemplateStore.js
+++ b/src/gateways/GovNotify/TemplateStore.js
@@ -8,12 +8,30 @@ export default {
       "visit_time",
     ],
   },
+  updatedVisitText: {
+    templateId: process.env.SMS_UPDATED_VISIT_TEMPLATE_ID,
+    personalisationKeys: [
+      "hospital_name",
+      "ward_name",
+      "visit_date",
+      "visit_time",
+    ],
+  },
   secondText: {
     templateId: process.env.SMS_JOIN_TEMPLATE_ID,
     personalisationKeys: ["call_url", "ward_name", "hospital_name"],
   },
   firstEmail: {
     templateId: process.env.EMAIL_INITIAL_TEMPLATE_ID,
+    personalisationKeys: [
+      "hospital_name",
+      "ward_name",
+      "visit_date",
+      "visit_time",
+    ],
+  },
+  updatedVisitEmail: {
+    templateId: process.env.EMAIL_UPDATED_VISIT_TEMPLATE_ID,
     personalisationKeys: [
       "hospital_name",
       "ward_name",


### PR DESCRIPTION
# What

Add updated visit text and email to TemplateStore.

# Why

So that we can eventually send a different notification for when a visit is updated.

# Screenshots

N/A

# Notes

See https://trello.com/c/jgRkQChb/718-create-sms-email-templates-for-visit-change-notification for more detail. 