### PR TITLE
Add very basic edit visit success page

### DIFF
--- a/pageTests/wards/visits/[id]/edit-success.test.js
+++ b/pageTests/wards/visits/[id]/edit-success.test.js
@@ -1,0 +1,23 @@
+import { getServerSideProps } from "../../../../pages/wards/visits/[id]/edit-success";
+
+describe("wards/visits/[id]/edit-success", () => {
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      const anonymousReq = {
+        headers: {
+          cookie: "",
+        },
+      };
+
+      const res = {
+        writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+      };
+
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/wards/login",
+      });
+    });
+  });
+});

--- a/pages/wards/visits/[id]/edit-success.js
+++ b/pages/wards/visits/[id]/edit-success.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { GridRow, GridColumn } from "../../../../src/components/Grid";
+import ActionLink from "../../../../src/components/ActionLink";
+import AnchorLink from "../../../../src/components/AnchorLink";
+import Layout from "../../../../src/components/Layout";
+import verifyToken from "../../../../src/usecases/verifyToken";
+import propsWithContainer from "../../../../src/middleware/propsWithContainer";
+import { WARD_STAFF } from "../../../../src/helpers/userTypes";
+
+const EditVisitSuccess = () => (
+  <Layout
+    title="Virtual visit has been updated"
+    showNavigationBar={true}
+    showNavigationBarForType={WARD_STAFF}
+  >
+    <GridRow>
+      <GridColumn width="two-thirds">
+        <div
+          className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+          style={{ textAlign: "center" }}
+        >
+          <h1 className="nhsuk-panel__title">Virtual visit has been updated</h1>
+        </div>
+
+        <h2>What happens next</h2>
+
+        <ActionLink href={`/wards/book-a-visit`}>
+          Book a virtual visit
+        </ActionLink>
+        <p>
+          <AnchorLink href="/wards/visits">Return to virtual visits</AnchorLink>
+        </p>
+      </GridColumn>
+    </GridRow>
+  </Layout>
+);
+
+export const getServerSideProps = propsWithContainer(
+  verifyToken(() => {
+    return {
+      props: {},
+    };
+  })
+);
+
+export default EditVisitSuccess;


### PR DESCRIPTION
# What

Add very basic edit visit success page.

# Why

So that we can notify the ward staff when they've successfully updated a visit.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/87956097-843a0c00-caa6-11ea-825b-7a8c3aaaf585.png)

# Notes

N/A