### PR TITLE
Add retrieveVisitById usecase and update edit a visit page to use id instead of callId

### DIFF
--- a/pageTests/wards/visits/[id]/edit.test.js
+++ b/pageTests/wards/visits/[id]/edit.test.js
@@ -21,9 +21,11 @@ describe("wards/visits/[id]/edit", () => {
     });
 
     it("retrieves a visit", async () => {
+      const id = "1";
+      const wardId = "10";
       const callTime = new Date(2020, 1, 1, 15, 0);
 
-      const retrieveVisitByCallId = jest.fn().mockResolvedValue({
+      const retrieveVisitById = jest.fn().mockResolvedValue({
         scheduledCall: {
           id: "1",
           patientName: "Bob Smith",
@@ -37,16 +39,15 @@ describe("wards/visits/[id]/edit", () => {
       });
 
       const container = {
-        getUserIsAuthenticated: () => () => true,
+        getUserIsAuthenticated: () => jest.fn().mockResolvedValue({ wardId }),
         getRetrieveWardById: () => () => ({ error: null }),
         getTokenProvider: () => ({
           validate: jest.fn(() => ({
             type: "wardStaff",
-            wardId: 123,
-            trustId: 10,
+            wardId,
           })),
         }),
-        getRetrieveVisitByCallId: () => retrieveVisitByCallId,
+        getRetrieveVisitById: () => retrieveVisitById,
       };
 
       const { props } = await getServerSideProps({
@@ -55,12 +56,12 @@ describe("wards/visits/[id]/edit", () => {
             cookie: "token=123",
           },
         },
-        query: { id: "callId" },
+        query: { id },
         container,
       });
 
       expect(props).toEqual({
-        callId: "callId",
+        id: "1",
         initialPatientName: "Bob Smith",
         initialContactName: "John Smith",
         initialContactNumber: "07123456789",
@@ -73,7 +74,7 @@ describe("wards/visits/[id]/edit", () => {
           minute: 0,
         },
       });
-      expect(retrieveVisitByCallId).toBeCalledWith("callId");
+      expect(retrieveVisitById).toBeCalledWith({ id, wardId });
     });
   });
 });

--- a/pages/wards/visits/[id]/edit.js
+++ b/pages/wards/visits/[id]/edit.js
@@ -9,7 +9,7 @@ import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import { WARD_STAFF } from "../../../../src/helpers/userTypes";
 
 const EditAVisit = ({
-  callId,
+  id,
   initialPatientName,
   initialContactName,
   initialContactNumber,
@@ -20,7 +20,7 @@ const EditAVisit = ({
 
   const submit = () => {
     Router.push({
-      pathname: `/wards/visits/${callId}/edit-success`,
+      pathname: `/wards/visits/${id}/edit-success`,
     });
   };
 
@@ -50,12 +50,15 @@ const EditAVisit = ({
     </Layout>
   );
 };
-export const getServerSideProps = propsWithContainer(
-  verifyToken(async ({ query, container }) => {
-    const callId = query.id;
-    const retrieveVisitByCallId = container.getRetrieveVisitByCallId();
 
-    const { scheduledCall } = await retrieveVisitByCallId(callId);
+export const getServerSideProps = propsWithContainer(
+  verifyToken(async ({ authenticationToken, query, container }) => {
+    const { wardId } = authenticationToken;
+
+    const id = query.id;
+    const retrieveVisitById = container.getRetrieveVisitById();
+
+    const { scheduledCall } = await retrieveVisitById({ id, wardId });
 
     const callTime = new Date(scheduledCall.callTime);
 
@@ -69,7 +72,7 @@ export const getServerSideProps = propsWithContainer(
 
     return {
       props: {
-        callId,
+        id,
         initialPatientName: scheduledCall.patientName,
         initialContactName: scheduledCall.recipientName,
         initialContactNumber: scheduledCall.recipientNumber,

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -44,6 +44,7 @@ import retrieveSurveyUrlByCallId from "../usecases/retrieveSurveyUrlByCallId";
 import retrieveSupportUrlByCallId from "../usecases/retrieveSupportUrlByCallId";
 import updateVisitByCallId from "../usecases/updateVisitByCallId";
 import sendBookingNotification from "../usecases/sendBookingNotification";
+import retrieveVisitById from "../usecases/retrieveVisitById";
 
 class AppContainer {
   getDb = () => {
@@ -228,6 +229,10 @@ class AppContainer {
 
   getSendBookingNotification = () => {
     return sendBookingNotification(this);
+  };
+
+  getRetrieveVisitById = () => {
+    return retrieveVisitById(this);
   };
 }
 

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -123,4 +123,8 @@ describe("AppContainer", () => {
   it("returns getSendBookingNotification", () => {
     expect(container.getSendBookingNotification()).toBeDefined();
   });
+
+  it("returns getRetrieveVisitById", () => {
+    expect(container.getRetrieveVisitById()).toBeDefined();
+  });
 });

--- a/src/usecases/retrieveVisitById.contractTest.js
+++ b/src/usecases/retrieveVisitById.contractTest.js
@@ -1,0 +1,45 @@
+import AppContainer from "../containers/AppContainer";
+import {
+  setupWardWithinHospitalAndTrust,
+  setupVisit,
+} from "../testUtils/factories";
+
+describe("retrieveVisitById contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("retrieves a visit by id", async () => {
+    const { wardId } = await setupWardWithinHospitalAndTrust();
+
+    const { id } = await setupVisit({ wardId });
+
+    const { scheduledCall, error } = await container.getRetrieveVisitById()({
+      id,
+      wardId,
+    });
+
+    expect(scheduledCall).toEqual({
+      patientName: "Patient Name",
+      recipientName: "Contact Name",
+      recipientNumber: "",
+      recipientEmail: "contact@example.com",
+      callTime: new Date("2020-06-01 13:00"),
+      callId: "TESTCALLID",
+      provider: "TESTPROVIDER",
+      callPassword: "TESTCALLPASSWORD",
+      id,
+    });
+    expect(error).toBeNull();
+  });
+
+  it("returns an error if no id is provided", async () => {
+    const { error } = await container.getRetrieveVisitById()({ wardId: 1 });
+
+    expect(error).toEqual("An id must be provided.");
+  });
+
+  it("returns an error if no wardId is provided", async () => {
+    const { error } = await container.getRetrieveVisitById()({ id: 1 });
+
+    expect(error).toEqual("A wardId must be provided.");
+  });
+});

--- a/src/usecases/retrieveVisitById.js
+++ b/src/usecases/retrieveVisitById.js
@@ -1,0 +1,41 @@
+import { SCHEDULED } from "../../src/helpers/visitStatus";
+
+const retrieveVisitById = ({ getDb }) => async ({ id, wardId }) => {
+  if (!id) {
+    return { scheduledCall: null, error: "An id must be provided." };
+  }
+  if (!wardId) {
+    return { scheduledCall: null, error: "A wardId must be provided." };
+  }
+
+  const db = await getDb();
+
+  try {
+    const scheduledCall = await db.one(
+      `SELECT * FROM scheduled_calls_table WHERE id = $1 AND ward_id = $2 AND status = $3 LIMIT 1`,
+      [id, wardId, SCHEDULED]
+    );
+
+    return {
+      scheduledCall: {
+        id: scheduledCall.id,
+        patientName: scheduledCall.patient_name,
+        recipientName: scheduledCall.recipient_name,
+        recipientNumber: scheduledCall.recipient_number,
+        recipientEmail: scheduledCall.recipient_email,
+        callTime: scheduledCall.call_time,
+        callId: scheduledCall.call_id,
+        provider: scheduledCall.provider,
+        callPassword: scheduledCall.call_password,
+      },
+      error: null,
+    };
+  } catch (error) {
+    return {
+      scheduledCall: null,
+      error: error.message,
+    };
+  }
+};
+
+export default retrieveVisitById;


### PR DESCRIPTION
# What

Add `retrieveVisitById` usecase and update edit a visit page to use id instead of callId.

# Why

Makes more sense to the primary `id` than the `callId` when editing a visit as a ward staff. https://github.com/madetech/nhs-virtual-visit/pull/529#discussion_r458035470

# Screenshots

N/A

# Notes

The `retrieveVisitById` usecase takes in an `id` and `wardId` to ensure that you can only get visits of your own ward and therefore only edit visits in own ward. Is this okay?

Any thoughts on what do to when someone goes to the edit visit page of a visit not associated to their ward? Currently just blows up... 😅 