### PR TITLE
Complete visit API

### DIFF
--- a/pageTests/api/complete-visit.test.js
+++ b/pageTests/api/complete-visit.test.js
@@ -1,0 +1,132 @@
+import completeVisit from "../../pages/api/complete-visit";
+
+jest.mock("node-fetch");
+
+describe("/api/complete-visit", () => {
+  let response = {
+    status: jest.fn(),
+    setHeader: jest.fn(),
+    send: jest.fn(),
+    end: jest.fn(),
+    body: jest.fn(),
+  };
+
+  const validUserIsAuthenticatedSpy = jest.fn().mockResolvedValue({
+    wardId: 10,
+    ward: "MEOW",
+    trustId: 1,
+  });
+
+  it("returns 405 if not POST method", async () => {
+    await completeVisit({ method: "GET", body: {} }, response, {});
+
+    expect(response.status).toHaveBeenCalledWith(405);
+  });
+
+  it("returns a 401 if user is not authenticated", async () => {
+    const invalidUserIsAuthenticatedSpy = jest.fn().mockResolvedValue(false);
+
+    await completeVisit(
+      {
+        method: "POST",
+        body: {},
+        headers: {},
+      },
+      response,
+      {
+        container: {
+          getUserIsAuthenticated: () => invalidUserIsAuthenticatedSpy,
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(401);
+  });
+
+  it("returns a 400 if no callId provided", async () => {
+    await completeVisit(
+      {
+        method: "POST",
+        body: {},
+      },
+      response,
+      {
+        container: {
+          getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns a 401 if invalid callId", async () => {
+    await completeVisit(
+      {
+        method: "POST",
+        body: { callId: "123" },
+      },
+      response,
+      {
+        container: {
+          getRetrieveVisitByCallId: () =>
+            jest.fn().mockResolvedValue({
+              scheduledCall: null,
+              error: "failed to retrieve visit",
+            }),
+          getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(401);
+  });
+
+  it("returns 500 if mark visit complete failed", async () => {
+    await completeVisit(
+      {
+        method: "POST",
+        body: { callId: "123" },
+      },
+      response,
+      {
+        container: {
+          getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
+          getRetrieveVisitByCallId: () =>
+            jest.fn().mockResolvedValue({
+              scheduledCall: { id: "456" },
+              error: null,
+            }),
+          getMarkVisitAsComplete: () =>
+            jest.fn().mockResolvedValue({ id: null, error: "fail" }),
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(500);
+  });
+
+  it("returns 201 when a visit is marked as complete successfully", async () => {
+    await completeVisit(
+      {
+        method: "POST",
+        body: { callId: "123" },
+      },
+      response,
+      {
+        container: {
+          getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
+          getRetrieveVisitByCallId: () =>
+            jest.fn().mockResolvedValue({
+              scheduledCall: { id: "456" },
+              error: null,
+            }),
+          getMarkVisitAsComplete: () =>
+            jest.fn().mockResolvedValue({ id: "456", error: null }),
+        },
+      }
+    );
+
+    expect(response.status).toHaveBeenCalledWith(201);
+  });
+});

--- a/pages/api/complete-visit.js
+++ b/pages/api/complete-visit.js
@@ -1,0 +1,53 @@
+import withContainer from "../../src/middleware/withContainer";
+
+export default withContainer(
+  async ({ headers, body, method }, res, { container }) => {
+    if (method !== "POST") {
+      res.status(405);
+      res.end(JSON.stringify({ err: "Method not allowed" }));
+      return;
+    }
+
+    const userIsAuthenticated = container.getUserIsAuthenticated();
+    const userIsAuthenticatedResponse = await userIsAuthenticated(
+      headers?.cookie
+    );
+
+    if (!userIsAuthenticatedResponse) {
+      res.status(401);
+      res.end(JSON.stringify({ err: "Unauthorized" }));
+      return;
+    }
+
+    if (!body.callId) {
+      res.status(400);
+      res.end(JSON.stringify({ err: "callId must be present" }));
+      return;
+    }
+
+    const {
+      scheduledCall,
+      error: retrieveVisitError,
+    } = await container.getRetrieveVisitByCallId()(body.callId);
+
+    if (retrieveVisitError) {
+      console.error(retrieveVisitError);
+      res.status(401);
+      res.end(JSON.stringify({ err: "Visit not found" }));
+      return;
+    }
+
+    const { error } = await container.getMarkVisitAsComplete()({
+      id: scheduledCall.id,
+      wardId: userIsAuthenticatedResponse.wardId,
+    });
+
+    if (error) {
+      console.error(error);
+      res.status(500);
+      res.end(JSON.stringify({ err: "Unable to mark visit as complete" }));
+    } else {
+      res.status(201);
+    }
+  }
+);

--- a/src/usecases/markVisitAsComplete.contractTest.js
+++ b/src/usecases/markVisitAsComplete.contractTest.js
@@ -33,16 +33,4 @@ describe("markVisitAsComplete contract tests", () => {
       })
     );
   });
-
-  it("returns an error if no id is provided", async () => {
-    const { error } = await container.getMarkVisitAsComplete()({ wardId: 1 });
-
-    expect(error).toEqual("An id must be provided.");
-  });
-
-  it("returns an error if no wardId is provided", async () => {
-    const { error } = await container.getMarkVisitAsComplete()({ id: 1 });
-
-    expect(error).toEqual("A wardId must be provided.");
-  });
 });

--- a/src/usecases/markVisitAsComplete.js
+++ b/src/usecases/markVisitAsComplete.js
@@ -2,10 +2,10 @@ import { COMPLETE } from "../helpers/visitStatus";
 
 const markVisitAsComplete = ({ getDb }) => async ({ id, wardId }) => {
   if (!id) {
-    return { scheduledCall: null, error: "An id must be provided." };
+    return { id: null, error: "An id must be provided." };
   }
   if (!wardId) {
-    return { scheduledCall: null, error: "A wardId must be provided." };
+    return { id: null, error: "A wardId must be provided." };
   }
 
   const db = await getDb();

--- a/src/usecases/markVisitAsComplete.test.js
+++ b/src/usecases/markVisitAsComplete.test.js
@@ -1,0 +1,41 @@
+import markVisitAsComplete from "./markVisitAsComplete";
+
+describe("markVisitAsComplete", () => {
+  it("returns an error if no id is provided", async () => {
+    const { id, error } = await markVisitAsComplete({ async getDb() {} })({
+      wardId: 1,
+    });
+
+    expect(error).toEqual("An id must be provided.");
+    expect(id).toBeNull();
+  });
+
+  it("returns an error if no wardId is provided", async () => {
+    const { id, error } = await markVisitAsComplete({ async getDb() {} })({
+      id: 1,
+    });
+
+    expect(error).toEqual("A wardId must be provided.");
+    expect(id).toBeNull();
+  });
+
+  it("returns any errors thrown by the database query", async () => {
+    const container = {
+      async getDb() {
+        return {
+          one: jest.fn(() => {
+            throw "failure";
+          }),
+        };
+      },
+    };
+
+    const { id, error } = await markVisitAsComplete(container)({
+      id: 1,
+      wardId: 1,
+    });
+
+    expect(error).toEqual("failure");
+    expect(id).toBeNull();
+  });
+});


### PR DESCRIPTION
# What
Introduces a complete-visit API which will be used to mark visits are complete when a patient ends the call

# Why
So that we can keep track of complete visits and display this to status Ward Staff

# Screenshots

# Notes
