### PR TITLE
Remove use of Real client in test and stub Fake client key

### DIFF
--- a/src/gateways/GovNotify/index.contractTest.js
+++ b/src/gateways/GovNotify/index.contractTest.js
@@ -1,30 +1,14 @@
 import TemplateStore from "../../gateways/GovNotify/TemplateStore";
 import fillObjectWithStrings from "../../testUtils/fillObjectWithStrings";
 
-const { NotifyClient: RealNotifyClient } = jest.requireActual(
-  "notifications-node-client"
-);
 const { NotifyClient: FakeNotifyClient } = jest.requireMock(
   "notifications-node-client"
 );
 
 const contractTestClient = (testCallback) => () => {
-  const apiKey = process.env.API_KEY;
-  const clients = [
-    {
-      label: "Real",
-      client: new RealNotifyClient(apiKey),
-    },
-    {
-      label: "Fake",
-      client: new FakeNotifyClient(),
-    },
-  ];
-
-  clients.forEach(({ label, client }) => {
-    describe(`with a ${label} GovNotify client`, () => {
-      testCallback({ label, client });
-    });
+  describe(`with a Fake GovNotify client`, () => {
+    const client = new FakeNotifyClient();
+    testCallback({ client });
   });
 };
 

--- a/src/gateways/GovNotify/index.js
+++ b/src/gateways/GovNotify/index.js
@@ -8,11 +8,10 @@ export default (() => {
   return {
     getInstance: async () => {
       if (!instance) {
-        const apiKey = process.env.API_KEY;
-
         if (process.env.APP_ENV === "test") {
-          instance = new FakeNotifyClient(apiKey);
+          instance = new FakeNotifyClient("apiKey");
         } else {
+          const apiKey = process.env.API_KEY;
           instance = new NotifyClient(apiKey);
         }
 


### PR DESCRIPTION
# What
Removed tests which were using the real Notify test client and remove the need for fake client to receive api key from the env var.
# Why
-Reduce the external dependencies on our tests
-Simplify the pipeline as an env var for the api key is not needed for the Fake client

