### PR TITLE
Fix 404 showing in console on edit visit success page

### DIFF
--- a/pages/wards/visits/[id]/edit-confirmation.js
+++ b/pages/wards/visits/[id]/edit-confirmation.js
@@ -71,7 +71,10 @@ const EditAVisitConfirmation = ({
       const { success, err } = await response.json();
 
       if (success) {
-        Router.push(`/wards/visits/${id}/edit-success`);
+        Router.push(
+          "/wards/visits/[id]/edit-success",
+          `/wards/visits/${id}/edit-success`
+        );
       } else {
         console.error(err);
       }


### PR DESCRIPTION
# What

Fix 404 showing in console on edit visit success page

# Why

This is caused by not passing in the correct values for `Router.push`
when using dynamic routes which needs a `pathname` (path in `pages` directory)
and `as` (path shown in browser URL).

See:
- https://nextjs.org/docs/api-reference/next/router#routerpush
- vercel/next.js#2208

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/88265185-f0925680-ccc4-11ea-8c2d-6b16b98295e7.png)

# Notes

I missed one out.
