### PR TITLE
markVisitAsComplete usecase

### DIFF
--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -45,6 +45,7 @@ import retrieveSupportUrlByCallId from "../usecases/retrieveSupportUrlByCallId";
 import updateVisitById from "../usecases/updateVisitById";
 import sendBookingNotification from "../usecases/sendBookingNotification";
 import retrieveVisitById from "../usecases/retrieveVisitById";
+import markVisitAsComplete from "../usecases/markVisitAsComplete";
 
 class AppContainer {
   getDb = () => {
@@ -233,6 +234,10 @@ class AppContainer {
 
   getRetrieveVisitById = () => {
     return retrieveVisitById(this);
+  };
+
+  getMarkVisitAsComplete = () => {
+    return markVisitAsComplete(this);
   };
 }
 

--- a/src/usecases/markVisitAsComplete.contractTest.js
+++ b/src/usecases/markVisitAsComplete.contractTest.js
@@ -1,0 +1,48 @@
+import AppContainer from "../containers/AppContainer";
+import {
+  setupWardWithinHospitalAndTrust,
+  setupVisit,
+} from "../testUtils/factories";
+import { COMPLETE } from "../helpers/visitStatus";
+
+describe("markVisitAsComplete contract tests", () => {
+  const container = AppContainer.getInstance();
+
+  it("retrieves a visit by id", async () => {
+    const { wardId } = await setupWardWithinHospitalAndTrust();
+
+    const { id } = await setupVisit({ wardId });
+
+    const {
+      id: scheduledCallId,
+      error,
+    } = await container.getMarkVisitAsComplete()({
+      id,
+      wardId,
+    });
+
+    const { scheduledCall } = await container.getRetrieveVisitById()({
+      id: scheduledCallId,
+      wardId,
+    });
+
+    expect(error).toBeNull();
+    expect(scheduledCall).toEqual(
+      expect.objectContaining({
+        status: COMPLETE,
+      })
+    );
+  });
+
+  it("returns an error if no id is provided", async () => {
+    const { error } = await container.getMarkVisitAsComplete()({ wardId: 1 });
+
+    expect(error).toEqual("An id must be provided.");
+  });
+
+  it("returns an error if no wardId is provided", async () => {
+    const { error } = await container.getMarkVisitAsComplete()({ id: 1 });
+
+    expect(error).toEqual("A wardId must be provided.");
+  });
+});

--- a/src/usecases/markVisitAsComplete.js
+++ b/src/usecases/markVisitAsComplete.js
@@ -1,0 +1,36 @@
+import { COMPLETE } from "../helpers/visitStatus";
+
+const markVisitAsComplete = ({ getDb }) => async ({ id, wardId }) => {
+  if (!id) {
+    return { scheduledCall: null, error: "An id must be provided." };
+  }
+  if (!wardId) {
+    return { scheduledCall: null, error: "A wardId must be provided." };
+  }
+
+  const db = await getDb();
+
+  try {
+    const updatedVisit = await db.one(
+      `UPDATE scheduled_calls_table
+      SET status = $1
+      WHERE
+        id = $2
+      RETURNING id
+			`,
+      [COMPLETE, id]
+    );
+    return {
+      id: updatedVisit.id,
+      error: null,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      id: null,
+      error: error.toString(),
+    };
+  }
+};
+
+export default markVisitAsComplete;

--- a/src/usecases/retrieveVisitById.contractTest.js
+++ b/src/usecases/retrieveVisitById.contractTest.js
@@ -3,6 +3,7 @@ import {
   setupWardWithinHospitalAndTrust,
   setupVisit,
 } from "../testUtils/factories";
+import { SCHEDULED } from "../helpers/visitStatus";
 
 describe("retrieveVisitById contract tests", () => {
   const container = AppContainer.getInstance();
@@ -26,6 +27,7 @@ describe("retrieveVisitById contract tests", () => {
       callId: "TESTCALLID",
       provider: "TESTPROVIDER",
       callPassword: "TESTCALLPASSWORD",
+      status: SCHEDULED,
       id,
     });
     expect(error).toBeNull();

--- a/src/usecases/retrieveVisitById.js
+++ b/src/usecases/retrieveVisitById.js
@@ -29,6 +29,7 @@ const retrieveVisitById = ({ getDb }) => async ({ id, wardId }) => {
         callId: scheduledCall.call_id,
         provider: scheduledCall.provider,
         callPassword: scheduledCall.call_password,
+        status: scheduledCall.status,
       },
       error: null,
     };


### PR DESCRIPTION
# What
Adds a markVisitAsComplete usecase which updates the visit status to 'complete'

# Why
This will eventually allow us to mark a visit as complete when the patient ends the call.

# Screenshots

# Notes
