### PR TITLE
Fix incorrectly prefilling month in booking form

### DIFF
--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -72,7 +72,7 @@ const DateSelect = ({
             onChange={(event) => {
               setDate({ ...date, month: parseInt(event.target.value) - 1 });
             }}
-            value={date.month + 1}
+            value={Number(date.month) + 1}
             autoComplete="off"
           />
         </div>


### PR DESCRIPTION
# What

Fix incorrectly prefilling month in booking a visit form when coming back from the confirmation page.

# Why

When coming back to the book a visit form from the confirmation page, we
appended the month value with "1" so when the month was "8" it became
"71" because the month is zero indexed and a string.

# Screenshots


Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/90000254-d4f8eb00-dc87-11ea-84fd-6070d142c08f.png)|![image](https://user-images.githubusercontent.com/42817036/90000216-c90d2900-dc87-11ea-85c2-3acf9ec8b4bb.png)

# Notes

N/A