### PR TITLE
Add London North West Trust to the list of syncd forks

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -3,6 +3,7 @@ name: Sync Fork
 on:
   schedule:
     - cron: "*/10 * * * *"
+  workflow_dispatch:
 
 jobs:
   sync:

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    if: github.repository == 'Kettering-General-Hospital/nhs-virtual-visit'
+    if: (github.repository == 'Kettering-General-Hospital/nhs-virtual-visit') || (github.repository == 'London-North-West-Trust/nhs-virtual-visit')
     steps:
       - name: Fork Sync
         uses: TG908/fork-sync@v1.1.7


### PR DESCRIPTION
# What
Adds London North West Trust to the list of syncd forks

# Why
So that their fork is kept up to date automatically

# Screenshots

# Notes
Also adds the ability to manually trigger a fork sync on any fork