### PR TITLE
Add edit a trust form for changing video provider

### DIFF
--- a/cypress/integration/admin/editingATrust.js
+++ b/cypress/integration/admin/editingATrust.js
@@ -1,0 +1,62 @@
+describe("As an admin, I want to edit a trust so that I can update the details of a trust.", () => {
+  before(() => {
+    // reset and seed the database
+    cy.exec(
+      "npm run dbmigratetest reset && npm run dbmigratetest up && npm run db:seed"
+    );
+  });
+
+  it("allows an admin to edit a trust", () => {
+    GivenIAmLoggedInAsAnAdmin();
+    WhenIClickToEditATrust();
+    ThenISeeTheEditATrustForm();
+
+    WhenIUpdateTheVideoProvider();
+    AndISubmitTheForm();
+    ThenISeeTheTrustIsUpdated();
+
+    WhenIClickToReturnToSiteAdministration();
+    ThenISeeTheSiteAdministrationPage();
+    AndISeeTheUpdatedTrust();
+  });
+
+  // Allows an admin to edit a trust
+  function GivenIAmLoggedInAsAnAdmin() {
+    cy.visit(Cypress.env("baseUrl") + "/admin/login");
+    cy.get("input[name=code]").type(Cypress.env("validAdminCode"));
+    cy.get("input[name=password]").type(Cypress.env("validAdminPassword"));
+    cy.get("button").contains("Log in").click();
+  }
+
+  function WhenIClickToEditATrust() {
+    cy.get("a.nhsuk-link").contains("Edit Test Trust").click();
+  }
+
+  function ThenISeeTheEditATrustForm() {
+    cy.get("h1").should("contain", "Edit Test Trust");
+  }
+
+  function WhenIUpdateTheVideoProvider() {
+    cy.get("select[name=video-provider]").select("whereby");
+  }
+
+  function AndISubmitTheForm() {
+    cy.get("button").contains("Edit Trust").click();
+  }
+
+  function ThenISeeTheTrustIsUpdated() {
+    cy.get("h1").should("contain", "Test Trust has been updated");
+  }
+
+  function WhenIClickToReturnToSiteAdministration() {
+    cy.get("a").contains("Return to site administration").click();
+  }
+
+  function ThenISeeTheSiteAdministrationPage() {
+    cy.get("h1").should("contain", "Site administration");
+  }
+
+  function AndISeeTheUpdatedTrust() {
+    cy.get("[data-testid=test-trust]").should("contain", "Whereby");
+  }
+});

--- a/pageTests/admin/trusts/[id]/edit-success.test.js
+++ b/pageTests/admin/trusts/[id]/edit-success.test.js
@@ -1,0 +1,97 @@
+import { getServerSideProps } from "../../../../pages/admin/trusts/[id]/edit-success";
+
+const authenticatedReq = {
+  headers: {
+    cookie: "token=123",
+  },
+};
+
+const tokenProvider = {
+  validate: jest.fn(() => ({ type: "admin" })),
+};
+
+describe("/admin/admin/trusts/[id]/edit-success", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/admin/login",
+      });
+    });
+
+    it("retrieves a trust by the trustId parameter", async () => {
+      const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+        trust: {
+          id: 1,
+          name: "Northwick Park Trust",
+          videoProvider: "whereby",
+        },
+        error: null,
+      });
+
+      const container = {
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          id: "1",
+        },
+        container,
+      });
+
+      expect(retrieveTrustByIdSpy).toHaveBeenCalledWith("1");
+    });
+
+    it("set a trust prop based on the retrieved trust", async () => {
+      const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+        trust: {
+          id: 1,
+          name: "Northwick Park Trust",
+          videoProvider: "whereby",
+        },
+        error: null,
+      });
+
+      const container = {
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          trustId: "trust ID",
+        },
+        container,
+      });
+
+      expect(props.trust).toEqual({
+        id: 1,
+        name: "Northwick Park Trust",
+        videoProvider: "whereby",
+      });
+    });
+  });
+});

--- a/pageTests/admin/trusts/[id]/edit.test.js
+++ b/pageTests/admin/trusts/[id]/edit.test.js
@@ -1,0 +1,97 @@
+import { getServerSideProps } from "../../../../pages/admin/trusts/[id]/edit";
+
+const authenticatedReq = {
+  headers: {
+    cookie: "token=123",
+  },
+};
+
+const tokenProvider = {
+  validate: jest.fn(() => ({ type: "admin" })),
+};
+
+describe("/admin/admin/trusts/[id]/edit", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/admin/login",
+      });
+    });
+
+    it("retrieves a trust by the trustId parameter", async () => {
+      const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+        trust: {
+          id: 1,
+          name: "Northwick Park Trust",
+          videoProvider: "whereby",
+        },
+        error: null,
+      });
+
+      const container = {
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          id: "1",
+        },
+        container,
+      });
+
+      expect(retrieveTrustByIdSpy).toHaveBeenCalledWith("1");
+    });
+
+    it("set a trust prop based on the retrieved trust", async () => {
+      const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+        trust: {
+          id: 1,
+          name: "Northwick Park Trust",
+          videoProvider: "whereby",
+        },
+        error: null,
+      });
+
+      const container = {
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          trustId: "trust ID",
+        },
+        container,
+      });
+
+      expect(props.trust).toEqual({
+        id: 1,
+        name: "Northwick Park Trust",
+        videoProvider: "whereby",
+      });
+    });
+  });
+});

--- a/pageTests/api/update-a-trust.test.js
+++ b/pageTests/api/update-a-trust.test.js
@@ -20,7 +20,7 @@ describe("/api/update-a-trust", () => {
       getUpdateTrust: () => jest.fn().mockResolvedValue({ id: 5, error: null }),
     };
 
-    await updateATrust(req, response, container);
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(200);
   });
@@ -51,7 +51,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, container);
+    updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
@@ -72,7 +72,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, container);
+    updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
@@ -92,7 +92,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, container);
+    updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
@@ -113,7 +113,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, container);
+    updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
@@ -135,7 +135,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, container);
+    updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(401);
     expect(adminIsAuthenticatedStub).toBeCalledWith("token");
@@ -160,7 +160,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    await updateATrust(req, response, container);
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(200);
     expect(updateTrustStub).toHaveBeenCalledWith({
@@ -190,7 +190,7 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    await updateATrust(req, response, container);
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(404);
   });

--- a/pages/admin/trusts/[id]/edit-success.js
+++ b/pages/admin/trusts/[id]/edit-success.js
@@ -1,0 +1,59 @@
+import React from "react";
+import Error from "next/error";
+import Layout from "../../../../src/components/Layout";
+import AnchorLink from "../../../../src/components/AnchorLink";
+import propsWithContainer from "../../../../src/middleware/propsWithContainer";
+import verifyAdminToken from "../../../../src/usecases/verifyAdminToken";
+import { ADMIN } from "../../../../src/helpers/userTypes";
+
+const EditATrustSuccess = ({ error, trust }) => {
+  if (error) {
+    return <Error />;
+  }
+
+  return (
+    <Layout
+      title={`${trust.name} has been updated`}
+      showNavigationBarForType={ADMIN}
+      showNavigationBar={true}
+    >
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-two-thirds">
+          <div
+            className="nhsuk-panel nhsuk-panel--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+            style={{ textAlign: "center" }}
+          >
+            <h1 className="nhsuk-panel__title">
+              {trust.name} has been updated
+            </h1>
+          </div>
+          <h2>What happens next</h2>
+
+          <p>
+            <AnchorLink href="/admin">Return to site administration</AnchorLink>
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyAdminToken(async ({ container, query }) => {
+    const getRetrieveTrustById = container.getRetrieveTrustById();
+    const { trust, error } = await getRetrieveTrustById(query.id);
+
+    if (error) {
+      return { props: { error: error } };
+    } else {
+      return {
+        props: {
+          trust,
+          error,
+        },
+      };
+    }
+  })
+);
+
+export default EditATrustSuccess;

--- a/pages/admin/trusts/[id]/edit.js
+++ b/pages/admin/trusts/[id]/edit.js
@@ -1,0 +1,125 @@
+import React, { useState, useCallback } from "react";
+import ErrorSummary from "../../../../src/components/ErrorSummary";
+import { GridRow, GridColumn } from "../../../../src/components/Grid";
+import Layout from "../../../../src/components/Layout";
+import verifyAdminToken from "../../../../src/usecases/verifyAdminToken";
+import propsWithContainer from "../../../../src/middleware/propsWithContainer";
+import FormGroup from "../../../../src/components/FormGroup";
+import Heading from "../../../../src/components/Heading";
+import Label from "../../../../src/components/Label";
+import Button from "../../../../src/components/Button";
+import Select from "../../../../src/components/Select";
+import Router from "next/router";
+import { ADMIN } from "../../../../src/helpers/userTypes";
+import { VIDEO_PROVIDER_OPTIONS } from "../../../../src/providers/CallIdProvider";
+
+const EditTrust = ({ trust }) => {
+  const [errors, setErrors] = useState([]);
+  const [videoProvider, setVideoProvider] = useState(trust.videoProvider);
+
+  const hasError = (field) =>
+    errors.find((error) => error.id === `${field}-error`);
+
+  const getErrorMessage = (field) => {
+    const error = errors.filter((err) => err.id === `${field}-error`);
+    return error.length === 1 ? error[0].message : "";
+  };
+
+  const onSubmit = useCallback(async (event) => {
+    event.preventDefault();
+    const onSubmitErrors = [];
+
+    if (videoProvider.length === 0) {
+      onSubmitErrors.push({
+        id: "video-provider-error",
+        message: "Select a video provider",
+      });
+    }
+
+    if (onSubmitErrors.length === 0) {
+      const submitAnswers = async () => {
+        const response = await fetch("/api/update-a-trust", {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            id: trust.id,
+            videoProvider,
+          }),
+        });
+
+        const status = response.status;
+
+        if (status == 200) {
+          Router.push({
+            pathname: `/admin/trusts/${trust.id}/edit-success`,
+          });
+        } else {
+          onSubmitErrors.push({
+            message: "Something went wrong, please try again later.",
+          });
+          setErrors(onSubmitErrors);
+        }
+      };
+
+      await submitAnswers(name);
+    }
+    setErrors(onSubmitErrors);
+  });
+
+  return (
+    <Layout
+      title={`Edit ${trust.name}`}
+      hasErrors={errors.length != 0}
+      showNavigationBarForType={ADMIN}
+      showNavigationBar={true}
+    >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <ErrorSummary errors={errors} />
+          <form onSubmit={onSubmit}>
+            <Heading>{`Edit ${trust.name}`}</Heading>
+
+            <FormGroup>
+              <Label htmlFor="video-provider" className="nhsuk-label--l">
+                Which video provider would you like to use?
+              </Label>
+              <Select
+                id="video-provider"
+                className="nhsuk-input--width-10 nhsuk-u-width-one-half"
+                prompt="Choose a provider"
+                options={VIDEO_PROVIDER_OPTIONS}
+                onChange={(event) => {
+                  setVideoProvider(event.target.value);
+                }}
+                hasError={hasError("video-provider")}
+                errorMessage={getErrorMessage("video-provider")}
+                name="video-provider"
+                value={videoProvider}
+              />
+            </FormGroup>
+            <Button className="nhsuk-u-margin-top-5">Edit Trust</Button>
+          </form>
+        </GridColumn>
+      </GridRow>
+    </Layout>
+  );
+};
+
+export const getServerSideProps = propsWithContainer(
+  verifyAdminToken(async ({ container, query }) => {
+    const { id: trustId } = query;
+
+    const { trust, error } = await container.getRetrieveTrustById()(trustId);
+
+    return {
+      props: {
+        trust,
+        error,
+      },
+    };
+  })
+);
+
+export default EditTrust;

--- a/pages/admin/trusts/[id]/edit.js
+++ b/pages/admin/trusts/[id]/edit.js
@@ -96,7 +96,7 @@ const EditTrust = ({ trust }) => {
                 hasError={hasError("video-provider")}
                 errorMessage={getErrorMessage("video-provider")}
                 name="video-provider"
-                value={videoProvider}
+                defaultValue={videoProvider}
               />
             </FormGroup>
             <Button className="nhsuk-u-margin-top-5">Edit Trust</Button>

--- a/pages/api/update-a-trust.js
+++ b/pages/api/update-a-trust.js
@@ -1,7 +1,7 @@
 import { VIDEO_PROVIDERS } from "../../src/providers/CallIdProvider";
 import withContainer from "../../src/middleware/withContainer";
 
-export default withContainer(async (req, res, container) => {
+export default withContainer(async (req, res, { container }) => {
   if (req.method !== "PATCH") {
     res.status(405).end();
     return;

--- a/src/components/TrustsTable/index.js
+++ b/src/components/TrustsTable/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import AnchorLink from "../AnchorLink";
+import { VIDEO_PROVIDER_OPTIONS } from "../../providers/CallIdProvider";
 
 const TrustsTable = ({ trusts }) => (
   <div className="nhsuk-table-responsive">
@@ -10,6 +11,9 @@ const TrustsTable = ({ trusts }) => (
           <th className="nhsuk-table__header" scope="col">
             Trust name
           </th>
+          <th className="nhsuk-table__header" scope="col">
+            Video provider
+          </th>
           <th className="nhsuk-table__header" scope="col" colSpan="2">
             <span className="nhsuk-u-visually-hidden">Actions</span>
           </th>
@@ -17,8 +21,19 @@ const TrustsTable = ({ trusts }) => (
       </thead>
       <tbody className="nhsuk-table__body">
         {trusts.map((trust) => (
-          <tr key={trust.callId} className="nhsuk-table__row">
+          <tr
+            key={trust.callId}
+            className="nhsuk-table__row"
+            data-testid={trust.name.toLowerCase().replace(/\W+/g, "-")}
+          >
             <td className="nhsuk-table__cell">{trust.name}</td>
+            <td className="nhsuk-table__cell">
+              {
+                VIDEO_PROVIDER_OPTIONS.find(
+                  ({ id }) => id === trust.videoProvider
+                ).name
+              }
+            </td>
             <td className="nhsuk-table__cell">
               <AnchorLink href={`/admin/trusts/${trust.id}/edit`}>
                 Edit

--- a/src/components/TrustsTable/index.js
+++ b/src/components/TrustsTable/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import AnchorLink from "../AnchorLink";
 
 const TrustsTable = ({ trusts }) => (
   <div className="nhsuk-table-responsive">
@@ -9,12 +10,21 @@ const TrustsTable = ({ trusts }) => (
           <th className="nhsuk-table__header" scope="col">
             Trust name
           </th>
+          <th className="nhsuk-table__header" scope="col" colSpan="2">
+            <span className="nhsuk-u-visually-hidden">Actions</span>
+          </th>
         </tr>
       </thead>
       <tbody className="nhsuk-table__body">
         {trusts.map((trust) => (
           <tr key={trust.callId} className="nhsuk-table__row">
             <td className="nhsuk-table__cell">{trust.name}</td>
+            <td className="nhsuk-table__cell">
+              <AnchorLink href={`/admin/trusts/${trust.id}/edit`}>
+                Edit
+                <span className="nhsuk-u-visually-hidden"> {trust.name}</span>
+              </AnchorLink>
+            </td>
           </tr>
         ))}
       </tbody>

--- a/src/components/TrustsTable/index.js
+++ b/src/components/TrustsTable/index.js
@@ -20,28 +20,32 @@ const TrustsTable = ({ trusts }) => (
         </tr>
       </thead>
       <tbody className="nhsuk-table__body">
-        {trusts.map((trust) => (
-          <tr
-            key={trust.callId}
-            className="nhsuk-table__row"
-            data-testid={trust.name.toLowerCase().replace(/\W+/g, "-")}
-          >
-            <td className="nhsuk-table__cell">{trust.name}</td>
-            <td className="nhsuk-table__cell">
-              {
-                VIDEO_PROVIDER_OPTIONS.find(
-                  ({ id }) => id === trust.videoProvider
-                ).name
-              }
-            </td>
-            <td className="nhsuk-table__cell">
-              <AnchorLink href={`/admin/trusts/${trust.id}/edit`}>
-                Edit
-                <span className="nhsuk-u-visually-hidden"> {trust.name}</span>
-              </AnchorLink>
-            </td>
-          </tr>
-        ))}
+        {trusts.map((trust) => {
+          const trustKey = trust.name.toLowerCase().replace(/\W+/g, "-");
+
+          return (
+            <tr
+              key={trustKey}
+              className="nhsuk-table__row"
+              data-testid={trustKey}
+            >
+              <td className="nhsuk-table__cell">{trust.name}</td>
+              <td className="nhsuk-table__cell">
+                {
+                  VIDEO_PROVIDER_OPTIONS.find(
+                    ({ id }) => id === trust.videoProvider
+                  ).name
+                }
+              </td>
+              <td className="nhsuk-table__cell">
+                <AnchorLink href={`/admin/trusts/${trust.id}/edit`}>
+                  Edit
+                  <span className="nhsuk-u-visually-hidden"> {trust.name}</span>
+                </AnchorLink>
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </div>

--- a/src/usecases/retrieveTrusts.contractTest.js
+++ b/src/usecases/retrieveTrusts.contractTest.js
@@ -17,8 +17,18 @@ describe("retrieveTrusts contract tests", () => {
     const { trusts } = await container.getRetrieveTrusts()();
 
     expect(trusts).toEqual([
-      { id: trustId1, name: "Test Trust", adminCode: "code1" },
-      { id: trustId2, name: "Test Trust 2", adminCode: "code2" },
+      {
+        id: trustId1,
+        name: "Test Trust",
+        adminCode: "code1",
+        videoProvider: "TESTPROVIDER",
+      },
+      {
+        id: trustId2,
+        name: "Test Trust 2",
+        adminCode: "code2",
+        videoProvider: "TESTPROVIDER",
+      },
     ]);
   });
 });

--- a/src/usecases/retrieveTrusts.js
+++ b/src/usecases/retrieveTrusts.js
@@ -5,7 +5,8 @@ const retrieveTrusts = ({ getDb }) => async () => {
       `SELECT
         id as id,
         name as name,
-        admin_code as admin_code
+        admin_code as admin_code,
+        video_provider
       FROM
         trusts`
     );
@@ -15,6 +16,7 @@ const retrieveTrusts = ({ getDb }) => async () => {
         id: trust.id,
         name: trust.name,
         adminCode: trust.admin_code,
+        videoProvider: trust.video_provider,
       })),
       error: null,
     };


### PR DESCRIPTION
# What

Add edit a trust form for changing video provider and display the video provider on the trusts table.

# Why

So that a site admin can edit the video provider of a trust.

# Screenshots

![image](https://user-images.githubusercontent.com/42817036/89784167-1e262f00-db10-11ea-9dfb-4c948c0fd620.png)

![image](https://user-images.githubusercontent.com/42817036/89784200-2b431e00-db10-11ea-98c6-83aba041b733.png)

# Notes

N/A