### PR TITLE
Regenerate WardStaff token

### DIFF
--- a/pageTests/wards/book-a-visit-success.test.js
+++ b/pageTests/wards/book-a-visit-success.test.js
@@ -40,6 +40,7 @@ describe("wards/book-a-visit-success", () => {
       const container = {
         getRetrieveWardById: () => getRetrieveWardByIdSpy,
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({

--- a/pageTests/wards/book-a-visit.test.js
+++ b/pageTests/wards/book-a-visit.test.js
@@ -30,6 +30,7 @@ describe("ward/book-a-visit", () => {
     originalBookingDate = new Date();
     container = {
       getTokenProvider: () => tokenProvider,
+      getRegenerateToken: () => jest.fn().mockReturnValue({}),
       getRetrieveWardById: () => jest.fn().mockReturnValue({}),
       getUserIsAuthenticated: () =>
         jest.fn().mockResolvedValue("token=123" && { ward: "123" }),

--- a/pageTests/wards/cancel-visit-confirmation.test.js
+++ b/pageTests/wards/cancel-visit-confirmation.test.js
@@ -41,6 +41,7 @@ describe("ward/cancel-visit-confirmation", () => {
             },
           }),
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
         getRetrieveWardById: () => jest.fn().mockReturnValue({}),
       };
 
@@ -73,6 +74,7 @@ describe("ward/cancel-visit-confirmation", () => {
               ],
             }),
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
           getRetrieveWardById: () => jest.fn().mockReturnValue({}),
         };
 

--- a/pageTests/wards/cancel-visit-success.test.js
+++ b/pageTests/wards/cancel-visit-success.test.js
@@ -41,6 +41,7 @@ describe("ward/cancel-visit-success", () => {
             },
           }),
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
         getRetrieveWardById: () => jest.fn().mockReturnValue({}),
       };
 
@@ -72,6 +73,7 @@ describe("ward/cancel-visit-success", () => {
               ],
             }),
           getTokenProvider: () => tokenProvider,
+          getRegenerateToken: () => jest.fn().mockReturnValue({}),
           getRetrieveWardById: () => jest.fn().mockReturnValue({}),
         };
 

--- a/pageTests/wards/visits.test.js
+++ b/pageTests/wards/visits.test.js
@@ -46,6 +46,7 @@ describe("ward/visits", () => {
         getRetrieveVisits: () => visitsSpy,
         getRetrieveWardById: () => wardSpy,
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({
@@ -81,6 +82,7 @@ describe("ward/visits", () => {
         getRetrieveVisits: () => retrieveVisitsStub,
         getRetrieveWardById: () => jest.fn().mockReturnValue({}),
         getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({

--- a/pageTests/wards/visits/[id]/edit.test.js
+++ b/pageTests/wards/visits/[id]/edit.test.js
@@ -47,6 +47,7 @@ describe("wards/visits/[id]/edit", () => {
             wardId,
           })),
         }),
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
         getRetrieveVisitById: () => retrieveVisitById,
       };
 
@@ -105,6 +106,7 @@ describe("wards/visits/[id]/edit", () => {
           })),
         }),
         getRetrieveVisitById: () => retrieveVisitById,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
 
       const { props } = await getServerSideProps({

--- a/src/usecases/verifyToken.js
+++ b/src/usecases/verifyToken.js
@@ -9,6 +9,22 @@ export default function (callback) {
     );
 
     if (authenticationToken) {
+      const {
+        regeneratedToken,
+        regeneratedEncodedToken,
+        isTokenRegenerated,
+      } = container.getRegenerateToken()(authenticationToken);
+
+      if (isTokenRegenerated) {
+        res.setHeader("Set-Cookie", [
+          `token=${regeneratedEncodedToken}; httpOnly; path=/;`,
+        ]);
+        return (
+          callback({ ...context, authenticationToken: regeneratedToken }) ?? {
+            props: {},
+          }
+        );
+      }
       return callback({ ...context, authenticationToken }) ?? { props: {} };
     } else {
       res.writeHead(302, { Location: "/wards/login" }).end();

--- a/src/usecases/verifyToken.test.js
+++ b/src/usecases/verifyToken.test.js
@@ -23,6 +23,7 @@ describe("verifyToken", () => {
     };
     const container = {
       getTokenProvider: () => tokenProvider,
+      getRegenerateToken: () => jest.fn().mockReturnValue({}),
       getRetrieveWardById: () => jest.fn().mockReturnValue({ error: null }),
     };
 
@@ -67,5 +68,59 @@ describe("verifyToken", () => {
     expect(res.writeHead).toHaveBeenCalledWith(302, {
       Location: "/wards/login",
     });
+  });
+
+  it("updates the cookie if the token is regenerated", async () => {
+    const regenRes = {
+      writeHead: jest.fn(() => regenRes),
+      end: jest.fn(),
+      setHeader: jest.fn(),
+    };
+
+    const regenReq = {
+      headers: {
+        cookie: "token=sample.token.value",
+      },
+    };
+
+    const callback = jest.fn();
+    const authenticationToken = {
+      type: "wardStaff",
+    };
+    const tokenProvider = {
+      validate: jest.fn(() => authenticationToken),
+    };
+
+    const regeneratedToken = { type: "wardStaff", test: "1" };
+
+    const regenerateTokenSpy = jest.fn().mockReturnValue({
+      isTokenRegenerated: true,
+      regeneratedEncodedToken: "encodedToken",
+      regeneratedToken: regeneratedToken,
+    });
+
+    const container = {
+      getTokenProvider: () => tokenProvider,
+      getRegenerateToken: () => regenerateTokenSpy,
+      getRetrieveWardById: () => jest.fn().mockReturnValue({ error: null }),
+    };
+
+    await verifyToken(callback)({
+      req: regenReq,
+      res: regenRes,
+      container,
+    });
+
+    expect(regenerateTokenSpy).toHaveBeenCalledWith(authenticationToken);
+
+    expect(regenRes.setHeader).toHaveBeenCalledWith("Set-Cookie", [
+      "token=encodedToken; httpOnly; path=/;",
+    ]);
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticationToken: regeneratedToken,
+      })
+    );
   });
 });


### PR DESCRIPTION
# What
Regenerates the authentication token for WardStaff using the regenerateToken usecase when it is about to expire

# Why
Ensures that the ward staff token does not expire if the WardStaff is actively using the app.

# Screenshots

# Notes
See https://github.com/madetech/nhs-virtual-visit/pull/352 for original token regeneration work