### PR TITLE
Reduce nano id collisions

### DIFF
--- a/pages/api/book-a-visit.js
+++ b/pages/api/book-a-visit.js
@@ -54,7 +54,7 @@ export default withContainer(
         body.callTime
       );
       const callId = await callIdProvider.generate();
-      let callPassword = ids.generate();
+      let callPassword = ids.generate(10);
 
       const createVisit = container.getCreateVisit();
       const updateWardVisitTotals = container.getUpdateWardVisitTotals();

--- a/src/providers/RandomIdProvider.js
+++ b/src/providers/RandomIdProvider.js
@@ -1,8 +1,7 @@
-import { customAlphabet } from "nanoid";
+import { nanoid } from "nanoid";
 
 class RandomIdProvider {
   generate() {
-    const nanoid = customAlphabet("1234567890abcdef", 10);
     return nanoid();
   }
 }

--- a/src/providers/RandomIdProvider.js
+++ b/src/providers/RandomIdProvider.js
@@ -1,7 +1,11 @@
 import { nanoid } from "nanoid";
 
 class RandomIdProvider {
-  generate() {
+  generate(length = null) {
+    if (length) {
+      return nanoid(length);
+    }
+
     return nanoid();
   }
 }

--- a/src/providers/RandomIdProvider.test.js
+++ b/src/providers/RandomIdProvider.test.js
@@ -1,0 +1,15 @@
+import RandomIdProvider from "./RandomIdProvider";
+
+describe("generate", () => {
+  it("returns a random ID with 21 length by default", () => {
+    const provider = new RandomIdProvider();
+    const id = provider.generate();
+    expect(id.length).toEqual(21);
+  });
+
+  it("returns a random ID matching the provided length", () => {
+    const provider = new RandomIdProvider();
+    const id = provider.generate(12);
+    expect(id.length).toEqual(12);
+  });
+});


### PR DESCRIPTION
# What
Uses a larger alphabet and size by default when generating RandomIDs

# Why
We want to keep the collision probability very low for Jitsi meet calls otherwise you may join a meeting room meant for someone else. The default nanoid generator generates an ID with 21 characters and a much largers alphabet, resulting in a collision probability similar to uiud v4.

https://github.com/ai/nanoid/blob/master/index.d.ts#L15

https://zelark.github.io/nano-id-cc/

# Screenshots

# Notes
The callPassword uses a shorter (10) ID as collisions are not a concern here and the password is short lived (only used for the duration of the call)