### PR TITLE
Label 'Complete' visits in the visit list screen

### DIFF
--- a/cypress/integration/wards/startingAVisit.js
+++ b/cypress/integration/wards/startingAVisit.js
@@ -21,6 +21,7 @@ describe("As a ward staff, I want to start a virtual visit so that patients can 
 
     WhenIClickToReturnToVirtualVisits();
     ThenISeeTheVirtualVisitsPage();
+    AndISeeTheVirtualVisitMarkedAsComplete();
   });
 
   // Allows a ward staff to start a virtual visit
@@ -74,5 +75,11 @@ describe("As a ward staff, I want to start a virtual visit so that patients can 
 
   function ThenISeeTheVirtualVisitsPage() {
     cy.get("h1").should("contain", "Virtual visits");
+  }
+
+  function AndISeeTheVirtualVisitMarkedAsComplete() {
+    cy.get("summary.nhsuk-details__summary")
+      .contains("Alice")
+      .should("contain", "(Complete)");
   }
 });

--- a/src/components/VisitsPanelList/index.js
+++ b/src/components/VisitsPanelList/index.js
@@ -5,6 +5,7 @@ import formatDateAndTime from "../../helpers/formatDateAndTime";
 import VisitSummaryList from "../VisitSummaryList";
 import TimeFromNow from "../TimeFromNow";
 import Text from "../Text";
+import { COMPLETE } from "../../helpers/visitStatus";
 
 const VisitsPanelList = ({ visits, title, showButtons }) => {
   if (visits.length != 0) {
@@ -37,6 +38,7 @@ const VisitsPanelList = ({ visits, title, showButtons }) => {
                       <span className="nhsuk-details__summary-text">
                         {formatDateAndTime(visit.callTime, "HH:mm")} -{" "}
                         {visit.patientName}
+                        {visit.status == COMPLETE && " (Complete)"}
                       </span>
                     </summary>
                     <div


### PR DESCRIPTION
# What
Appends a "Complete" label to visits that have been marked as complete in the database

# Why
Makes it easy for ward staff to see at a glance which visits have been completed (call ended by the patient).

# Screenshots
![ScreenShot 2020-07-28 at 13 50 35](https://user-images.githubusercontent.com/7527178/88649962-3766be80-d0c0-11ea-850d-bcc977a27f29.png)

# Notes
