### PR TITLE
Refactor book-a-visit API to use sendBookingNotification usecase

### DIFF
--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -43,6 +43,7 @@ import retrieveReportingStartDateByTrustId from "../usecases/retrieveReportingSt
 import retrieveSurveyUrlByCallId from "../usecases/retrieveSurveyUrlByCallId";
 import retrieveSupportUrlByCallId from "../usecases/retrieveSupportUrlByCallId";
 import updateVisitByCallId from "../usecases/updateVisitByCallId";
+import sendBookingNotification from "../usecases/sendBookingNotification";
 
 class AppContainer {
   getDb = () => {
@@ -223,6 +224,10 @@ class AppContainer {
 
   getUpdateVisitByCallId = () => {
     return updateVisitByCallId(this);
+  };
+
+  getSendBookingNotification = () => {
+    return sendBookingNotification(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -119,4 +119,8 @@ describe("AppContainer", () => {
   it("returns getUpdateVisitByCallId", () => {
     expect(container.getUpdateVisitByCallId()).toBeDefined();
   });
+
+  it("returns getSendBookingNotification", () => {
+    expect(container.getSendBookingNotification()).toBeDefined();
+  });
 });


### PR DESCRIPTION
# What

Refactor `book-a-visit` API to use `sendBookingNotification` usecase. 

# Why

Previous PR https://github.com/madetech/nhs-virtual-visit/pull/508, added a new usecase to wrap the sending of the email or text message when a visit is booked.

# Screenshots

N/A

# Notes

Next step is to update the `sendBookingNotification` usecase to decide whether to send the booking confirmation notification or the updated visit one.