### PR TITLE
Add CYPRESS_INSTALL_BINARY to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,5 +6,8 @@
         "postdeploy": "psql -f 'db/seeds.sql' $DATABASE_URL"
       }
     }
+  },
+  "env": {
+    "CYPRESS_INSTALL_BINARY": "0"
   }
 }


### PR DESCRIPTION
# What

Add `CYPRESS_INSTALL_BINARY` to app.json.

# Why

When Heroku builds an app, it downloads all dependencies and then prunes the dev dependencies. Sometimes this takes longer than the set timeout time which causes a deploy to fail. Cypress is the dependency which takes the longest amount of time to download and install.

This change stops Cypress from installing and therefore should reduce the likelihood of app builds failing due to timeout.

# Screenshots

N/A

# Notes

https://docs.cypress.io/guides/getting-started/installing-cypress.html#Advanced