### PR TITLE
Mark pii cleared at for visits

### DIFF
--- a/db/migrations/20200723155729-add-pii-cleared-at-to-scheduled-calls-table.js
+++ b/db/migrations/20200723155729-add-pii-cleared-at-to-scheduled-calls-table.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var fs = require("fs");
+var path = require("path");
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20200723155729-add-pii-cleared-at-to-scheduled-calls-table-up.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      console.log("received data: " + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20200723155729-add-pii-cleared-at-to-scheduled-calls-table-down.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      console.log("received data: " + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/sqls/20200723155729-add-pii-cleared-at-to-scheduled-calls-table-down.sql
+++ b/db/migrations/sqls/20200723155729-add-pii-cleared-at-to-scheduled-calls-table-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scheduled_calls_table DROP COLUMN pii_cleared_at;

--- a/db/migrations/sqls/20200723155729-add-pii-cleared-at-to-scheduled-calls-table-up.sql
+++ b/db/migrations/sqls/20200723155729-add-pii-cleared-at-to-scheduled-calls-table-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE scheduled_calls_table ADD COLUMN pii_cleared_at timestamp with time zone;
+
+UPDATE scheduled_calls_table SET pii_cleared_at = NOW() WHERE STATUS = ANY('{complete,archived,cancelled}'::text[]);

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -24,22 +24,22 @@ async function cleanupScheduledCalls() {
   const db = await getDb();
 
   const scheduledCalls = await db.result(
-    `UPDATE scheduled_calls_table 
-     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1
+    `UPDATE scheduled_calls_table
+     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1, pii_cleared_at = NOW()
      WHERE call_time < (now() - INTERVAL '1 DAY') AND status = $2`,
     [status.COMPLETE, status.SCHEDULED]
   );
 
   const archivedCalls = await db.result(
-    `UPDATE scheduled_calls_table 
-     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null
+    `UPDATE scheduled_calls_table
+     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
      WHERE status = $1`,
     status.ARCHIVED
   );
 
   const cancelledCalls = await db.result(
-    `UPDATE scheduled_calls_table 
-     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null
+    `UPDATE scheduled_calls_table
+     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
      WHERE status = $1`,
     status.CANCELLED
   );
@@ -57,7 +57,7 @@ cleanupScheduledCalls()
   .then(function (result) {
     console.log(`
     ${result.completed} visits completed
-    ${result.archived} visits archived 
+    ${result.archived} visits archived
     ${result.cancelled} visits cancelled`);
   })
   .catch((error) => {


### PR DESCRIPTION
# What
Adds a pii_cleared_at field to the scheduled_calls_table

# Why
So that we know which records have not been cleared and can be returned in the retrieve visits usecases

# Screenshots

# Notes
