### PR TITLE
Refresh Trust Admin token expiry

### DIFF
--- a/pageTests/performance.test.js
+++ b/pageTests/performance.test.js
@@ -38,6 +38,7 @@ describe("/performance", () => {
       const container = {
         getRetrieveWardVisitTotals: () => wardVisitTotalSpy,
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
       const { props } = await getServerSideProps({
         req: authenticatedReq,

--- a/pageTests/trust-admin.test.js
+++ b/pageTests/trust-admin.test.js
@@ -103,6 +103,7 @@ describe("trust-admin", () => {
     getRetrieveAverageVisitsPerDayByTrustId: () =>
       retrieveAverageVisitsPerDayByTrustId,
     getTokenProvider: () => tokenProvider,
+    getRegenerateToken: () => jest.fn().mockReturnValue({}),
   };
 
   beforeEach(() => {

--- a/pageTests/trust-admin/hospitals/[id].test.js
+++ b/pageTests/trust-admin/hospitals/[id].test.js
@@ -69,6 +69,7 @@ describe("trust-admin/hospitals/[id]", () => {
         getRetrieveHospitalVisitTotals: () => visitTotalsSpy,
         getRetrieveHospitalWardVisitTotals: () => hospitalWardTotalsSpy,
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({

--- a/pageTests/trust-admin/hospitals/[id]/add-success.test.js
+++ b/pageTests/trust-admin/hospitals/[id]/add-success.test.js
@@ -47,6 +47,7 @@ describe("/trust-admin/hospitals/[id]/add-success", () => {
         const container = {
           getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         await getServerSideProps({
@@ -73,6 +74,7 @@ describe("/trust-admin/hospitals/[id]/add-success", () => {
         const container = {
           getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/trust-admin/hospitals/[id]/edit.test.js
+++ b/pageTests/trust-admin/hospitals/[id]/edit.test.js
@@ -51,6 +51,7 @@ describe("/trust-admin/hospitals/[id]/edit", () => {
       const container = {
         getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
 
       await getServerSideProps({

--- a/pageTests/trust-admin/hospitals/index.test.js
+++ b/pageTests/trust-admin/hospitals/index.test.js
@@ -52,6 +52,7 @@ describe("trust-admin/hospitals", () => {
       getRetrieveHospitalsByTrustId: () => retrieveHospitalsByTrustIdSuccessSpy,
       getRetrieveHospitalVisitTotals: () => retrieveHospitalVisitTotalsStub,
       getTokenProvider: () => tokenProvider,
+      getRegenerateToken: () => jest.fn().mockReturnValue({}),
     };
   });
 

--- a/pageTests/trust-admin/wards/[id]/add-success.test.js
+++ b/pageTests/trust-admin/wards/[id]/add-success.test.js
@@ -48,6 +48,7 @@ describe("/trust-admin/wards/[id]/add-success", () => {
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         await getServerSideProps({
@@ -75,6 +76,7 @@ describe("/trust-admin/wards/[id]/add-success", () => {
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/trust-admin/wards/[id]/edit-a-ward.test.js
+++ b/pageTests/trust-admin/wards/[id]/edit-a-ward.test.js
@@ -53,6 +53,7 @@ describe("/trust-admin/wards/[id]/edit", () => {
               error: null,
             }),
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         await getServerSideProps({
@@ -85,6 +86,7 @@ describe("/trust-admin/wards/[id]/edit", () => {
               error: null,
             }),
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         const { props } = await getServerSideProps({

--- a/pageTests/trust-admin/wards/[id]/edit-success.test.js
+++ b/pageTests/trust-admin/wards/[id]/edit-success.test.js
@@ -48,6 +48,7 @@ describe("/trust-admin/wards/[id]/edit-success", () => {
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         await getServerSideProps({
@@ -75,6 +76,7 @@ describe("/trust-admin/wards/[id]/edit-success", () => {
         const container = {
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
         };
 
         const { props } = await getServerSideProps({

--- a/src/usecases/verifyTrustAdminToken.js
+++ b/src/usecases/verifyTrustAdminToken.js
@@ -9,6 +9,22 @@ export default function (callback) {
     );
 
     if (authenticationToken) {
+      const {
+        regeneratedToken,
+        regeneratedEncodedToken,
+        isTokenRegenerated,
+      } = container.getRegenerateToken()(authenticationToken);
+
+      if (isTokenRegenerated) {
+        res.setHeader("Set-Cookie", [
+          `token=${regeneratedEncodedToken}; httpOnly; path=/;`,
+        ]);
+        return (
+          callback({ ...context, authenticationToken: regeneratedToken }) ?? {
+            props: {},
+          }
+        );
+      }
       return callback({ ...context, authenticationToken }) ?? { props: {} };
     } else {
       res.writeHead(302, { Location: "/trust-admin/login" }).end();


### PR DESCRIPTION
# What
Regenerated the Trust Admin token within a refresh timeframe

# Why
So that users are not logged out if they are using the app

# Screenshots

# Notes
See https://github.com/madetech/nhs-virtual-visit/pull/352 for the original implementation of the token regeneration