### PR TITLE
Return empty props after redirecting due to being logged out

### DIFF
--- a/src/usecases/verifyAdminToken.js
+++ b/src/usecases/verifyAdminToken.js
@@ -32,6 +32,7 @@ export default function (callback) {
       );
     } else {
       res.writeHead(302, { Location: "/admin/login" }).end();
+      return { props: {} };
     }
   };
 }

--- a/src/usecases/verifyToken.js
+++ b/src/usecases/verifyToken.js
@@ -12,6 +12,7 @@ export default function (callback) {
       return callback({ ...context, authenticationToken }) ?? { props: {} };
     } else {
       res.writeHead(302, { Location: "/wards/login" }).end();
+      return { props: {} };
     }
   };
 }

--- a/src/usecases/verifyTrustAdminToken.js
+++ b/src/usecases/verifyTrustAdminToken.js
@@ -12,6 +12,7 @@ export default function (callback) {
       return callback({ ...context, authenticationToken }) ?? { props: {} };
     } else {
       res.writeHead(302, { Location: "/trust-admin/login" }).end();
+      return { props: {} };
     }
   };
 }


### PR DESCRIPTION
# What
Returns an empty prop object when authentication fails

# Why
We have been receiving a recurring exception in Sentry that happens when nothing is returned in getServerSideProps.

When you are logged out and attempt to visit a page, the verify usecase exits early without returning anything, resulting in the exception: "TypeError: Cannot convert undefined or null to object"

https://github.com/vercel/next.js/discussions/12601

# Screenshots

# Notes
