### PR TITLE
Add a feature flag provider

### DIFF
--- a/src/helpers/featureFlag.js
+++ b/src/helpers/featureFlag.js
@@ -1,5 +1,5 @@
 const featureIsEnabled = (feature) => {
-  return process.env[feature] === "yes" ? true : false;
+  return process.env[feature] === "true";
 };
 
 export default featureIsEnabled;

--- a/src/helpers/featureFlag.js
+++ b/src/helpers/featureFlag.js
@@ -1,0 +1,5 @@
+const featureIsEnabled = (feature) => {
+  return process.env[feature] === "yes" ? true : false;
+};
+
+export default featureIsEnabled;

--- a/src/helpers/featureFlag.test.js
+++ b/src/helpers/featureFlag.test.js
@@ -2,12 +2,12 @@ import featureIsEnabled from "./featureFlag";
 
 describe("featureFlag", () => {
   it("returns true if env var for feature is set to yes", () => {
-    process.env.FEATURE_FLAG_COOL_FEATURE = "yes";
+    process.env.FEATURE_FLAG_COOL_FEATURE = "true";
     expect(featureIsEnabled("FEATURE_FLAG_COOL_FEATURE")).toBeTruthy();
   });
 
   it("returns false if env var for feature is set to no", () => {
-    process.env.FEATURE_FLAG_COOL_FEATURE = "no";
+    process.env.FEATURE_FLAG_COOL_FEATURE = "false";
     expect(featureIsEnabled("FEATURE_FLAG_COOL_FEATURE")).toBeFalsy();
   });
 

--- a/src/helpers/featureFlag.test.js
+++ b/src/helpers/featureFlag.test.js
@@ -1,0 +1,17 @@
+import featureIsEnabled from "./featureFlag";
+
+describe("featureFlag", () => {
+  it("returns true if env var for feature is set to yes", () => {
+    process.env.FEATURE_FLAG_COOL_FEATURE = "yes";
+    expect(featureIsEnabled("FEATURE_FLAG_COOL_FEATURE")).toBeTruthy();
+  });
+
+  it("returns false if env var for feature is set to no", () => {
+    process.env.FEATURE_FLAG_COOL_FEATURE = "no";
+    expect(featureIsEnabled("FEATURE_FLAG_COOL_FEATURE")).toBeFalsy();
+  });
+
+  it("returns false if env var for feature is not set", () => {
+    expect(featureIsEnabled("FEATURE_FLAG_TEST_FEATURE")).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# What
Adds a feature flag provider.

# Why
So that we can deploy features without releasing them, and are able to toggle features on per environment.

# Notes
The feature flag provider takes an argument that corresponds to the name of the feature flag environment variable for the feature, e.g:

```
if (featureIsEnabled(`FEATURE_FLAG_TEST_FEATURE`)) {
    .....
}
```

where `featureIsEnabled` is the feature flag provider and, for the sake of this example, `FEATURE_FLAG_TEST_FEATURE` is the name of the env var for the 'test feature' feature flag. The feature flag env var needs to be set to `true` for the feature to be toggled on, e.g.

`FEATURE_FLAG_TEST_FEATURE=true`

and toggled to false, or simply omitted as an env var altogether, if the feature is to be toggled off.