### PR TITLE
Update add a trust success page to use dynamic routing

### DIFF
--- a/pageTests/admin/trusts/[id]/add-success.test.js
+++ b/pageTests/admin/trusts/[id]/add-success.test.js
@@ -1,4 +1,4 @@
-import { getServerSideProps } from "../../pages/admin/add-a-trust-success";
+import { getServerSideProps } from "../../../../pages/admin/trusts/[id]/add-success";
 
 const authenticatedReq = {
   headers: {
@@ -10,7 +10,7 @@ const tokenProvider = {
   validate: jest.fn(() => ({ type: "admin" })),
 };
 
-describe("/admin/add-a-trust-success", () => {
+describe("/admin/trusts/[id]/add-success", () => {
   const anonymousReq = {
     headers: {
       cookie: "",
@@ -54,7 +54,7 @@ describe("/admin/add-a-trust-success", () => {
           req: authenticatedReq,
           res,
           query: {
-            trustId: "trust ID",
+            id: "trust ID",
           },
           container,
         });

--- a/pages/admin/add-a-trust.js
+++ b/pages/admin/add-a-trust.js
@@ -3,7 +3,6 @@ import ErrorSummary from "../../src/components/ErrorSummary";
 import { GridRow, GridColumn } from "../../src/components/Grid";
 import Layout from "../../src/components/Layout";
 import verifyAdminToken from "../../src/usecases/verifyAdminToken";
-
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import FormGroup from "../../src/components/FormGroup";
 import Heading from "../../src/components/Heading";
@@ -136,10 +135,10 @@ const AddATrust = () => {
 
         if (status == 201) {
           const { trustId } = await response.json();
-          Router.push({
-            pathname: "/admin/add-a-trust-success",
-            query: { trustId: trustId },
-          });
+          Router.push(
+            "/admin/trusts/[id]/add-success",
+            `/admin/trusts/${trustId}/add-success`
+          );
           return true;
         } else if (status === 409) {
           const { err } = await response.json();

--- a/pages/admin/trusts/[id]/add-success.js
+++ b/pages/admin/trusts/[id]/add-success.js
@@ -1,11 +1,11 @@
 import React from "react";
 import Error from "next/error";
-import Layout from "../../src/components/Layout";
-import AnchorLink from "../../src/components/AnchorLink";
-import propsWithContainer from "../../src/middleware/propsWithContainer";
-import verifyAdminToken from "../../src/usecases/verifyAdminToken";
-import ActionLink from "../../src/components/ActionLink";
-import { ADMIN } from "../../src/helpers/userTypes";
+import Layout from "../../../../src/components/Layout";
+import AnchorLink from "../../../../src/components/AnchorLink";
+import propsWithContainer from "../../../../src/middleware/propsWithContainer";
+import verifyAdminToken from "../../../../src/usecases/verifyAdminToken";
+import ActionLink from "../../../../src/components/ActionLink";
+import { ADMIN } from "../../../../src/helpers/userTypes";
 
 const AddATrustSuccess = ({ error, name }) => {
   if (error) {
@@ -42,7 +42,7 @@ const AddATrustSuccess = ({ error, name }) => {
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(async ({ container, query }) => {
     const getRetrieveTrustById = container.getRetrieveTrustById();
-    const { trust, error } = await getRetrieveTrustById(query.trustId);
+    const { trust, error } = await getRetrieveTrustById(query.id);
 
     if (error) {
       return { props: { error: error } };


### PR DESCRIPTION
# What

Update add a trust success page for a site admin to use dynamic routing.

# Why

This means we don't get the trustId from the query params, instead we
get it from within the path i.e.

Previous: `admin/add-a-trust-success?trustId=1`
Now: `admin/trusts/1/add-success`

Thereby making it consistent with all other pages.

# Screenshots

N/A

# Notes

N/A