### PR TITLE
Fix rendering of Error page when authentication fails during a visit

### DIFF
--- a/pageTests/visitors/name.test.js
+++ b/pageTests/visitors/name.test.js
@@ -70,8 +70,8 @@ describe("call", () => {
       expect(props.callId).toEqual(1);
     });
 
-    it("given an invalid passcode, the user should be redirected", async () => {
-      await getServerSideProps({
+    it("given an invalid passcode, an error should be returned", async () => {
+      const { props } = await getServerSideProps({
         query: {
           callPassword: "fakeCode",
           id: 1,
@@ -80,7 +80,7 @@ describe("call", () => {
         res,
       });
       expect(getVerifyCallPasswordSpy).toHaveBeenCalledWith(1, "fakeCode");
-      expect(res.writeHead).toHaveBeenCalledWith(307, { Location: "/error" });
+      expect(props.error).toEqual("Unauthorized");
     });
   });
 });

--- a/pageTests/visitors/start.test.js
+++ b/pageTests/visitors/start.test.js
@@ -70,8 +70,8 @@ describe("call", () => {
       expect(props.callId).toEqual(1);
     });
 
-    it("given an invalid passcode, the user should be redirected", async () => {
-      await getServerSideProps({
+    it("given an invalid passcode, an error should be returned", async () => {
+      const { props } = await getServerSideProps({
         query: {
           callPassword: "fakeCode",
           id: 1,
@@ -80,7 +80,7 @@ describe("call", () => {
         res,
       });
       expect(getVerifyCallPasswordSpy).toHaveBeenCalledWith(1, "fakeCode");
-      expect(res.writeHead).toHaveBeenCalledWith(307, { Location: "/error" });
+      expect(props.error).toEqual("Unauthorized");
     });
   });
 });

--- a/pageTests/visits/[id].test.js
+++ b/pageTests/visits/[id].test.js
@@ -69,8 +69,8 @@ describe("call", () => {
       expect(props.callId).toEqual(1);
     });
 
-    it("redirects when password is invalid, and the user is unauthenticated", async () => {
-      await getServerSideProps({
+    it("an error is returned when password is invalid", async () => {
+      const { props } = await getServerSideProps({
         query: {
           callPassword: "fakeCode",
           id: 1,
@@ -82,7 +82,7 @@ describe("call", () => {
 
       expect(getUserIsAuthenticatedSpy).toHaveBeenCalled();
       expect(getVerifyCallPasswordSpy).toHaveBeenCalledWith(1, "fakeCode");
-      expect(res.writeHead).toHaveBeenCalledWith(307, { Location: "/error" });
+      expect(props.error).toEqual("Unauthorized");
     });
 
     it("returns sessionId", async () => {

--- a/pages/visitors/[id]/name.js
+++ b/pages/visitors/[id]/name.js
@@ -102,7 +102,7 @@ const Name = ({ callId, error, callPassword }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  async ({ query, container, res }) => {
+  async ({ query, container }) => {
     const { id: callId, callPassword } = query;
 
     const verifyCallPassword = container.getVerifyCallPassword();
@@ -113,10 +113,7 @@ export const getServerSideProps = propsWithContainer(
     );
 
     if (!validCallPassword) {
-      res.writeHead(307, {
-        Location: "/error",
-      });
-      res.end();
+      return { props: { error: "Unauthorized" } };
     }
     console.log("name.js error", error);
     return { props: { callId, error, callPassword } };

--- a/pages/visitors/[id]/start.js
+++ b/pages/visitors/[id]/start.js
@@ -56,7 +56,7 @@ const Start = ({ callId, error, callPassword }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  async ({ query, container, res }) => {
+  async ({ query, container }) => {
     const { id: callId, callPassword } = query;
 
     const verifyCallPassword = container.getVerifyCallPassword();
@@ -67,10 +67,7 @@ export const getServerSideProps = propsWithContainer(
     );
 
     if (!validCallPassword) {
-      res.writeHead(307, {
-        Location: "/error",
-      });
-      res.end();
+      return { props: { error: "Unauthorized" } };
     }
     console.log("start.js error", error);
 

--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -70,7 +70,7 @@ const Call = ({
 };
 
 export const getServerSideProps = propsWithContainer(
-  async ({ req: { headers }, res, query, container }) => {
+  async ({ req: { headers }, query, container }) => {
     const { id: callId, name, callPassword } = query;
 
     const verifyCallPassword = container.getVerifyCallPassword();
@@ -102,12 +102,7 @@ export const getServerSideProps = propsWithContainer(
         },
       };
     } else {
-      res.writeHead(307, {
-        Location: "/error",
-      });
-      res.end();
-
-      return { props: {} };
+      return { props: { error: "Unauthorized" } };
     }
   }
 );


### PR DESCRIPTION
# What
Correctly returns an error page when authentication fails during a visit

# Why
The old implementation resulted in a 404 whilst redirecting to /error. Instead we should render the page and set an error prop so that the Error component is used

# Screenshots

# Notes
