### PR TITLE
Add fork sync github workflow

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -1,0 +1,18 @@
+name: Fork Sync
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fork Sync
+        uses: TG908/fork-sync@v1.1.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          owner: madetech
+          base: master
+          head: master
+          merge_method: merge

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Fork Sync
         uses: TG908/fork-sync@v1.1.7
+        if: github.repository == 'Kettering-General-Hospital/nhs-virtual-visit'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           owner: madetech


### PR DESCRIPTION
# What
Adds [fork sync](https://github.com/TG908/fork-sync) as a github workflow.

# Why
https://github.com/wei/pull relies on an external service which as been down for a while and is less reliable then using github actions

# Screenshots

# Notes
The workflow has been setup to explicitly declare which repos it will run on