### PR TITLE
Update visit retrieving usecases to include complete visits that have not been cleared

### DIFF
--- a/db/scripts/cleanup_scheduled_calls.contractTest.js
+++ b/db/scripts/cleanup_scheduled_calls.contractTest.js
@@ -105,5 +105,11 @@ describe("test cleanup script", () => {
     // archived visit cannot be retrieved
     const archivedVisit = await container.getRetrieveVisitByCallId()("4");
     expect(archivedVisit.scheduledCall).toBeNull();
+
+    // Only the future visit is retrieved when retrieving all visits
+    const { scheduledCalls: visits } = await container.getRetrieveVisits()({
+      wardId,
+    });
+    expect(visits.map((visit) => visit.callId)).toEqual(["1"]);
   });
 });

--- a/db/scripts/cleanup_scheduled_calls.contractTest.js
+++ b/db/scripts/cleanup_scheduled_calls.contractTest.js
@@ -33,7 +33,7 @@ describe("test cleanup script", () => {
       callPassword: "securePassword",
     });
 
-    await container.getCreateVisit()({
+    const { id: pastVisitId } = await container.getCreateVisit()({
       patientName: "Bob Smith",
       contactEmail: "bob.smith@madetech.com",
       contactName: "John Smith",
@@ -90,6 +90,13 @@ describe("test cleanup script", () => {
     // past visit is now complete and cannot be retrieved
     const pastVisit = await container.getRetrieveVisitByCallId()("2");
     expect(pastVisit.scheduledCall).toBeNull();
+
+    // past visit is now complete and cannot be retrieved
+    const pastVisitById = await container.getRetrieveVisitById()({
+      id: pastVisitId,
+      wardId: wardId,
+    });
+    expect(pastVisitById.scheduledCall).toBeNull();
 
     // cancelled visit cannot be retrieved
     const cancelledVisit = await container.getRetrieveVisitByCallId()("3");

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -26,21 +26,21 @@ async function cleanupScheduledCalls() {
   const scheduledCalls = await db.result(
     `UPDATE scheduled_calls_table
      SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1, pii_cleared_at = NOW()
-     WHERE call_time < (now() - INTERVAL '1 DAY') AND status = $2`,
+     WHERE call_time < (now() - INTERVAL '1 DAY') AND status = $2 AND pii_cleared_at IS NULL`,
     [status.COMPLETE, status.SCHEDULED]
   );
 
   const archivedCalls = await db.result(
     `UPDATE scheduled_calls_table
      SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
-     WHERE status = $1`,
+     WHERE status = $1 AND pii_cleared_at IS NULL`,
     status.ARCHIVED
   );
 
   const cancelledCalls = await db.result(
     `UPDATE scheduled_calls_table
      SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
-     WHERE status = $1`,
+     WHERE status = $1 AND pii_cleared_at IS NULL`,
     status.CANCELLED
   );
 

--- a/src/usecases/retrieveVisitByCallId.js
+++ b/src/usecases/retrieveVisitByCallId.js
@@ -1,12 +1,14 @@
-import { SCHEDULED } from "../../src/helpers/visitStatus";
+import { SCHEDULED, COMPLETE } from "../../src/helpers/visitStatus";
 
 const retrieveVisitByCallId = ({ getDb }) => async (callId) => {
   const db = await getDb();
   console.log("Retrieving visit for  ", callId);
   try {
     const scheduledCalls = await db.any(
-      `SELECT * FROM scheduled_calls_table WHERE call_id = $1 AND status = $2 LIMIT 1`,
-      [callId, SCHEDULED]
+      `SELECT * FROM scheduled_calls_table
+         WHERE call_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
+         LIMIT 1`,
+      [callId, SCHEDULED, COMPLETE]
     );
 
     const scheduledCall = scheduledCalls[0];

--- a/src/usecases/retrieveVisitById.js
+++ b/src/usecases/retrieveVisitById.js
@@ -1,4 +1,4 @@
-import { SCHEDULED } from "../../src/helpers/visitStatus";
+import { SCHEDULED, COMPLETE } from "../../src/helpers/visitStatus";
 
 const retrieveVisitById = ({ getDb }) => async ({ id, wardId }) => {
   if (!id) {
@@ -12,8 +12,10 @@ const retrieveVisitById = ({ getDb }) => async ({ id, wardId }) => {
 
   try {
     const scheduledCall = await db.one(
-      `SELECT * FROM scheduled_calls_table WHERE id = $1 AND ward_id = $2 AND status = $3 LIMIT 1`,
-      [id, wardId, SCHEDULED]
+      `SELECT * FROM scheduled_calls_table
+         WHERE id = $1 AND ward_id = $2 AND status = ANY(ARRAY[$3,$4]::text[]) AND pii_cleared_at IS NULL
+         LIMIT 1`,
+      [id, wardId, SCHEDULED, COMPLETE]
     );
 
     return {

--- a/src/usecases/retrieveVisits.js
+++ b/src/usecases/retrieveVisits.js
@@ -1,13 +1,13 @@
-import { SCHEDULED } from "../../src/helpers/visitStatus";
+import { SCHEDULED, COMPLETE } from "../../src/helpers/visitStatus";
 
 const retrieveVisits = ({ getDb }) => async ({ wardId }) => {
   const db = await getDb();
   try {
-    let query = `SELECT * FROM scheduled_calls_table 
-                 WHERE ward_id = $1 AND status = $2
+    let query = `SELECT * FROM scheduled_calls_table
+                 WHERE ward_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
                  ORDER BY call_time ASC`;
 
-    const scheduledCalls = await db.any(query, [wardId, SCHEDULED]);
+    const scheduledCalls = await db.any(query, [wardId, SCHEDULED, COMPLETE]);
 
     return {
       scheduledCalls: scheduledCalls.map((scheduledCall) => ({

--- a/src/usecases/retrieveVisits.test.js
+++ b/src/usecases/retrieveVisits.test.js
@@ -38,7 +38,11 @@ describe("retrieveVisits", () => {
     });
 
     expect(error).toBeNull();
-    expect(anySpy).toHaveBeenCalledWith(expect.anything(), [1, "scheduled"]);
+    expect(anySpy).toHaveBeenCalledWith(expect.anything(), [
+      1,
+      "scheduled",
+      "complete",
+    ]);
     expect(scheduledCalls).toHaveLength(2);
     expect(scheduledCalls[0]).toEqual({
       id: 1,
@@ -78,10 +82,10 @@ describe("retrieveVisits", () => {
     });
 
     expect(anySpy).toHaveBeenCalledWith(
-      `SELECT * FROM scheduled_calls_table 
-                 WHERE ward_id = $1 AND status = $2
+      `SELECT * FROM scheduled_calls_table
+                 WHERE ward_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
                  ORDER BY call_time ASC`,
-      [1, "scheduled"]
+      [1, "scheduled", "complete"]
     );
   });
 


### PR DESCRIPTION
We eventually want to be able to mark visits as complete but still show them in the list screen. To do that we need to be able to differentiate between visits that have been cleared and which have not.

This change updates the visit retrieving usecases to check for complete visits where pii_cleared_at IS NULL, which signifies that they are safe to display to the user

# Screenshots

# Notes
