### PR TITLE
Fix not sending updated visit text when mobile number is added

### DIFF
--- a/pages/api/update-a-visit.js
+++ b/pages/api/update-a-visit.js
@@ -106,7 +106,7 @@ export default withContainer(
 
         if (!notificationType)
           return {
-            success: null,
+            success: true,
             errors: null,
           };
 
@@ -126,7 +126,7 @@ export default withContainer(
           success: emailSuccess,
           errors: emailErrors,
         } = await sendNotification("email");
-        if (emailSuccess === false) {
+        if (!emailSuccess) {
           respond(500, { err: emailErrors });
           return;
         }
@@ -137,7 +137,7 @@ export default withContainer(
           success: numberSuccess,
           errors: numberErrors,
         } = await sendNotification("number");
-        if (numberSuccess === false) {
+        if (!numberSuccess) {
           respond(500, { err: numberErrors });
           return;
         }

--- a/pages/api/update-a-visit.js
+++ b/pages/api/update-a-visit.js
@@ -126,7 +126,7 @@ export default withContainer(
           success: emailSuccess,
           errors: emailErrors,
         } = await sendNotification("email");
-        if (!emailSuccess) {
+        if (emailSuccess === false) {
           respond(500, { err: emailErrors });
           return;
         }
@@ -137,7 +137,7 @@ export default withContainer(
           success: numberSuccess,
           errors: numberErrors,
         } = await sendNotification("number");
-        if (!numberSuccess) {
+        if (numberSuccess === false) {
           respond(500, { err: numberErrors });
           return;
         }

--- a/pages/api/update-a-visit.js
+++ b/pages/api/update-a-visit.js
@@ -104,7 +104,11 @@ export default withContainer(
             : scheduledCall.recipientNumber
         );
 
-        if (!notificationType) return;
+        if (!notificationType)
+          return {
+            success: null,
+            errors: null,
+          };
 
         const sendBookingNotification = container.getSendBookingNotification();
         return await sendBookingNotification({


### PR DESCRIPTION
# What

- Fix `TypeError` showing in terminal when no edit a visit notification.
- Fix not sending updated visit text when mobile number is added with an already existing email address.

# Why

We want to ensure that a text message is sent when a mobile number is added when updating the details of a booked visit.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/88290661-06b50c80-ccef-11ea-9b1e-a5c422e9dcf2.png)

# Notes

N/A