### PR TITLE
Add update-a-trust API endpoint

### DIFF
--- a/pageTests/api/update-a-trust.test.js
+++ b/pageTests/api/update-a-trust.test.js
@@ -1,0 +1,197 @@
+import updateATrust from "../../pages/api/update-a-trust";
+
+describe("/api/update-a-trust", () => {
+  it("returns a 200 if the method is PATCH", async () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const req = {
+      headers: { cookie: "token" },
+      body: {
+        id: 5,
+        videoProvider: "whereby",
+      },
+      method: "PATCH",
+    };
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+      getUpdateTrust: () => jest.fn().mockResolvedValue({ id: 5, error: null }),
+    };
+
+    await updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(200);
+  });
+
+  it("returns a 405 if the action is not PATCH", () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+    const req = { body: {}, method: "GET" };
+
+    updateATrust(req, response);
+
+    expect(response.status).toBeCalledWith(405);
+  });
+
+  it("returns a 400 if the id is not present", () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      videoProvider: "whereby",
+    };
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(400);
+  });
+
+  it("returns a 400 if the id is invalid", () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      id: "hello",
+      videoProvider: "whereby",
+    };
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(400);
+  });
+
+  it("returns a 400 if the videoProvider is not present", () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      id: 5,
+    };
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(400);
+  });
+
+  it("returns a 400 if the videoProvider is invalid", () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      id: 5,
+      videoProvider: "hello",
+    };
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(400);
+  });
+
+  it("returns a 401 if user is not an admin", () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      id: 5,
+      videoProvider: "whereby",
+    };
+
+    const adminIsAuthenticatedStub = jest.fn().mockReturnValue(false);
+    const container = {
+      getAdminIsAuthenticated: () => adminIsAuthenticatedStub,
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(401);
+    expect(adminIsAuthenticatedStub).toBeCalledWith("token");
+  });
+
+  it("updates a trust", async () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      id: 5,
+      videoProvider: "whereby",
+    };
+
+    const updateTrustStub = jest.fn().mockResolvedValue({ id: 5, error: null });
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+      getUpdateTrust: () => updateTrustStub,
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    await updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(200);
+    expect(updateTrustStub).toHaveBeenCalledWith({
+      id: 5,
+      videoProvider: "whereby",
+    });
+  });
+
+  it("returns a 404 if trust doesn't exist", async () => {
+    const response = {
+      status: jest.fn().mockReturnValue({ end: jest.fn() }),
+    };
+
+    const body = {
+      id: 12345,
+      videoProvider: "whereby",
+    };
+
+    const updateTrustStub = jest
+      .fn()
+      .mockResolvedValue({ id: null, error: null });
+
+    const container = {
+      getAdminIsAuthenticated: () => jest.fn().mockReturnValue(true),
+      getUpdateTrust: () => updateTrustStub,
+    };
+
+    const req = { headers: { cookie: "token" }, body, method: "PATCH" };
+
+    await updateATrust(req, response, container);
+
+    expect(response.status).toBeCalledWith(404);
+  });
+});

--- a/pages/api/update-a-trust.js
+++ b/pages/api/update-a-trust.js
@@ -1,0 +1,37 @@
+import { VIDEO_PROVIDERS } from "../../src/providers/CallIdProvider";
+import withContainer from "../../src/middleware/withContainer";
+
+export default withContainer(async (req, res, container) => {
+  if (req.method !== "PATCH") {
+    res.status(405).end();
+    return;
+  }
+
+  const adminIsAuthenticated = container.getAdminIsAuthenticated();
+
+  const token = adminIsAuthenticated(req.headers.cookie);
+
+  if (!token) {
+    return res.status(401).end();
+  }
+
+  const { id, videoProvider } = req.body;
+
+  if (!id || !Number.isInteger(id)) {
+    return res.status(400).end();
+  }
+
+  if (!VIDEO_PROVIDERS.includes(videoProvider)) {
+    return res.status(400).end();
+  }
+
+  const updateTrust = container.getUpdateTrust();
+
+  const { id: updateTrustId, error } = await updateTrust({ id, videoProvider });
+
+  if (!updateTrustId && !error) {
+    return res.status(404).end();
+  }
+
+  return res.status(200).end();
+});

--- a/src/usecases/updateTrust.contractTest.js
+++ b/src/usecases/updateTrust.contractTest.js
@@ -17,7 +17,7 @@ describe("updateTrust contract test", () => {
     expect(trust.videoProvider).toEqual("whereby");
   });
 
-  it("returns an error if the trust doesn't exist", async () => {
+  it("returns a null id and error if the Trust does not exist", async () => {
     const container = AppContainer.getInstance();
     const updateTrust = container.getUpdateTrust();
 
@@ -26,6 +26,7 @@ describe("updateTrust contract test", () => {
       videoProvider: "whereby",
     });
 
-    expect(result.error).not.toBeNull();
+    expect(result.id).toBeNull();
+    expect(result.error).toBeNull();
   });
 });

--- a/src/usecases/updateTrust.js
+++ b/src/usecases/updateTrust.js
@@ -14,7 +14,7 @@ const updateTrust = ({ getDb }) => async ({ id, videoProvider }) => {
   const db = await getDb();
 
   try {
-    const updatedTrust = await db.one(
+    const updatedTrust = await db.oneOrNone(
       `UPDATE trusts
       SET video_provider = $1
       WHERE
@@ -24,10 +24,17 @@ const updateTrust = ({ getDb }) => async ({ id, videoProvider }) => {
       [videoProvider, id]
     );
 
-    return {
-      id: updatedTrust.id,
-      error: null,
-    };
+    if (updatedTrust) {
+      return {
+        id: updatedTrust.id,
+        error: null,
+      };
+    } else {
+      return {
+        id: null,
+        error: null,
+      };
+    }
   } catch (error) {
     console.error(error);
 

--- a/src/usecases/updateTrust.test.js
+++ b/src/usecases/updateTrust.test.js
@@ -19,4 +19,23 @@ describe("updateTrust", () => {
 
     expect(error).toEqual("An id must be provided.");
   });
+
+  it("returns an error if the database query errors", async () => {
+    const container = {
+      async getDb() {
+        return {
+          oneOrNone: jest.fn(() => {
+            throw new Error("fail");
+          }),
+        };
+      },
+    };
+
+    const { error, id } = await updateTrust(container)({
+      id: 123,
+      videoProvider: "whereby",
+    });
+    expect(error).toEqual("Error: fail");
+    expect(id).toBeNull();
+  });
 });


### PR DESCRIPTION
# What

Add `update-a-trust` API endpoint.

# Why

So a site admin can update the details of a trust, specifically the video provider.

# Screenshots

N/A

# Notes

N/A