### PR TITLE
Fix the login redirect for the same ward and admin code

### DIFF
--- a/cypress/integration/admin/loggingInAndOut.js
+++ b/cypress/integration/admin/loggingInAndOut.js
@@ -31,12 +31,31 @@ describe("As an admin, I want to log in so that I can access the service.", () =
     ThenISeeAnError();
   });
 
+  it("allows an admin to log in and out when a ward code and admin code are the same", () => {
+    GivenTheSameWardCodeAsAdminCode();
+    GivenIAmAnAdmin();
+    WhenIVisitTheAdminLogInPage();
+
+    cy.audit();
+
+    AndIEnterAValidAdminCodeAndPassword();
+    AndISubmitTheForm();
+    ThenISeeTheAdminHomePage();
+
+    cy.audit();
+
+    thenIClickLogOut();
+    ThenISeeTheAdminLogInPage();
+  });
+
   it("displays an error for an invalid password", () => {
     WhenIVisitTheAdminLogInPage();
     AndIEnterAnInvalidPassword();
     AndISubmitTheForm();
     ThenISeeAnError();
   });
+
+  function GivenTheSameWardCodeAsAdminCode() {}
 
   function WhenIVisitTheAdminLogInPage() {
     cy.visit(Cypress.env("baseUrl") + "/admin/login");

--- a/cypress/integration/trust-admin/loggingInAndOut.js
+++ b/cypress/integration/trust-admin/loggingInAndOut.js
@@ -27,12 +27,29 @@ describe("As a trust admin, I want to log in so that I can access the service.",
     ThenISeeAnError();
   });
 
+  it("allows a trust admin to log in and out when the ward code and trust admin code are the same", () => {
+    GivenTheSameWardCodeAsAdminCode();
+    GivenIAmATrustAdmin();
+    WhenIVisitTheTrustAdminLogInPage();
+    cy.audit();
+
+    AndIEnterAValidTrustAdminCodeAndPassword();
+    AndISubmitTheForm();
+    ThenISeeTheTrustAdminHomePage();
+    cy.audit();
+
+    WhenIClickLogOut();
+    ThenISeeTheTrustAdminLogInPage();
+  });
+
   it("displays an error for an invalid password", () => {
     WhenIVisitTheTrustAdminLogInPage();
     AndIEnterAnInvalidPassword();
     AndISubmitTheForm();
     ThenISeeAnError();
   });
+
+  function GivenTheSameWardCodeAsAdminCode() {}
 
   function WhenIVisitTheTrustAdminLogInPage() {
     cy.visit(Cypress.env("baseUrl") + "/trust-admin/login");

--- a/db/scripts/seed_database.js
+++ b/db/scripts/seed_database.js
@@ -27,6 +27,10 @@ async function seedDatabase() {
     "INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward Two', (SELECT id FROM hospitals WHERE name='Test Hospital'), 'TEST2', (SELECT id FROM trusts WHERE name='Test Trust')) RETURNING id"
   );
 
+  await db.one(
+    "INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward Two', (SELECT id FROM hospitals WHERE name='Test Hospital'), 'super', (SELECT id FROM trusts WHERE name='Test Trust')) RETURNING id"
+  );
+
   await db.result(
     `INSERT INTO scheduled_calls_table
     (patient_name, recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status)

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -4,8 +4,11 @@ import { WARD_STAFF, TRUST_ADMIN, ADMIN } from "../../src/helpers/userTypes";
 export default withContainer(
   async ({ body: { code, password }, method }, res, { container }) => {
     if (method === "POST") {
-      const verifyWardCode = container.getVerifyWardCode();
-      const verifyWardCodeResponse = await verifyWardCode(code);
+      let verifyWardCodeResponse = {};
+      if (password === undefined) {
+        const verifyWardCode = container.getVerifyWardCode();
+        verifyWardCodeResponse = await verifyWardCode(code);
+      }
 
       const verifyTrustAdminCode = container.getVerifyTrustAdminCode();
       const verifyTrustAdminCodeResponse = await verifyTrustAdminCode(


### PR DESCRIPTION
# What
 A guard clause is added to check if a password exists before a ward code can be verified and a token generated.
# Why
For a token to be generated, the code passed in to the session api must first be validated. `Trust admin` codes and `admin` codes require passwords in order for them to be verified as codes for which a token can be generated, `ward `codes do not. This means that if a `ward` code was the same as an `admin` code, when a login request is made using the `admin`, both the `admin` code and `ward` code is verified (as a password is provided for the `admin` verification and `ward` verification only requires for there to be a `ward` with that code) allowing a token to be generated for the `ward `code and set as the cookie. If a token exists for a `ward` code it would automatically redirect to the ward login page.

