### PR TITLE
Send visit updated notifications via the sendBookingNotification usecase

### DIFF
--- a/__mocks__/notifications-node-client.js
+++ b/__mocks__/notifications-node-client.js
@@ -25,7 +25,7 @@ export class NotifyClient {
     }
 
     if (
-      Object.values(TemplateStore).findIndex(
+      Object.values(TemplateStore()).findIndex(
         (it) => it.templateId === templateId
       ) === -1
     ) {
@@ -51,7 +51,7 @@ export class NotifyClient {
   };
 
   _validatePersonalisation = (templateId, personalisation) => {
-    const template = Object.values(TemplateStore).filter(
+    const template = Object.values(TemplateStore()).filter(
       (it) => it.templateId === templateId
     )[0];
 

--- a/pageTests/api/send-visit-ready-notification.test.js
+++ b/pageTests/api/send-visit-ready-notification.test.js
@@ -105,7 +105,7 @@ describe("send-visit-ready-notification", () => {
         });
 
         expect(sendTextMessageSpy).toHaveBeenCalledWith(
-          TemplateStore.secondText.templateId,
+          TemplateStore().secondText.templateId,
           "07123456789",
           {
             call_url:
@@ -170,7 +170,7 @@ describe("send-visit-ready-notification", () => {
         });
 
         expect(sendEmailSpy).toHaveBeenCalledWith(
-          TemplateStore.secondEmail.templateId,
+          TemplateStore().secondEmail.templateId,
           "leslie@knope.com",
           {
             call_url:
@@ -271,7 +271,7 @@ describe("send-visit-ready-notification", () => {
         });
 
         expect(sendTextMessageSpy).toHaveBeenCalledWith(
-          TemplateStore.secondText.templateId,
+          TemplateStore().secondText.templateId,
           "07123456789",
           {
             call_url:

--- a/pages/api/send-visit-ready-notification.js
+++ b/pages/api/send-visit-ready-notification.js
@@ -33,10 +33,10 @@ export default withContainer(async (req, res, { container }) => {
   const visitsUrl = `${origin}/visits/${callId}?name=Ward`;
 
   const sendTextMessage = container.getSendTextMessage();
-  const secondTextTemplateId = TemplateStore.secondText.templateId;
+  const secondTextTemplateId = TemplateStore().secondText.templateId;
 
   const sendEmail = container.getSendEmail();
-  const secondEmailTemplateId = TemplateStore.secondEmail.templateId;
+  const secondEmailTemplateId = TemplateStore().secondEmail.templateId;
 
   try {
     const { ward, error } = await container.getRetrieveWardById()(

--- a/src/gateways/GovNotify/TemplateStore.js
+++ b/src/gateways/GovNotify/TemplateStore.js
@@ -1,46 +1,48 @@
-export default {
-  firstText: {
-    templateId: process.env.SMS_INITIAL_TEMPLATE_ID,
-    personalisationKeys: [
-      "hospital_name",
-      "ward_name",
-      "visit_date",
-      "visit_time",
-    ],
-  },
-  updatedVisitText: {
-    templateId: process.env.SMS_UPDATED_VISIT_TEMPLATE_ID,
-    personalisationKeys: [
-      "hospital_name",
-      "ward_name",
-      "visit_date",
-      "visit_time",
-    ],
-  },
-  secondText: {
-    templateId: process.env.SMS_JOIN_TEMPLATE_ID,
-    personalisationKeys: ["call_url", "ward_name", "hospital_name"],
-  },
-  firstEmail: {
-    templateId: process.env.EMAIL_INITIAL_TEMPLATE_ID,
-    personalisationKeys: [
-      "hospital_name",
-      "ward_name",
-      "visit_date",
-      "visit_time",
-    ],
-  },
-  updatedVisitEmail: {
-    templateId: process.env.EMAIL_UPDATED_VISIT_TEMPLATE_ID,
-    personalisationKeys: [
-      "hospital_name",
-      "ward_name",
-      "visit_date",
-      "visit_time",
-    ],
-  },
-  secondEmail: {
-    templateId: process.env.EMAIL_JOIN_TEMPLATE_ID,
-    personalisationKeys: ["call_url", "ward_name", "hospital_name"],
-  },
+export default () => {
+  return {
+    firstText: {
+      templateId: process.env.SMS_INITIAL_TEMPLATE_ID,
+      personalisationKeys: [
+        "hospital_name",
+        "ward_name",
+        "visit_date",
+        "visit_time",
+      ],
+    },
+    updatedVisitText: {
+      templateId: process.env.SMS_UPDATED_VISIT_TEMPLATE_ID,
+      personalisationKeys: [
+        "hospital_name",
+        "ward_name",
+        "visit_date",
+        "visit_time",
+      ],
+    },
+    secondText: {
+      templateId: process.env.SMS_JOIN_TEMPLATE_ID,
+      personalisationKeys: ["call_url", "ward_name", "hospital_name"],
+    },
+    firstEmail: {
+      templateId: process.env.EMAIL_INITIAL_TEMPLATE_ID,
+      personalisationKeys: [
+        "hospital_name",
+        "ward_name",
+        "visit_date",
+        "visit_time",
+      ],
+    },
+    updatedVisitEmail: {
+      templateId: process.env.EMAIL_UPDATED_VISIT_TEMPLATE_ID,
+      personalisationKeys: [
+        "hospital_name",
+        "ward_name",
+        "visit_date",
+        "visit_time",
+      ],
+    },
+    secondEmail: {
+      templateId: process.env.EMAIL_JOIN_TEMPLATE_ID,
+      personalisationKeys: ["call_url", "ward_name", "hospital_name"],
+    },
+  };
 };

--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -31,7 +31,7 @@ const contractTestClient = (testCallback) => () => {
 describe(
   "GovNotify contract sms tests",
   contractTestClient(({ client }) => {
-    const { templateId, personalisationKeys } = TemplateStore.firstText;
+    const { templateId, personalisationKeys } = TemplateStore().firstText;
 
     const personalisation = fillObjectWithStrings(personalisationKeys);
 
@@ -113,7 +113,7 @@ describe(
 describe(
   "GovNotify contract email tests",
   contractTestClient(({ client }) => {
-    const { templateId, personalisationKeys } = TemplateStore.firstEmail;
+    const { templateId, personalisationKeys } = TemplateStore().firstEmail;
 
     const personalisation = fillObjectWithStrings(personalisationKeys);
 

--- a/src/usecases/sendBookingNotification.js
+++ b/src/usecases/sendBookingNotification.js
@@ -14,8 +14,8 @@ const sendBookingNotification = ({
   hospitalName,
   visitDateAndTime,
 }) => {
-  const textMessageTemplateId = TemplateStore.firstText.templateId;
-  const emailTemplateId = TemplateStore.firstEmail.templateId;
+  const textMessageTemplateId = TemplateStore().firstText.templateId;
+  const emailTemplateId = TemplateStore().firstEmail.templateId;
 
   const personalisation = {
     visit_date: formatDate(visitDateAndTime),

--- a/src/usecases/sendBookingNotification.js
+++ b/src/usecases/sendBookingNotification.js
@@ -5,7 +5,8 @@ import formatTime from "../../src/helpers/formatTime";
 import ConsoleNotifyProvider from "../providers/ConsoleNotifyProvider";
 
 const NEW_NOTIFICATION = "new";
-const NOTIFICATION_TYPES = [NEW_NOTIFICATION];
+const UPDATED_NOTIFICATION = "updated";
+const NOTIFICATION_TYPES = [NEW_NOTIFICATION, UPDATED_NOTIFICATION];
 
 const sendBookingNotification = ({
   getSendTextMessage,
@@ -84,6 +85,11 @@ const getTemplateIds = (notificationType) => {
   if (notificationType == NEW_NOTIFICATION) {
     textMessageTemplateId = TemplateStore().firstText.templateId;
     emailTemplateId = TemplateStore().firstEmail.templateId;
+  }
+
+  if (notificationType == UPDATED_NOTIFICATION) {
+    textMessageTemplateId = TemplateStore().updatedVisitText.templateId;
+    emailTemplateId = TemplateStore().updatedVisitEmail.templateId;
   }
 
   return { textMessageTemplateId, emailTemplateId };

--- a/src/usecases/sendBookingNotification.js
+++ b/src/usecases/sendBookingNotification.js
@@ -6,7 +6,6 @@ import ConsoleNotifyProvider from "../providers/ConsoleNotifyProvider";
 
 const NEW_NOTIFICATION = "new";
 const UPDATED_NOTIFICATION = "updated";
-const NOTIFICATION_TYPES = [NEW_NOTIFICATION, UPDATED_NOTIFICATION];
 
 const sendBookingNotification = ({
   getSendTextMessage,
@@ -19,9 +18,6 @@ const sendBookingNotification = ({
   visitDateAndTime,
   notificationType = NEW_NOTIFICATION,
 }) => {
-  if (!NOTIFICATION_TYPES.includes(notificationType))
-    throw `Unsupported notification type ${notificationType}`;
-
   const { textMessageTemplateId, emailTemplateId } = getTemplateIds(
     notificationType
   );
@@ -82,14 +78,17 @@ const getTemplateIds = (notificationType) => {
   let textMessageTemplateId;
   let emailTemplateId;
 
-  if (notificationType == NEW_NOTIFICATION) {
-    textMessageTemplateId = TemplateStore().firstText.templateId;
-    emailTemplateId = TemplateStore().firstEmail.templateId;
-  }
-
-  if (notificationType == UPDATED_NOTIFICATION) {
-    textMessageTemplateId = TemplateStore().updatedVisitText.templateId;
-    emailTemplateId = TemplateStore().updatedVisitEmail.templateId;
+  switch (notificationType) {
+    case NEW_NOTIFICATION:
+      textMessageTemplateId = TemplateStore().firstText.templateId;
+      emailTemplateId = TemplateStore().firstEmail.templateId;
+      break;
+    case UPDATED_NOTIFICATION:
+      textMessageTemplateId = TemplateStore().updatedVisitText.templateId;
+      emailTemplateId = TemplateStore().updatedVisitEmail.templateId;
+      break;
+    default:
+      throw `Unsupported notification type ${notificationType}`;
   }
 
   return { textMessageTemplateId, emailTemplateId };

--- a/src/usecases/sendBookingNotification.js
+++ b/src/usecases/sendBookingNotification.js
@@ -4,6 +4,9 @@ import formatDate from "../../src/helpers/formatDate";
 import formatTime from "../../src/helpers/formatTime";
 import ConsoleNotifyProvider from "../providers/ConsoleNotifyProvider";
 
+const NEW_NOTIFICATION = "new";
+const NOTIFICATION_TYPES = [NEW_NOTIFICATION];
+
 const sendBookingNotification = ({
   getSendTextMessage,
   getSendEmail,
@@ -13,9 +16,14 @@ const sendBookingNotification = ({
   wardName,
   hospitalName,
   visitDateAndTime,
+  notificationType = NEW_NOTIFICATION,
 }) => {
-  const textMessageTemplateId = TemplateStore().firstText.templateId;
-  const emailTemplateId = TemplateStore().firstEmail.templateId;
+  if (!NOTIFICATION_TYPES.includes(notificationType))
+    throw `Unsupported notification type ${notificationType}`;
+
+  const { textMessageTemplateId, emailTemplateId } = getTemplateIds(
+    notificationType
+  );
 
   const personalisation = {
     visit_date: formatDate(visitDateAndTime),
@@ -67,6 +75,18 @@ const sendBookingNotification = ({
       errors: null,
     };
   }
+};
+
+const getTemplateIds = (notificationType) => {
+  let textMessageTemplateId;
+  let emailTemplateId;
+
+  if (notificationType == NEW_NOTIFICATION) {
+    textMessageTemplateId = TemplateStore().firstText.templateId;
+    emailTemplateId = TemplateStore().firstEmail.templateId;
+  }
+
+  return { textMessageTemplateId, emailTemplateId };
 };
 
 export default sendBookingNotification;

--- a/src/usecases/sendBookingNotification.test.js
+++ b/src/usecases/sendBookingNotification.test.js
@@ -62,9 +62,10 @@ describe("sendBookingNotification", () => {
         success: false,
         error: "Failed to send text message!",
       });
-      sendEmail = jest
-        .fn()
-        .mockResolvedValue({ success: false, error: "Failed to send email!" });
+      sendEmail = jest.fn().mockResolvedValue({
+        success: false,
+        error: "Failed to send email!",
+      });
       container = {
         getSendTextMessage: () => sendTextMessage,
         getSendEmail: () => sendEmail,

--- a/src/usecases/sendBookingNotification.test.js
+++ b/src/usecases/sendBookingNotification.test.js
@@ -2,8 +2,8 @@ import sendBookingNotification from "./sendBookingNotification";
 import TemplateStore from "../gateways/GovNotify/TemplateStore";
 
 describe("sendBookingNotification", () => {
-  const textMessageTemplateId = TemplateStore.firstText.templateId;
-  const emailTemplateId = TemplateStore.firstEmail.templateId;
+  const textMessageTemplateId = TemplateStore().firstText.templateId;
+  const emailTemplateId = TemplateStore().firstEmail.templateId;
   const mobileNumber = "07123456789";
   const emailAddress = "test@example.com";
   const wardName = "Test Ward";

--- a/src/usecases/sendBookingNotification.test.js
+++ b/src/usecases/sendBookingNotification.test.js
@@ -2,8 +2,6 @@ import sendBookingNotification from "./sendBookingNotification";
 import TemplateStore from "../gateways/GovNotify/TemplateStore";
 
 describe("sendBookingNotification", () => {
-  const textMessageTemplateId = TemplateStore().firstText.templateId;
-  const emailTemplateId = TemplateStore().firstEmail.templateId;
   const mobileNumber = "07123456789";
   const emailAddress = "test@example.com";
   const wardName = "Test Ward";
@@ -15,6 +13,11 @@ describe("sendBookingNotification", () => {
     ward_name: wardName,
     hospital_name: hospitalName,
   };
+
+  let textMessageTemplateId;
+  let emailTemplateId;
+  let textMessageUpdatedTemplateId;
+  let emailUpdatedTemplateId;
 
   let sendTextMessage;
   let sendEmail;
@@ -29,6 +32,27 @@ describe("sendBookingNotification", () => {
       getSendTextMessage: () => sendTextMessage,
       getSendEmail: () => sendEmail,
     };
+
+    process.env.SMS_INITIAL_TEMPLATE_ID = "1";
+    process.env.SMS_UPDATED_VISIT_TEMPLATE_ID = "2";
+    process.env.SMS_JOIN_TEMPLATE_ID = "3";
+    process.env.EMAIL_INITIAL_TEMPLATE_ID = "4";
+    process.env.EMAIL_UPDATED_VISIT_TEMPLATE_ID = "5";
+    process.env.EMAIL_JOIN_TEMPLATE_ID = "6";
+
+    textMessageTemplateId = TemplateStore().firstText.templateId;
+    emailTemplateId = TemplateStore().firstEmail.templateId;
+    textMessageUpdatedTemplateId = TemplateStore().updatedVisitText.templateId;
+    emailUpdatedTemplateId = TemplateStore().updatedVisitEmail.templateId;
+  });
+
+  afterEach(() => {
+    process.env.SMS_INITIAL_TEMPLATE_ID = "";
+    process.env.SMS_UPDATED_VISIT_TEMPLATE_ID = "";
+    process.env.SMS_JOIN_TEMPLATE_ID = "";
+    process.env.EMAIL_INITIAL_TEMPLATE_ID = "";
+    process.env.EMAIL_UPDATED_VISIT_TEMPLATE_ID = "";
+    process.env.EMAIL_JOIN_TEMPLATE_ID = "";
   });
 
   describe("when a mobile number and email address is provided", () => {
@@ -178,11 +202,6 @@ describe("sendBookingNotification", () => {
 
   describe("when we set the notificationType to updated", () => {
     it("uses the correct text message and email template", async () => {
-      const textMessageUpdatedTemplateId = TemplateStore().updatedVisitText
-        .templateId;
-      const emailUpdatedTemplateId = TemplateStore().updatedVisitEmail
-        .templateId;
-
       const { success, errors } = await sendBookingNotification(container)({
         mobileNumber,
         emailAddress,

--- a/src/usecases/sendBookingNotification.test.js
+++ b/src/usecases/sendBookingNotification.test.js
@@ -175,4 +175,37 @@ describe("sendBookingNotification", () => {
       textMessageError: null,
     });
   });
+
+  describe("when we set the notificationType to updated", () => {
+    it("uses the correct text message and email template", async () => {
+      const textMessageUpdatedTemplateId = TemplateStore().updatedVisitText
+        .templateId;
+      const emailUpdatedTemplateId = TemplateStore().updatedVisitEmail
+        .templateId;
+
+      const { success, errors } = await sendBookingNotification(container)({
+        mobileNumber,
+        emailAddress,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+        notificationType: "updated",
+      });
+
+      expect(success).toBeTruthy();
+      expect(errors).toBeNull();
+      expect(sendTextMessage).toHaveBeenCalledWith(
+        textMessageUpdatedTemplateId,
+        mobileNumber,
+        personalisation,
+        null
+      );
+      expect(sendEmail).toHaveBeenCalledWith(
+        emailUpdatedTemplateId,
+        emailAddress,
+        personalisation,
+        null
+      );
+    });
+  });
 });

--- a/src/usecases/sendBookingNotification.test.js
+++ b/src/usecases/sendBookingNotification.test.js
@@ -227,4 +227,19 @@ describe("sendBookingNotification", () => {
       );
     });
   });
+
+  it("throws an error if the notificationType is not supported", async () => {
+    try {
+      await sendBookingNotification(container)({
+        mobileNumber,
+        emailAddress,
+        wardName,
+        hospitalName,
+        visitDateAndTime,
+        notificationType: "notsupported",
+      });
+    } catch (e) {
+      expect(e).toEqual("Unsupported notification type notsupported");
+    }
+  });
 });

--- a/src/usecases/sendEmail.test.js
+++ b/src/usecases/sendEmail.test.js
@@ -4,7 +4,7 @@ import sendEmail from "./sendEmail";
 import fillObjectWithStrings from "../testUtils/fillObjectWithStrings";
 
 describe("sendEmail", () => {
-  const { templateId, personalisationKeys } = TemplateStore.firstEmail;
+  const { templateId, personalisationKeys } = TemplateStore().firstEmail;
   const personalisation = fillObjectWithStrings(personalisationKeys);
 
   const emailAddress = "test@example.com";

--- a/src/usecases/sendTextMessage.test.js
+++ b/src/usecases/sendTextMessage.test.js
@@ -4,7 +4,7 @@ import sendTextMessage from "./sendTextMessage";
 import fillObjectWithStrings from "../testUtils/fillObjectWithStrings";
 
 describe("sendTextMessage", () => {
-  const { templateId, personalisationKeys } = TemplateStore.firstText;
+  const { templateId, personalisationKeys } = TemplateStore().firstText;
   const personalisation = fillObjectWithStrings(personalisationKeys);
 
   const phoneNumber = "07123456789";


### PR DESCRIPTION
# What
Updates the sendBookingNotification usecase to be able to send 'visit updated' notifications as well as 'new visit' notifications.

# Why
Allows us to use this usecase in the upcoming update-a-visit API to send notifications

# Screenshots

# Notes
