### PR TITLE
Fix Whereby not displaying when attending a visit as visitor

### DIFF
--- a/pages/visits/[id].js
+++ b/pages/visits/[id].js
@@ -16,6 +16,7 @@ const Call = ({
   name,
   provider,
   error,
+  wherebySubdomain,
 }) => {
   if (error) {
     return <Error />;
@@ -61,7 +62,12 @@ const Call = ({
   return (
     <Layout title="Virtual visit" isBookService={false} mainStyleOverride>
       {provider === "whereby" ? (
-        <Whereby callId={callId} displayName={name} onEnd={leaveVisit} />
+        <Whereby
+          callId={callId}
+          displayName={name}
+          onEnd={leaveVisit}
+          wherebySubdomain={wherebySubdomain}
+        />
       ) : (
         <Jitsi callId={callId} name={name} onEnd={leaveVisit} />
       )}
@@ -99,6 +105,7 @@ export const getServerSideProps = propsWithContainer(
           name,
           provider,
           error,
+          wherebySubdomain: process.env.WHEREBY_SUBDOMAIN || null,
         },
       };
     } else {

--- a/src/components/Whereby/index.js
+++ b/src/components/Whereby/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Router from "next/router";
 
-const Whereby = ({ callId, displayName, onEnd }) => (
+const Whereby = ({ callId, displayName, onEnd, wherebySubdomain }) => (
   <div>
     <iframe
       data-testid="whereby"
@@ -10,7 +10,7 @@ const Whereby = ({ callId, displayName, onEnd }) => (
         height: "calc(100vh - 195px)",
         border: 0,
       }}
-      src={`https://${process.env.WHEREBY_SUBDOMAIN}.whereby.com/${callId}?embed&iframeSource=${process.env.WHEREBY_SUBDOMAIN}&background=off&displayName=${displayName}&screenshare=off&chat=off`}
+      src={`https://${wherebySubdomain}.whereby.com/${callId}?embed&iframeSource=${wherebySubdomain}&background=off&displayName=${displayName}&screenshare=off&chat=off`}
       allow="camera; microphone; fullscreen; speaker"
     ></iframe>
     <button

--- a/src/components/Whereby/index.test.js
+++ b/src/components/Whereby/index.test.js
@@ -5,19 +5,17 @@ import Whereby from "./index";
 jest.mock("next/router");
 
 describe("Whereby", () => {
-  beforeEach(() => {
-    process.env.WHEREBY_SUBDOMAIN = "test-subdomain";
-  });
-
-  afterEach(() => {
-    process.env.WHEREBY_SUBDOMAIN = "";
-  });
-
   it("sets the source of the iframe with the subdomain", () => {
     const callId = "testCallId";
     const displayName = "Test McTest";
 
-    render(<Whereby callId={callId} displayName={displayName} />);
+    render(
+      <Whereby
+        callId={callId}
+        displayName={displayName}
+        wherebySubdomain="test-subdomain"
+      />
+    );
 
     expect(screen.getByTestId("whereby")).toHaveAttribute(
       "src",


### PR DESCRIPTION
# What

Fix Whereby not displaying when attending a visit as visitor.

# Why

As a result of fixing our incorrect usage of `router.push`, it only works after a refresh of the page.

Because we use `router.push` from the visitor's name page,
`WHEREBY_SUBDOMAIN` isn't available so by passing it down from
Server-side props it should be available for the Whereby component to
use when generating the src for the iFrame.

# Screenshots

N/A

# Notes

N/A