### PR TITLE
speprate wardId from visit

### DIFF
--- a/src/testUtils/factories.js
+++ b/src/testUtils/factories.js
@@ -64,5 +64,5 @@ export const setupVisit = async (args = {}) => {
     callPassword: "TESTCALLPASSWORD",
     ...args,
   };
-  return await insertVisit(db, visit);
+  return await insertVisit(db, visit, args.wardId);
 };

--- a/src/usecases/createVisit.js
+++ b/src/usecases/createVisit.js
@@ -46,7 +46,7 @@ const createVisit = (
   try {
     return await db.tx(async (t) => {
       logger.debug("inserting visit");
-      // const { id, call_id } = await insertVisit(t, visit);
+
       await insertVisitQuery(t, populatedVisit, wardId);
       logger.debug("updating ward totals");
       await updateWardVisitTotalsSql(t, wardId, populatedVisit.callTime);

--- a/src/usecases/createVisit.test.js
+++ b/src/usecases/createVisit.test.js
@@ -19,8 +19,8 @@ describe("insertVisit sql test", () => {
       wardId: 1,
       callPassword: "securePassword",
     };
-
-    const { id, callId } = await insertVisit(db, request);
+    const wardId = "wardId";
+    const { id, callId } = await insertVisit(db, request, wardId);
 
     expect(id).toEqual(10);
     expect(callId).toEqual("12345");
@@ -33,7 +33,7 @@ describe("insertVisit sql test", () => {
       request.callTime,
       request.callId,
       request.provider,
-      request.wardId,
+      wardId,
       request.callPassword,
       SCHEDULED,
     ]);

--- a/src/usecases/retrieveVisits.contractTest.js
+++ b/src/usecases/retrieveVisits.contractTest.js
@@ -30,57 +30,69 @@ describe("retrieveVisits contract tests", () => {
       trustId: trustId,
     });
 
-    await insertVisit(db, {
-      wardId: wardId,
-      trustId: trustId,
-      provider: "whereby",
-      callPassword: "test",
-      patientName: "past visit",
-      callTime: moment().subtract(2, "hours"),
-      contactEmail: "contact@example.com",
-      contactName: "Contact Name",
-      callId: "two",
-    });
+    await insertVisit(
+      db,
+      {
+        trustId: trustId,
+        provider: "whereby",
+        callPassword: "test",
+        patientName: "past visit",
+        callTime: moment().subtract(2, "hours"),
+        contactEmail: "contact@example.com",
+        contactName: "Contact Name",
+        callId: "two",
+      },
+      wardId
+    );
 
-    await insertVisit(db, {
-      wardId: wardId,
-      trustId: trustId,
-      provider: "test",
-      callPassword: "test",
-      patientName: "future visit",
-      callTime: moment().add(2, "hours"),
-      contactEmail: "contact@example.com",
-      contactName: "Contact Name",
-      callId: "three",
-    });
+    await insertVisit(
+      db,
+      {
+        trustId: trustId,
+        provider: "test",
+        callPassword: "test",
+        patientName: "future visit",
+        callTime: moment().add(2, "hours"),
+        contactEmail: "contact@example.com",
+        contactName: "Contact Name",
+        callId: "three",
+      },
+      wardId
+    );
 
     // Cancelled visits are not returned
-    const visitToBeCancelled = await insertVisit(db, {
-      wardId: wardId,
-      trustId: trustId,
-      provider: "test",
-      callPassword: "test",
-      callId: "cancelledVisit",
-      patientName: "cancelled visit",
-      callTime: moment().add(2, "hours"),
-      contactEmail: "contact@example.com",
-      contactName: "Contact Name",
-    });
+    const visitToBeCancelled = await insertVisit(
+      db,
+      {
+        trustId: trustId,
+        provider: "test",
+        callPassword: "test",
+        callId: "cancelledVisit",
+        patientName: "cancelled visit",
+        callTime: moment().add(2, "hours"),
+        contactEmail: "contact@example.com",
+        contactName: "Contact Name",
+      },
+      wardId
+    );
 
     await deleteVisitByCallId(container)(visitToBeCancelled.callId);
 
     // Visits from other wards are not returned
-    await insertVisit(db, {
-      wardId: wardId2,
-      trustId: trustId,
-      provider: "test",
-      callPassword: "test",
-      patientName: "different ward visit",
-      callTime: moment().add(2, "hours"),
-      contactEmail: "contact@example.com",
-      contactName: "Contact Name",
-      callId: "five",
-    });
+    await insertVisit(
+      db,
+      {
+        trustId: trustId,
+        provider: "test",
+        callPassword: "test",
+        patientName: "different ward visit",
+        callTime: moment().add(2, "hours"),
+        contactEmail: "contact@example.com",
+        contactName: "Contact Name",
+        callId: "five",
+      },
+      wardId2
+    );
 
     const { scheduledCalls } = await container.getRetrieveVisits()({ wardId });
     expect(scheduledCalls).toEqual([

--- a/src/usecases/retrieveVisits.contractTest.js
+++ b/src/usecases/retrieveVisits.contractTest.js
@@ -33,7 +33,6 @@ describe("retrieveVisits contract tests", () => {
     await insertVisit(
       db,
       {
-        trustId: trustId,
         provider: "whereby",
         callPassword: "test",
         patientName: "past visit",
@@ -48,7 +47,6 @@ describe("retrieveVisits contract tests", () => {
     await insertVisit(
       db,
       {
-        trustId: trustId,
         provider: "test",
         callPassword: "test",
         patientName: "future visit",
@@ -64,7 +62,6 @@ describe("retrieveVisits contract tests", () => {
     const visitToBeCancelled = await insertVisit(
       db,
       {
-        trustId: trustId,
         provider: "test",
         callPassword: "test",
         callId: "cancelledVisit",
@@ -82,7 +79,6 @@ describe("retrieveVisits contract tests", () => {
     await insertVisit(
       db,
       {
-        trustId: trustId,
         provider: "test",
         callPassword: "test",
         patientName: "different ward visit",


### PR DESCRIPTION
# What
This commit separates `wardId` from `visit` in `createVisit`
# Why
Some time was spent refactoring `createVisit` so it accepts `wardId` and `trustId` as separate arguments because they are distinct domains from a `visit`. However the create visit function then merges these two concepts together and a `wardId` becomes part of a `visit`. This commit separates them.

