### PR TITLE
All instances of ErrorSummary will auto focus

### DIFF
--- a/src/components/ErrorSummary/index.js
+++ b/src/components/ErrorSummary/index.js
@@ -1,15 +1,23 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 
 const ErrorSummary = ({ errors }) => {
   if (errors.length === 0) {
     return null;
   }
 
+  const thisRef = useRef(null);
+
+  useEffect(() => {
+    thisRef.current.focus();
+  }, []);
+
   return (
     <div
       className="nhsuk-error-summary"
       aria-labelledby="error-summary-title"
       role="alert"
+      tabIndex="0"
+      ref={thisRef}
     >
       <h2 className="nhsuk-error-summary__title" id="error-summary-title">
         There is a problem

--- a/src/components/ErrorSummary/index.js
+++ b/src/components/ErrorSummary/index.js
@@ -9,7 +9,7 @@ const ErrorSummary = ({ errors }) => {
 
   useEffect(() => {
     thisRef.current.focus();
-  }, []);
+  }, [errors]);
 
   return (
     <div


### PR DESCRIPTION
# What

When there is an error in a form, the browser will auto focus the error summary.

# Why

Users with screen readers can now tab through all the errors

# Screenshots

![image](https://user-images.githubusercontent.com/10476581/90030538-12736d80-dcb4-11ea-960b-3741bf63c254.png)

*Yellow border shows focus*
