### PR TITLE
Add usecase for updating a visit

### DIFF
--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -42,6 +42,7 @@ import retrieveAverageVisitsPerDayByTrustId from "../usecases/retrieveAverageVis
 import retrieveReportingStartDateByTrustId from "../usecases/retrieveReportingStartDateByTrustId";
 import retrieveSurveyUrlByCallId from "../usecases/retrieveSurveyUrlByCallId";
 import retrieveSupportUrlByCallId from "../usecases/retrieveSupportUrlByCallId";
+import updateVisitByCallId from "../usecases/updateVisitByCallId";
 
 class AppContainer {
   getDb = () => {
@@ -218,6 +219,10 @@ class AppContainer {
 
   getRetrieveSupportUrlByCallId = () => {
     return retrieveSupportUrlByCallId(this);
+  };
+
+  getUpdateVisitByCallId = () => {
+    return updateVisitByCallId(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -115,4 +115,8 @@ describe("AppContainer", () => {
   it("returns getRetrieveSupportUrlByCallId", () => {
     expect(container.getRetrieveSupportUrlByCallId()).toBeDefined();
   });
+
+  it("returns getUpdateVisitByCallId", () => {
+    expect(container.getUpdateVisitByCallId()).toBeDefined();
+  });
 });

--- a/src/testUtils/factories.js
+++ b/src/testUtils/factories.js
@@ -28,22 +28,24 @@ export const setupWard = async (args = {}) => {
   });
 };
 
-export const setupWardWithinHospitalAndTrust = async ({
-  index = 1,
-  trustArgs = {},
-  hospitalArgs = {},
-  wardArgs = {},
-}) => {
+export const setupWardWithinHospitalAndTrust = async (
+  args = {
+    index: 1,
+    trustArgs: {},
+    hospitalArgs: {},
+    wardArgs: {},
+  }
+) => {
   const { trustId } = await setupTrust({
-    adminCode: `TESTCODE${index}`,
-    ...trustArgs,
+    adminCode: `TESTCODE${args.index}`,
+    ...args.trustArgs,
   });
-  const { hospitalId } = await setupHospital({ trustId, ...hospitalArgs });
+  const { hospitalId } = await setupHospital({ trustId, ...args.hospitalArgs });
   const { wardId } = await setupWard({
-    code: `wardCode${index}`,
+    code: `wardCode${args.index}`,
     trustId,
     hospitalId,
-    ...wardArgs,
+    ...args.wardArgs,
   });
 
   return { wardId, hospitalId, trustId };

--- a/src/usecases/createVisit.contractTest.js
+++ b/src/usecases/createVisit.contractTest.js
@@ -1,0 +1,23 @@
+import AppContainer from "../containers/AppContainer";
+import { setupWardWithinHospitalAndTrust } from "../testUtils/factories";
+
+describe("createVisit contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("creates a visit", async () => {
+    const { wardId } = await setupWardWithinHospitalAndTrust({ index: 1 });
+
+    const visit = await container.getCreateVisit()({
+      patientName: "Patient Name",
+      contactEmail: "contact@example.com",
+      contactName: "Contact Name",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "TESTCALLID",
+      provider: "TESTPROVIDER",
+      callPassword: "TESTCALLPASSWORD",
+      wardId,
+    });
+
+    expect(visit.id).not.toBeNull();
+  });
+});

--- a/src/usecases/createVisit.contractTest.js
+++ b/src/usecases/createVisit.contractTest.js
@@ -19,5 +19,6 @@ describe("createVisit contract tests", () => {
     });
 
     expect(visit.id).not.toBeNull();
+    expect(visit.callId).toEqual("TESTCALLID");
   });
 });

--- a/src/usecases/createVisit.js
+++ b/src/usecases/createVisit.js
@@ -3,11 +3,11 @@ import { SCHEDULED } from "../../src/helpers/visitStatus";
 const createVisit = ({ getDb }) => async (visit) => {
   const db = await getDb();
 
-  return await db.one(
+  const { id, call_id } = await db.one(
     `INSERT INTO scheduled_calls_table
       (id, patient_name, recipient_email, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password, status)
       VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-      RETURNING id
+      RETURNING id, call_id
     `,
     [
       visit.patientName,
@@ -22,6 +22,8 @@ const createVisit = ({ getDb }) => async (visit) => {
       SCHEDULED,
     ]
   );
+
+  return { id, callId: call_id };
 };
 
 export default createVisit;

--- a/src/usecases/createVisit.test.js
+++ b/src/usecases/createVisit.test.js
@@ -3,7 +3,7 @@ import { SCHEDULED } from "../../src/helpers/visitStatus";
 
 describe("createVisit", () => {
   it("creates a visit in the db when valid", async () => {
-    const oneSpy = jest.fn().mockReturnValue(10);
+    const oneSpy = jest.fn().mockResolvedValue({ id: 10, call_id: "12345" });
     const container = {
       async getDb() {
         return {
@@ -18,15 +18,16 @@ describe("createVisit", () => {
       contactName: "John Smith",
       contactNumber: "07123456789",
       callTime: new Date(),
-      callId: 12345,
+      callId: "12345",
       provider: "jitsi",
       wardId: 1,
       callPassword: "securePassword",
     };
 
-    const resultingId = await createVisit(container)(request);
+    const { id, callId } = await createVisit(container)(request);
 
-    expect(resultingId).toEqual(10);
+    expect(id).toEqual(10);
+    expect(callId).toEqual("12345");
 
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.patientName,

--- a/src/usecases/updateVisitByCallId.contractTest.js
+++ b/src/usecases/updateVisitByCallId.contractTest.js
@@ -1,0 +1,46 @@
+import AppContainer from "../containers/AppContainer";
+import {
+  setupWardWithinHospitalAndTrust,
+  setupVisit,
+} from "../testUtils/factories";
+
+describe("updateVisitByCallId contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("updates the details of a visit", async () => {
+    const { wardId } = await setupWardWithinHospitalAndTrust();
+    const { callId } = await setupVisit({ wardId });
+
+    const { visit, error } = await container.getUpdateVisitByCallId()({
+      callId,
+      patientName: "Aang",
+      contactName: "Katara",
+      contactEmail: "katara@example.com",
+      contactNumber: "07123456789",
+      callTime: new Date("2020-08-01 18:00"),
+    });
+
+    expect(visit.patientName).toEqual("Aang");
+    expect(visit.contactName).toEqual("Katara");
+    expect(visit.contactEmail).toEqual("katara@example.com");
+    expect(visit.contactNumber).toEqual("07123456789");
+    expect(visit.callTime).toEqual(new Date("2020-08-01 18:00"));
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if visit doesn't exisit", async () => {
+    await setupWardWithinHospitalAndTrust();
+
+    const { visit, error } = await container.getUpdateVisitByCallId()({
+      callId: "fakeCallId",
+      patientName: "Aang",
+      contactName: "Katara",
+      contactEmail: "katara@example.com",
+      contactNumber: "07123456789",
+      callTime: new Date("2020-08-01 18:00"),
+    });
+
+    expect(visit).toBeNull();
+    expect(error).not.toBeNull();
+  });
+});

--- a/src/usecases/updateVisitByCallId.js
+++ b/src/usecases/updateVisitByCallId.js
@@ -1,0 +1,41 @@
+const updateVisitByCallId = ({ getDb }) => async ({
+  callId,
+  patientName,
+  contactName,
+  contactEmail,
+  contactNumber,
+  callTime,
+}) => {
+  const db = await getDb();
+  try {
+    const updatedVisit = await db.one(
+      `UPDATE scheduled_calls_table
+      SET patient_name = $1,
+          recipient_name = $2,
+          recipient_email = $3,
+          recipient_number = $4,
+          call_time = $5
+      WHERE
+          call_id = $6
+      RETURNING *`,
+      [patientName, contactName, contactEmail, contactNumber, callTime, callId]
+    );
+
+    return {
+      visit: {
+        id: updatedVisit.id,
+        patientName: updatedVisit.patient_name,
+        contactName: updatedVisit.recipient_name,
+        contactNumber: updatedVisit.recipient_number,
+        contactEmail: updatedVisit.recipient_email,
+        callTime: updatedVisit.call_time,
+        callId: updatedVisit.call_id,
+      },
+      error: null,
+    };
+  } catch (error) {
+    return { visit: null, error: error.message };
+  }
+};
+
+export default updateVisitByCallId;


### PR DESCRIPTION
# What

Add usecase for updating a visit and update `createVisit` usecase to return `callId` in addition to `id`.

# Why

So it can be called to update the details of visit.

# Screenshots

N/A

# Notes

Best reviewed commit by commit.