### PR TITLE
Refactor updateVisit usecase to use id instead of callId

### DIFF
--- a/pageTests/api/update-a-visit.test.js
+++ b/pageTests/api/update-a-visit.test.js
@@ -33,7 +33,7 @@ describe("/api/book-a-visit", () => {
     const userIsAuthenticatedSpy = jest.fn().mockResolvedValue(false);
     const container = {
       getUserIsAuthenticated: () => userIsAuthenticatedSpy,
-      getUpdateVisitByCallId: () => updateVisitSpy,
+      getUpdateVisitById: () => updateVisitSpy,
     };
 
     await updateAVisit(request, response, { container });
@@ -44,7 +44,7 @@ describe("/api/book-a-visit", () => {
     expect(updateVisitSpy).not.toHaveBeenCalled();
   });
 
-  it("rejects if callId is missing", async () => {
+  it("rejects if id is missing", async () => {
     const request = {
       method: "PATCH",
       headers: { cookie: "test" },
@@ -59,14 +59,14 @@ describe("/api/book-a-visit", () => {
     const updateVisitSpy = jest.fn();
     const container = {
       getUserIsAuthenticated: () => () => true,
-      getUpdateVisitByCallId: () => updateVisitSpy,
+      getUpdateVisitById: () => updateVisitSpy,
     };
 
     await updateAVisit(request, response, { container });
 
     expect(response.status).toHaveBeenCalledWith(400);
     expect(response.end).toHaveBeenCalledWith(
-      '{"err":{"callId":"callId must be present"}}'
+      '{"err":{"id":"id must be present"}}'
     );
     expect(updateVisitSpy).not.toHaveBeenCalled();
   });
@@ -76,7 +76,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "INVALID_NUMBER",
         contactName: "John Smith",
@@ -93,7 +93,7 @@ describe("/api/book-a-visit", () => {
     const container = {
       getUserIsAuthenticated: () => () => true,
       getValidateMobileNumber: () => () => false,
-      getUpdateVisitByCallId: () => updateVisitSpy,
+      getUpdateVisitById: () => updateVisitSpy,
     };
 
     await updateAVisit(request, response, { container });
@@ -110,7 +110,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactName: "John Smith",
         callTime: moment(),
@@ -125,7 +125,7 @@ describe("/api/book-a-visit", () => {
     const updateVisitSpy = jest.fn();
     const container = {
       getUserIsAuthenticated: () => () => true,
-      getUpdateVisitByCallId: () => updateVisitSpy,
+      getUpdateVisitById: () => updateVisitSpy,
     };
 
     await updateAVisit(request, response, { container });
@@ -142,7 +142,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "07123456789",
         contactName: "John Smith",
@@ -162,8 +162,8 @@ describe("/api/book-a-visit", () => {
     };
     const container = {
       getUserIsAuthenticated: () => () => true,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callNotFoundResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callNotFoundResult,
     };
 
     await updateAVisit(request, response, { container });
@@ -178,7 +178,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "07123456789",
         contactName: "John Smith",
@@ -204,8 +204,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => true,
-      getRetrieveVisitByCallId: () => () => callResult,
-      getUpdateVisitByCallId: () => () => {
+      getRetrieveVisitById: () => () => callResult,
+      getUpdateVisitById: () => () => {
         throw new Error();
       },
     };
@@ -223,7 +223,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "07123456789",
         contactName: "John Smith",
@@ -254,8 +254,8 @@ describe("/api/book-a-visit", () => {
     };
     const container = {
       getUserIsAuthenticated: () => () => true,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => () => {
         return { success: true, errors: null };
@@ -267,7 +267,7 @@ describe("/api/book-a-visit", () => {
     expect(response.status).toHaveBeenCalledWith(200);
     expect(updateVisitSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         recipientNumber: "07123456789",
         recipientName: "John Smith",
@@ -280,7 +280,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactEmail: "john.smith@madetech.com",
         contactName: "John Smith",
@@ -311,8 +311,8 @@ describe("/api/book-a-visit", () => {
     };
     const container = {
       getUserIsAuthenticated: () => () => true,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => () => {
         return { success: true, errors: null };
@@ -324,7 +324,7 @@ describe("/api/book-a-visit", () => {
     expect(response.status).toHaveBeenCalledWith(200);
     expect(updateVisitSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         recipientEmail: "john.smith@madetech.com",
         recipientName: "John Smith",
@@ -338,7 +338,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactEmail: "john.smith@madetech.com",
         contactName: "John Smith",
@@ -376,8 +376,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -395,7 +395,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactEmail: "john.smith@madetech.com",
         contactName: "John Smith",
@@ -432,8 +432,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -451,7 +451,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactEmail: "john.smith@madetech.com",
         contactName: "John Smith",
@@ -489,8 +489,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -509,7 +509,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactEmail: "john.smith@madetech.com",
         contactName: "John Smith",
@@ -547,8 +547,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -574,7 +574,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactEmail: "Alice.smith@madetech.com",
         contactName: "Alice Smith",
@@ -612,8 +612,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -639,7 +639,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "07123456789",
         contactName: "John Smith",
@@ -677,8 +677,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -705,7 +705,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "07123456789",
         contactName: "John Smith",
@@ -745,8 +745,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };
@@ -781,7 +781,7 @@ describe("/api/book-a-visit", () => {
       method: "PATCH",
       headers: { cookie: "test" },
       body: {
-        callId: "1",
+        id: "1",
         patientName: "Bob Smith",
         contactNumber: "07123456789",
         contactName: "John Smith",
@@ -822,8 +822,8 @@ describe("/api/book-a-visit", () => {
 
     const container = {
       getUserIsAuthenticated: () => () => userAuthResult,
-      getUpdateVisitByCallId: () => updateVisitSpy,
-      getRetrieveVisitByCallId: () => () => callResult,
+      getUpdateVisitById: () => updateVisitSpy,
+      getRetrieveVisitById: () => () => callResult,
       getRetrieveWardById: () => () => wardResult,
       getSendBookingNotification: () => sendBookingNotificationSpy,
     };

--- a/pages/api/update-a-visit.js
+++ b/pages/api/update-a-visit.js
@@ -41,8 +41,8 @@ export default withContainer(
       return;
     }
 
-    if (!body.callId) {
-      respond(400, { err: { callId: "callId must be present" } });
+    if (!body.id) {
+      respond(400, { err: { id: "id must be present" } });
       return;
     }
 
@@ -59,16 +59,14 @@ export default withContainer(
       return;
     }
 
-    const { scheduledCall } = await container.getRetrieveVisitByCallId()(
-      body.callId
-    );
+    const { scheduledCall } = await container.getRetrieveVisitById()(body.id);
     if (!scheduledCall) {
       respond(404, { err: "call does not exist" });
       return;
     }
 
     const updatedCall = {
-      callId: body.callId,
+      id: body.id,
       patientName: body.patientName,
       recipientName: body.contactName,
       recipientEmail: body.contactEmail,
@@ -77,7 +75,7 @@ export default withContainer(
     };
 
     try {
-      await container.getUpdateVisitByCallId()(updatedCall);
+      await container.getUpdateVisitById()(updatedCall);
       respond(200, { success: true });
     } catch (updateError) {
       console.log(updateError);

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -42,7 +42,7 @@ import retrieveAverageVisitsPerDayByTrustId from "../usecases/retrieveAverageVis
 import retrieveReportingStartDateByTrustId from "../usecases/retrieveReportingStartDateByTrustId";
 import retrieveSurveyUrlByCallId from "../usecases/retrieveSurveyUrlByCallId";
 import retrieveSupportUrlByCallId from "../usecases/retrieveSupportUrlByCallId";
-import updateVisitByCallId from "../usecases/updateVisitByCallId";
+import updateVisitById from "../usecases/updateVisitById";
 import sendBookingNotification from "../usecases/sendBookingNotification";
 import retrieveVisitById from "../usecases/retrieveVisitById";
 
@@ -223,8 +223,8 @@ class AppContainer {
     return retrieveSupportUrlByCallId(this);
   };
 
-  getUpdateVisitByCallId = () => {
-    return updateVisitByCallId(this);
+  getUpdateVisitById = () => {
+    return updateVisitById(this);
   };
 
   getSendBookingNotification = () => {

--- a/src/containers/AppContainer.test.js
+++ b/src/containers/AppContainer.test.js
@@ -116,8 +116,8 @@ describe("AppContainer", () => {
     expect(container.getRetrieveSupportUrlByCallId()).toBeDefined();
   });
 
-  it("returns getUpdateVisitByCallId", () => {
-    expect(container.getUpdateVisitByCallId()).toBeDefined();
+  it("returns getUpdateVisitById", () => {
+    expect(container.getUpdateVisitById()).toBeDefined();
   });
 
   it("returns getSendBookingNotification", () => {

--- a/src/usecases/updateVisitById.contractTest.js
+++ b/src/usecases/updateVisitById.contractTest.js
@@ -4,15 +4,15 @@ import {
   setupVisit,
 } from "../testUtils/factories";
 
-describe("updateVisitByCallId contract tests", () => {
+describe("updateVisitById contract tests", () => {
   const container = AppContainer.getInstance();
 
   it("updates the details of a visit", async () => {
     const { wardId } = await setupWardWithinHospitalAndTrust();
-    const { callId } = await setupVisit({ wardId });
+    const { id } = await setupVisit({ wardId });
 
-    const { visit, error } = await container.getUpdateVisitByCallId()({
-      callId,
+    const { visit, error } = await container.getUpdateVisitById()({
+      id,
       patientName: "Aang",
       recipientName: "Katara",
       recipientEmail: "katara@example.com",
@@ -31,8 +31,8 @@ describe("updateVisitByCallId contract tests", () => {
   it("returns an error if visit doesn't exisit", async () => {
     await setupWardWithinHospitalAndTrust();
 
-    const { visit, error } = await container.getUpdateVisitByCallId()({
-      callId: "fakeCallId",
+    const { visit, error } = await container.getUpdateVisitById()({
+      id: "fakeId",
       patientName: "Aang",
       recipientName: "Katara",
       recipientEmail: "katara@example.com",

--- a/src/usecases/updateVisitById.js
+++ b/src/usecases/updateVisitById.js
@@ -1,5 +1,5 @@
-const updateVisitByCallId = ({ getDb }) => async ({
-  callId,
+const updateVisitById = ({ getDb }) => async ({
+  id,
   patientName,
   recipientName,
   recipientEmail,
@@ -16,7 +16,7 @@ const updateVisitByCallId = ({ getDb }) => async ({
           recipient_number = $4,
           call_time = $5
       WHERE
-          call_id = $6
+          id = $6
       RETURNING *`,
       [
         patientName,
@@ -24,7 +24,7 @@ const updateVisitByCallId = ({ getDb }) => async ({
         recipientEmail,
         recipientNumber,
         callTime,
-        callId,
+        id,
       ]
     );
 
@@ -45,4 +45,4 @@ const updateVisitByCallId = ({ getDb }) => async ({
   }
 };
 
-export default updateVisitByCallId;
+export default updateVisitById;


### PR DESCRIPTION
# What

Refactor updateVisit usecase to use id instead of callId and update the `update-a-visit` API to retrieve and update a visit by `id` instead of `callId`.

# Why

Makes more sense to the primary id than the callId when editing a visit as a ward staff. https://github.com/madetech/nhs-virtual-visit/pull/529#discussion_r458035470

# Screenshots

N/A

# Notes

N/A