### PR TITLE
Complete visit on end call

### DIFF
--- a/db/scripts/cleanup_scheduled_calls.contractTest.js
+++ b/db/scripts/cleanup_scheduled_calls.contractTest.js
@@ -1,7 +1,12 @@
 const { cleanupScheduledCalls } = require("./cleanup_scheduled_calls");
 import AppContainer from "../../src/containers/AppContainer";
 import moment from "moment";
-import { setupTrust } from "../../src/testUtils/factories";
+import {
+  setupTrust,
+  setupHospital,
+  setupWard,
+  setupVisit,
+} from "../../src/testUtils/factories";
 
 describe("test cleanup script", () => {
   it("updates visit states and data correctly", async () => {
@@ -9,73 +14,44 @@ describe("test cleanup script", () => {
 
     const { trustId } = await setupTrust();
 
-    const { hospitalId } = await container.getCreateHospital()({
-      name: "Test Hospital",
-      trustId: trustId,
-    });
+    const { hospitalId } = await setupHospital({ trustId: trustId });
 
-    const { wardId } = await container.getCreateWard()({
-      name: "Test Ward 1",
+    const { wardId } = await setupWard({
       code: "wardCode1",
       hospitalId: hospitalId,
       trustId: trustId,
     });
 
-    await container.getCreateVisit()({
-      patientName: "Bob Smith",
-      contactEmail: "bob.smith@madetech.com",
-      contactName: "John Smith",
-      contactNumber: "07123456789",
+    await setupVisit({
       callTime: moment(),
       callId: "1",
-      provider: "jitsi",
       wardId: wardId,
-      callPassword: "securePassword",
     });
 
-    const { id: pastVisitId } = await container.getCreateVisit()({
-      patientName: "Bob Smith",
-      contactEmail: "bob.smith@madetech.com",
-      contactName: "John Smith",
-      contactNumber: "07123456789",
+    const { id: pastVisitId } = await setupVisit({
       callTime: moment().subtract(5, "days"),
       callId: "2",
-      provider: "jitsi",
       wardId: wardId,
-      callPassword: "securePassword",
     });
 
-    await container.getCreateVisit()({
-      patientName: "Bob Smith",
-      contactEmail: "bob.smith@madetech.com",
-      contactName: "John Smith",
-      contactNumber: "07123456789",
+    await setupVisit({
       callTime: moment(),
       callId: "3",
-      provider: "jitsi",
       wardId: wardId,
-      callPassword: "securePassword",
     });
 
     await container.getDeleteVisitByCallId()("3");
 
-    const { wardId: archiveWardId } = await container.getCreateWard()({
-      name: "Test Ward 2",
+    const { wardId: archiveWardId } = await setupWard({
       code: "wardCode2",
       hospitalId: hospitalId,
       trustId: trustId,
     });
 
-    await container.getCreateVisit()({
-      patientName: "Bob Smith",
-      contactEmail: "bob.smith@madetech.com",
-      contactName: "John Smith",
-      contactNumber: "07123456789",
+    await setupVisit({
       callTime: moment(),
       callId: "4",
-      provider: "jitsi",
       wardId: archiveWardId,
-      callPassword: "securePassword",
     });
 
     await container.getArchiveWard()(archiveWardId, trustId);

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -26,7 +26,7 @@ async function cleanupScheduledCalls() {
   const scheduledCalls = await db.result(
     `UPDATE scheduled_calls_table
      SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1, pii_cleared_at = NOW()
-     WHERE call_time < (now() - INTERVAL '1 DAY') AND status = $2 AND pii_cleared_at IS NULL`,
+     WHERE call_time < (now() - INTERVAL '1 DAY') AND (status = $1 OR status = $2) AND pii_cleared_at IS NULL`,
     [status.COMPLETE, status.SCHEDULED]
   );
 

--- a/pageTests/api/complete-visit.test.js
+++ b/pageTests/api/complete-visit.test.js
@@ -107,6 +107,15 @@ describe("/api/complete-visit", () => {
   });
 
   it("returns 201 when a visit is marked as complete successfully", async () => {
+    const retrieveVisitByCallIdSpy = jest.fn().mockResolvedValue({
+      scheduledCall: { id: 456 },
+      error: null,
+    });
+
+    const markVisitAsCompleteSpy = jest
+      .fn()
+      .mockResolvedValue({ id: 456, error: null });
+
     await completeVisit(
       {
         method: "POST",
@@ -116,16 +125,17 @@ describe("/api/complete-visit", () => {
       {
         container: {
           getUserIsAuthenticated: () => validUserIsAuthenticatedSpy,
-          getRetrieveVisitByCallId: () =>
-            jest.fn().mockResolvedValue({
-              scheduledCall: { id: "456" },
-              error: null,
-            }),
-          getMarkVisitAsComplete: () =>
-            jest.fn().mockResolvedValue({ id: "456", error: null }),
+          getRetrieveVisitByCallId: () => retrieveVisitByCallIdSpy,
+          getMarkVisitAsComplete: () => markVisitAsCompleteSpy,
         },
       }
     );
+
+    expect(retrieveVisitByCallIdSpy).toHaveBeenCalledWith("123");
+    expect(markVisitAsCompleteSpy).toHaveBeenCalledWith({
+      id: 456,
+      wardId: 10,
+    });
 
     expect(response.status).toHaveBeenCalledWith(201);
   });

--- a/pages/api/complete-visit.js
+++ b/pages/api/complete-visit.js
@@ -48,6 +48,7 @@ export default withContainer(
       res.end(JSON.stringify({ err: "Unable to mark visit as complete" }));
     } else {
       res.status(201);
+      res.end(JSON.stringify({}));
     }
   }
 );

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -39,12 +39,23 @@ const Call = ({
     });
   };
 
+  const completeVisit = async () => {
+    await fetch("/api/complete-visit", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ callId }),
+    });
+  };
+
   useEffect(() => {
     captureEvent(JOIN_VISIT);
   }, []);
 
   const leaveVisit = useCallback(async () => {
     await captureEvent(LEAVE_VISIT);
+    await completeVisit();
   });
 
   return (


### PR DESCRIPTION
# What
Marks a visit as complete once the patient presses the "End call" button

# Why
This allows us to keep track of visits that have completed so that we can display this status to Ward Staff on the visit list screen. This will help them see which visits have been handled by other ward staff.

# Screenshots

# Notes
