### PR TITLE
Extract a validateVisit helper from book-a-visit API endpoint

### DIFF
--- a/pageTests/api/book-a-visit.test.js
+++ b/pageTests/api/book-a-visit.test.js
@@ -173,7 +173,7 @@ describe("/api/book-a-visit", () => {
     it("sends a text message and an email", async () => {
       request.body = {
         patientName: "Bob Smith",
-        contactNumber: "john@smith.com",
+        contactNumber: "07123456789",
         contactEmail: "john@smith.com",
         contactName: "John Smith",
         callTime: frozenTime,
@@ -197,7 +197,7 @@ describe("/api/book-a-visit", () => {
     it("returns a 201 status if successful", async () => {
       request.body = {
         patientName: "Bob Smith",
-        contactNumber: "john@smith.com",
+        contactNumber: "07123456789",
         contactEmail: "john@smith.com",
         contactName: "John Smith",
         callTime: frozenTime,
@@ -211,7 +211,7 @@ describe("/api/book-a-visit", () => {
     it("returns a 400 status if error with sending a text", async () => {
       request.body = {
         patientName: "Bob Smith",
-        contactNumber: "john@smith.com",
+        contactNumber: "07123456789",
         contactEmail: "john@smith.com",
         contactName: "John Smith",
         callTime: frozenTime,
@@ -238,7 +238,7 @@ describe("/api/book-a-visit", () => {
     it("returns a 400 status if error with sending an email", async () => {
       request.body = {
         patientName: "Bob Smith",
-        contactNumber: "john@smith.com",
+        contactNumber: "07123456789",
         contactEmail: "john@smith.com",
         contactName: "John Smith",
         callTime: frozenTime,
@@ -352,7 +352,9 @@ describe("/api/book-a-visit", () => {
     expect(response.status).toHaveBeenCalledWith(400);
     expect(createVisitSpy).not.toHaveBeenCalled();
     expect(response.end).toHaveBeenCalledWith(
-      JSON.stringify({ err: "contactEmail must be a valid email address" })
+      JSON.stringify({
+        err: { contactEmail: "contactEmail must be a valid email address" },
+      })
     );
   });
 
@@ -373,7 +375,9 @@ describe("/api/book-a-visit", () => {
     expect(response.status).toHaveBeenCalledWith(400);
     expect(createVisitSpy).not.toHaveBeenCalled();
     expect(response.end).toHaveBeenCalledWith(
-      JSON.stringify({ err: "contactNumber must be a valid mobile number" })
+      JSON.stringify({
+        err: { contactNumber: "contactNumber must be a valid mobile number" },
+      })
     );
   });
 
@@ -388,7 +392,12 @@ describe("/api/book-a-visit", () => {
     expect(response.status).toHaveBeenCalledWith(400);
     expect(createVisitSpy).not.toHaveBeenCalled();
     expect(response.end).toHaveBeenCalledWith(
-      JSON.stringify({ err: "contactNumber or contactEmail must be present" })
+      JSON.stringify({
+        err: {
+          contactEmail: "contactNumber or contactEmail must be present",
+          contactNumber: "contactNumber or contactEmail must be present",
+        },
+      })
     );
   });
 

--- a/src/helpers/validateMobileNumber.js
+++ b/src/helpers/validateMobileNumber.js
@@ -2,10 +2,15 @@ import { PhoneNumberUtil, PhoneNumberType } from "google-libphonenumber";
 
 export default (input) => {
   const validator = PhoneNumberUtil.getInstance();
-  const parsed = validator.parseAndKeepRawInput(input, "GB");
 
-  return (
-    validator.isValidNumber(parsed) &&
-    validator.getNumberType(parsed) === PhoneNumberType.MOBILE
-  );
+  try {
+    const parsed = validator.parseAndKeepRawInput(input, "GB");
+
+    return (
+      validator.isValidNumber(parsed) &&
+      validator.getNumberType(parsed) === PhoneNumberType.MOBILE
+    );
+  } catch (error) {
+    return false;
+  }
 };

--- a/src/helpers/validateMobileNumber.test.js
+++ b/src/helpers/validateMobileNumber.test.js
@@ -5,16 +5,24 @@ describe("validateMobileNumber", () => {
     const actual = validateMobileNumber("07123456789");
     expect(actual).toEqual(true);
   });
+
   it("accepts an Italian mobile number (+)", () => {
     const actual = validateMobileNumber("+393123456789");
     expect(actual).toEqual(true);
   });
+
   it("accepts an Italian mobile number (00)", () => {
     const actual = validateMobileNumber("00393123456789");
     expect(actual).toEqual(true);
   });
+
   it("rejects a UK landline number", () => {
     const actual = validateMobileNumber("02045678901");
+    expect(actual).toEqual(false);
+  });
+
+  it("rejects a random string", () => {
+    const actual = validateMobileNumber("invalidMobileNumber");
     expect(actual).toEqual(false);
   });
 });

--- a/src/helpers/validateVisit.js
+++ b/src/helpers/validateVisit.js
@@ -1,0 +1,56 @@
+import validateEmailAddress from "./validateEmailAddress";
+import isPresent from "./isPresent";
+import validateMobileNumber from "./validateMobileNumber";
+import validateDateAndTime from "./validateDateAndTime";
+
+export const validateVisit = ({
+  patientName,
+  contactName,
+  contactEmail,
+  contactNumber,
+  callTime,
+}) => {
+  let errors = {};
+
+  if (!isPresent(patientName)) {
+    errors.patientName = "patientName must be present";
+  }
+
+  if (!isPresent(contactName)) {
+    errors.contactName = "contactName must be present";
+  }
+
+  if (!isPresent(callTime)) {
+    errors.callTime = "callTime must be present";
+  } else {
+    const { isValidTime, isValidDate, errorMessage } = validateDateAndTime(
+      callTime
+    );
+
+    if (!isValidTime || !isValidDate) {
+      errors.callTime = errorMessage;
+    }
+  }
+
+  if (!isPresent(contactNumber) && !isPresent(contactEmail)) {
+    errors.contactEmail = "contactNumber or contactEmail must be present";
+    errors.contactNumber = "contactNumber or contactEmail must be present";
+  } else {
+    if (contactEmail && !validateEmailAddress(contactEmail)) {
+      errors.contactEmail = "contactEmail must be a valid email address";
+    }
+    if (contactNumber && !validateMobileNumber(contactNumber)) {
+      errors.contactNumber = "contactNumber must be a valid mobile number";
+    }
+  }
+
+  const hasErrors = Object.keys(errors).length;
+
+  if (hasErrors) {
+    return { validVisit: false, errors };
+  } else {
+    return { validVisit: true, errors: null };
+  }
+};
+
+export default validateVisit;

--- a/src/helpers/validateVisit.test.js
+++ b/src/helpers/validateVisit.test.js
@@ -1,0 +1,199 @@
+import validateVisit from "./validateVisit";
+import MockDate from "mockdate";
+
+describe("validateVisit", () => {
+  beforeAll(() => {
+    MockDate.set(new Date("2020-06-01 13:00"));
+  });
+
+  afterAll(() => {
+    MockDate.reset();
+  });
+
+  describe("when a valid visit is provided", () => {
+    it("returns true for validVisit", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "meow@example.com",
+        contactNumber: "07123456789",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeTruthy();
+      expect(errors).toBeNull;
+    });
+
+    it("returns true for validVisit if contact number is not provided but contact email is", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "meow@example.com",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeTruthy();
+      expect(errors).toBeNull;
+    });
+
+    it("returns true for validVisit if contact email is not provided but contact number is", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactNumber: "07123456789",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeTruthy();
+      expect(errors).toBeNull;
+    });
+  });
+
+  describe("when an invalid visit is provided", () => {
+    it("returns an error for patientName if patient name is not provided", () => {
+      const visit = {
+        contactName: "Meow Meowington",
+        contactEmail: "meow@example.com",
+        contactNumber: "07123456789",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({ patientName: "patientName must be present" });
+    });
+
+    it("returns an error for contactName if contact name is not provided", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactEmail: "meow@example.com",
+        contactNumber: "07123456789",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({ contactName: "contactName must be present" });
+    });
+
+    it("returns an error for callTime if call time is not provided", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "meow@example.com",
+        contactNumber: "07123456789",
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({ callTime: "callTime must be present" });
+    });
+
+    it("returns an error for callTime if invalid call date", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "meow@example.com",
+        contactNumber: "07123456789",
+        callTime: new Date("2020-06-01 09:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors.callTime).not.toBeUndefined();
+    });
+
+    it("returns an error for contactEmail and contactNumber if both are not provided", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({
+        contactEmail: "contactNumber or contactEmail must be present",
+        contactNumber: "contactNumber or contactEmail must be present",
+      });
+    });
+
+    it("returns an error for contactEmail if invalid email address", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "invalidEmailAddress",
+        contactNumber: "07123456789",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({
+        contactEmail: "contactEmail must be a valid email address",
+      });
+    });
+
+    it("returns an error for contactNumber if invalid mobile number", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "meow@example.com",
+        contactNumber: "invalidMobileNumber",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({
+        contactNumber: "contactNumber must be a valid mobile number",
+      });
+    });
+
+    it("returns errors for contactEmail and contactNumber if both invalid", () => {
+      const visit = {
+        patientName: "Woof Woofington",
+        contactName: "Meow Meowington",
+        contactEmail: "invalidEmailAddress",
+        contactNumber: "invalidMobileNumber",
+        callTime: new Date("2020-06-01 13:00"),
+      };
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({
+        contactEmail: "contactEmail must be a valid email address",
+        contactNumber: "contactNumber must be a valid mobile number",
+      });
+    });
+
+    it("returns multiple errors at once", () => {
+      const visit = {};
+
+      const { validVisit, errors } = validateVisit(visit);
+
+      expect(validVisit).toBeFalsy();
+      expect(errors).toEqual({
+        patientName: "patientName must be present",
+        contactName: "contactName must be present",
+        callTime: "callTime must be present",
+        contactEmail: "contactNumber or contactEmail must be present",
+        contactNumber: "contactNumber or contactEmail must be present",
+      });
+    });
+  });
+});


### PR DESCRIPTION
# What

Extract a `validateVisit` helper from `book-a-visit` API endpoint.

# Why

So that we can share the validation of a visit with our soon to be created `edit-a-visit` API endpoint.

# Screenshots

N/A

# Notes

- Best reviewed commit by commit.
- This slightly changes the response when a visit is invalid. Instead of only a single error being returned, all possible errors are returned.
- Refactoring suggestions for the helper are welcome!