### PR TITLE
Extract a usecase from the book-a-visit API for sending a booking notification

### DIFF
--- a/src/usecases/sendBookingNotification.js
+++ b/src/usecases/sendBookingNotification.js
@@ -1,0 +1,72 @@
+import TemplateStore from "../gateways/GovNotify/TemplateStore";
+import formatDateAndTime from "../../src/helpers/formatDateAndTime";
+import formatDate from "../../src/helpers/formatDate";
+import formatTime from "../../src/helpers/formatTime";
+import ConsoleNotifyProvider from "../providers/ConsoleNotifyProvider";
+
+const sendBookingNotification = ({
+  getSendTextMessage,
+  getSendEmail,
+}) => async ({
+  mobileNumber,
+  emailAddress,
+  wardName,
+  hospitalName,
+  visitDateAndTime,
+}) => {
+  const textMessageTemplateId = TemplateStore.firstText.templateId;
+  const emailTemplateId = TemplateStore.firstEmail.templateId;
+
+  const personalisation = {
+    visit_date: formatDate(visitDateAndTime),
+    visit_time: formatTime(visitDateAndTime),
+    ward_name: wardName,
+    hospital_name: hospitalName,
+  };
+
+  const sendMessage = getSendTextMessage();
+  const sendEmail = getSendEmail();
+
+  let textMessageError = null;
+
+  if (mobileNumber) {
+    const { error } = await sendMessage(
+      textMessageTemplateId,
+      mobileNumber,
+      personalisation,
+      null
+    );
+
+    textMessageError = error;
+  }
+
+  let emailError = null;
+
+  if (emailAddress) {
+    const { error } = await sendEmail(
+      emailTemplateId,
+      emailAddress,
+      personalisation,
+      null
+    );
+
+    emailError = error;
+  }
+
+  if (textMessageError || emailError) {
+    return {
+      success: false,
+      errors: { textMessageError, emailError },
+    };
+  } else {
+    const consoleNotifyProvider = new ConsoleNotifyProvider();
+    consoleNotifyProvider.notify(formatDateAndTime(visitDateAndTime));
+
+    return {
+      success: true,
+      errors: null,
+    };
+  }
+};
+
+export default sendBookingNotification;

--- a/src/usecases/sendBookingNotification.test.js
+++ b/src/usecases/sendBookingNotification.test.js
@@ -1,0 +1,177 @@
+import sendBookingNotification from "./sendBookingNotification";
+import TemplateStore from "../gateways/GovNotify/TemplateStore";
+
+describe("sendBookingNotification", () => {
+  const textMessageTemplateId = TemplateStore.firstText.templateId;
+  const emailTemplateId = TemplateStore.firstEmail.templateId;
+  const mobileNumber = "07123456789";
+  const emailAddress = "test@example.com";
+  const wardName = "Test Ward";
+  const hospitalName = "Test Hospital";
+  const visitDateAndTime = new Date("2020-06-01 13:00");
+  const personalisation = {
+    visit_date: "1 June 2020",
+    visit_time: "1:00pm",
+    ward_name: wardName,
+    hospital_name: hospitalName,
+  };
+
+  let sendTextMessage;
+  let sendEmail;
+  let container;
+
+  beforeEach(() => {
+    sendTextMessage = jest
+      .fn()
+      .mockResolvedValue({ success: true, error: null });
+    sendEmail = jest.fn().mockResolvedValue({ success: true, error: null });
+    container = {
+      getSendTextMessage: () => sendTextMessage,
+      getSendEmail: () => sendEmail,
+    };
+  });
+
+  describe("when a mobile number and email address is provided", () => {
+    it("sends a text message and email", async () => {
+      const { success, errors } = await sendBookingNotification(container)({
+        mobileNumber,
+        emailAddress,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+      });
+
+      expect(success).toBeTruthy();
+      expect(errors).toBeNull();
+      expect(sendTextMessage).toHaveBeenCalledWith(
+        textMessageTemplateId,
+        mobileNumber,
+        personalisation,
+        null
+      );
+      expect(sendEmail).toHaveBeenCalledWith(
+        emailTemplateId,
+        emailAddress,
+        personalisation,
+        null
+      );
+    });
+
+    it("returns an error if sending a text message and email fails", async () => {
+      sendTextMessage = jest.fn().mockResolvedValue({
+        success: false,
+        error: "Failed to send text message!",
+      });
+      sendEmail = jest
+        .fn()
+        .mockResolvedValue({ success: false, error: "Failed to send email!" });
+      container = {
+        getSendTextMessage: () => sendTextMessage,
+        getSendEmail: () => sendEmail,
+      };
+
+      const { success, errors } = await sendBookingNotification(container)({
+        mobileNumber,
+        emailAddress,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+      });
+
+      expect(success).toBeFalsy();
+      expect(errors).toEqual({
+        emailError: "Failed to send email!",
+        textMessageError: "Failed to send text message!",
+      });
+    });
+  });
+
+  describe("when only a mobile number is provided", () => {
+    it("sends a text message", async () => {
+      const { success, errors } = await sendBookingNotification(container)({
+        mobileNumber,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+      });
+
+      expect(success).toBeTruthy();
+      expect(errors).toBeNull();
+      expect(sendTextMessage).toHaveBeenCalledWith(
+        textMessageTemplateId,
+        mobileNumber,
+        personalisation,
+        null
+      );
+      expect(sendEmail).not.toHaveBeenCalled();
+    });
+
+    it("returns an error if sending a text message fails", async () => {
+      sendTextMessage = jest.fn().mockResolvedValue({
+        success: false,
+        error: "Failed to send text message!",
+      });
+      container = {
+        getSendTextMessage: () => sendTextMessage,
+        getSendEmail: () => sendEmail,
+      };
+
+      const { success, errors } = await sendBookingNotification(container)({
+        mobileNumber,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+      });
+
+      expect(success).toBeFalsy();
+      expect(errors).toEqual({
+        emailError: null,
+        textMessageError: "Failed to send text message!",
+      });
+    });
+  });
+
+  describe("when only an email address is provided", () => {
+    it("sends an email", async () => {
+      const { success, errors } = await sendBookingNotification(container)({
+        emailAddress,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+      });
+
+      expect(success).toBeTruthy();
+      expect(errors).toBeNull();
+      expect(sendEmail).toHaveBeenCalledWith(
+        emailTemplateId,
+        emailAddress,
+        personalisation,
+        null
+      );
+      expect(sendTextMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns an error if sending an email fails", async () => {
+    sendEmail = jest
+      .fn()
+      .mockResolvedValue({ success: false, error: "Failed to send email!" });
+    container = {
+      getSendTextMessage: () => sendTextMessage,
+      getSendEmail: () => sendEmail,
+    };
+
+    const { success, errors } = await sendBookingNotification(container)({
+      emailAddress,
+      wardName,
+      hospitalName,
+      visitDateAndTime,
+    });
+
+    expect(success).toBeFalsy();
+    expect(errors).toEqual({
+      emailError: "Failed to send email!",
+      textMessageError: null,
+    });
+  });
+});


### PR DESCRIPTION
# What

Extract a usecase from the `book-a-visit` API for sending a booking notification.

This works out whether to send a booking notification via text message or email. Eventually it will work out whether to send a booking confirmation or an updated visit notification.

# Why

So it can be reused when we create a `edit-a-visit` API endpoint for editing a visit.

# Screenshots

N/A

# Notes

Next step is to use this usecase in the `book-a-visit` API endpoint. Then update this usecase so it works out whether to send a booking confirmation or an updated visit notification.
