### PR TITLE
Migrate patient details to own table

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -100,3 +100,40 @@ jobs:
           SMS_JOIN_TEMPLATE_ID: ${{ secrets.SMS_JOIN_TEMPLATE_ID }}
           EMAIL_INITIAL_TEMPLATE_ID: ${{ secrets.EMAIL_INITIAL_TEMPLATE_ID }}
           EMAIL_JOIN_TEMPLATE_ID: ${{ secrets.EMAIL_JOIN_TEMPLATE_ID }}
+
+  migration-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nhs-virtual-visit-test
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    if: (github.repository == 'madetech/nhs-virtual-visit')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: npm install ci
+        run: npm ci
+
+      - name: run migration tests
+        run: |
+          npm run dbmigratetest up
+          npm run test:migration
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/nhs-virtual-visit-test
+          APP_ENV: test

--- a/db/migrations/20201030102755-move-patient-details-to-new-table.js
+++ b/db/migrations/20201030102755-move-patient-details-to-new-table.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var fs = require("fs");
+var path = require("path");
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20201030102755-move-patient-details-to-new-table-up.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      console.log("received data: " + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20201030102755-move-patient-details-to-new-table-down.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      console.log("received data: " + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/20201030102755-move-patient-details-to-new-table.js
+++ b/db/migrations/20201030102755-move-patient-details-to-new-table.js
@@ -45,8 +45,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
       if (err) return reject(err);
-      console.log("received data: " + data);
-
       resolve(data);
     });
   }).then(function (data) {

--- a/db/migrations/sqls/20201030102755-move-patient-details-to-new-table-down.sql
+++ b/db/migrations/sqls/20201030102755-move-patient-details-to-new-table-down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE scheduled_calls_table ADD patient_name varchar(255);
+
+UPDATE scheduled_calls_table
+SET patient_name = patient_details.patient_name
+FROM patient_details
+WHERE scheduled_calls_table.patient_details_id = patient_details.id;
+
+ALTER TABLE scheduled_calls_table DROP column patient_details_id;
+
+DROP TABLE patient_details;

--- a/db/migrations/sqls/20201030102755-move-patient-details-to-new-table-up.sql
+++ b/db/migrations/sqls/20201030102755-move-patient-details-to-new-table-up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE patient_details (
+    id serial PRIMARY KEY,
+    patient_name varchar(255) NOT NULL,
+    ward_id integer NOT NULL REFERENCES wards (id),
+    visit_id integer NOT NULL REFERENCES scheduled_calls_table (id)
+);
+
+INSERT INTO patient_details (patient_name, ward_id, visit_id) SELECT patient_name, ward_id, id FROM scheduled_calls_table;
+
+ALTER TABLE scheduled_calls_table ADD patient_details_id integer REFERENCES patient_details (id);
+
+UPDATE scheduled_calls_table
+SET patient_details_id = patient_details.id
+FROM patient_details
+WHERE scheduled_calls_table.id = patient_details.visit_id;
+
+ALTER TABLE patient_details DROP COLUMN visit_id;
+ALTER TABLE scheduled_calls_table DROP COLUMN patient_name;

--- a/db/scripts/cleanup_scheduled_calls.js
+++ b/db/scripts/cleanup_scheduled_calls.js
@@ -25,22 +25,53 @@ async function cleanupScheduledCalls() {
 
   const scheduledCalls = await db.result(
     `UPDATE scheduled_calls_table
-     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, status = $1, pii_cleared_at = NOW()
+     SET recipient_number = null, recipient_name = null, recipient_email = null, status = $1, pii_cleared_at = NOW()
      WHERE call_time < (now() - INTERVAL '1 DAY') AND (status = $1 OR status = $2) AND pii_cleared_at IS NULL`,
+    [status.COMPLETE, status.SCHEDULED]
+  );
+
+  await db.result(
+    `UPDATE patient_details
+     SET patient_name = null
+     FROM scheduled_calls_table
+     WHERE scheduled_calls_table.call_time < (now() - INTERVAL '1 DAY')
+     AND (scheduled_calls_table.status = $1 OR scheduled_calls_table.status = $2)
+     AND scheduled_calls_table.pii_cleared_at IS NULL
+     AND scheduled_calls_table.patient_details_id = patient_details.id`,
     [status.COMPLETE, status.SCHEDULED]
   );
 
   const archivedCalls = await db.result(
     `UPDATE scheduled_calls_table
-     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
+     SET recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
      WHERE status = $1 AND pii_cleared_at IS NULL`,
+    status.ARCHIVED
+  );
+
+  await db.result(
+    `UPDATE patient_details
+     SET patient_name = null
+     FROM scheduled_calls_table
+     WHERE scheduled_calls_table.status = $1
+     AND scheduled_calls_table.pii_cleared_at IS NULL
+     AND scheduled_calls_table.patient_details_id = patient_details.id`,
     status.ARCHIVED
   );
 
   const cancelledCalls = await db.result(
     `UPDATE scheduled_calls_table
-     SET patient_name = null, recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
+     SET recipient_number = null, recipient_name = null, recipient_email = null, pii_cleared_at = NOW()
      WHERE status = $1 AND pii_cleared_at IS NULL`,
+    status.CANCELLED
+  );
+
+  await db.result(
+    `UPDATE patient_details
+     SET patient_name = null
+     FROM scheduled_calls_table
+     WHERE scheduled_calls_table.status = $1
+     AND scheduled_calls_table.pii_cleared_at IS NULL
+     AND scheduled_calls_table.patient_details_id = patient_details.id`,
     status.CANCELLED
   );
 

--- a/db/scripts/seed_database.js
+++ b/db/scripts/seed_database.js
@@ -31,17 +31,31 @@ async function seedDatabase() {
     "INSERT INTO wards (name, hospital_id, code, trust_id) VALUES ('Test Ward Two', (SELECT id FROM hospitals WHERE name='Test Hospital'), 'super', (SELECT id FROM trusts WHERE name='Test Trust')) RETURNING id"
   );
 
+  const {
+    id: patientDetailsId,
+  } = await db.one(
+    "INSERT INTO patient_details (patient_name, ward_id) VALUES ('Alice', $1) RETURNING id",
+    [wardId]
+  );
+
+  const {
+    id: secondPatientDetailsId,
+  } = await db.one(
+    "INSERT INTO patient_details (patient_name, ward_id) VALUES ('Elliot', $1) RETURNING id",
+    [wardId]
+  );
+
   await db.result(
     `INSERT INTO scheduled_calls_table
-    (patient_name, recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status)
-    VALUES ('Alice', 'bob@example.com', 'Bob', CURRENT_TIMESTAMP + interval '1 hour', '123', 'whereby', $1, 'password', 'scheduled')`,
-    [wardId]
+    (recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status, patient_details_id)
+    VALUES ('bob@example.com', 'Bob', CURRENT_TIMESTAMP + interval '1 hour', '123', 'whereby', $1, 'password', 'scheduled', $2)`,
+    [wardId, patientDetailsId]
   );
   await db.result(
     `INSERT INTO scheduled_calls_table
-    (patient_name, recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status)
-    VALUES ('Elliot', 'darlene@example.com', 'Darlene', CURRENT_TIMESTAMP + interval '1 hour', '456', 'whereby', $1, 'password', 'scheduled')`,
-    [wardId]
+    (recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status, patient_details_id)
+    VALUES ('darlene@example.com', 'Darlene', CURRENT_TIMESTAMP + interval '1 hour', '456', 'whereby', $1, 'password', 'scheduled', $2)`,
+    [wardId, secondPatientDetailsId]
   );
   db.$pool.end();
 }

--- a/db/tests/patient_details_migration.migrationTest.js
+++ b/db/tests/patient_details_migration.migrationTest.js
@@ -1,0 +1,270 @@
+import { execSync } from "child_process";
+import AppContainer from "../../src/containers/AppContainer";
+import { setupWardWithinHospitalAndTrust } from "../../src/testUtils/factories";
+import { COMPLETE, SCHEDULED } from "../../src/helpers/visitStatus";
+
+describe("patient details migration", () => {
+  const container = AppContainer.getInstance();
+  let date;
+
+  beforeEach(() => {
+    date = new Date();
+    date.setDate(date.getDate() + 1);
+  });
+
+  it("migrates the patient details data from the visits table to the patient_details table", async () => {
+    const downAllMigrations = execSync("npm run dbmigratetest reset");
+    console.log(downAllMigrations.toString());
+
+    // run all migrations up until 24/07/2020 (which is just before the Patient Details migration)
+    const runMigrationsToBeforePatientDetailsMigration = execSync(
+      "npm run dbmigratetest up 20200724000000"
+    );
+    console.log(runMigrationsToBeforePatientDetailsMigration.toString());
+
+    const { wardId } = await setupWardWithinHospitalAndTrust();
+
+    const db = await container.getDb();
+
+    const { id } = await db.one(
+      `INSERT INTO scheduled_calls_table
+        (id, patient_name, recipient_email, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password, status)
+        VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        RETURNING id, call_id
+      `,
+      [
+        "Patient Name",
+        "contact@example.com",
+        "",
+        "Contact Name",
+        date,
+        "TESTCALLID",
+        "whereby",
+        wardId,
+        "TESTCALLPASSWORD",
+        SCHEDULED,
+      ]
+    );
+
+    const visit = await db.one(
+      `SELECT * FROM scheduled_calls_table
+      WHERE ward_id = $1
+      AND status = ANY(ARRAY[$2,$3]::text[])
+      AND pii_cleared_at IS NULL
+      `,
+      [id, wardId, SCHEDULED, COMPLETE]
+    );
+
+    // checking that, before the Patient Details migration is run, the visit contains the patient name
+    expect(visit).toEqual({
+      patient_name: "Patient Name",
+      recipient_name: "Contact Name",
+      recipient_number: "",
+      recipient_email: "contact@example.com",
+      call_time: date,
+      call_id: "TESTCALLID",
+      provider: "whereby",
+      call_password: "TESTCALLPASSWORD",
+      status: SCHEDULED,
+      id,
+      pii_cleared_at: null,
+      ward_id: wardId,
+    });
+
+    // running patient_details migration
+    execSync("npm run dbmigratetest up");
+
+    // checking patient_details table exists
+    const [{ exists: patientDetailsTableExists }] = await db.any(
+      "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'patient_details')"
+    );
+    expect(patientDetailsTableExists).toEqual(true);
+
+    // checking patient_details_id fields exists on visits table
+    const [{ exists: patientDetailsColumnExists }] = await db.any(
+      `SELECT EXISTS
+      (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'scheduled_calls_table'
+        AND column_name = 'patient_details_id'
+      )`
+    );
+    expect(patientDetailsColumnExists).toEqual(true);
+
+    // checking patient_name field no longer exist on visits table
+    const [{ exists: patientNameColumnExists }] = await db.any(
+      `SELECT EXISTS
+      (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'scheduled_calls_table'
+        AND column_name = 'patient_name'
+      )`
+    );
+    expect(patientNameColumnExists).toEqual(false);
+
+    // checking patient details in new table
+    const [
+      { patient_details_id: patientDetailsId },
+    ] = await db.any(
+      "SELECT patient_details_id FROM scheduled_calls_table WHERE id = $1",
+      [id]
+    );
+
+    const patientDetails = await db.any(
+      "SELECT * FROM patient_details WHERE id = $1",
+      [patientDetailsId]
+    );
+    expect(patientDetails).toEqual([
+      {
+        id: patientDetailsId,
+        patient_name: "Patient Name",
+        ward_id: wardId,
+      },
+    ]);
+
+    const { scheduledCall, error } = await container.getRetrieveVisitById()({
+      id,
+      wardId,
+    });
+
+    // checking visit is still there
+    expect(scheduledCall).toEqual({
+      patientName: "Patient Name",
+      recipientName: "Contact Name",
+      recipientNumber: "",
+      recipientEmail: "contact@example.com",
+      callTime: date,
+      callId: "TESTCALLID",
+      provider: "whereby",
+      callPassword: "TESTCALLPASSWORD",
+      status: SCHEDULED,
+      id,
+    });
+    expect(error).toBeNull();
+  });
+
+  it("migrates the patient details data from the patient_details table to the visits table on the down migration", async () => {
+    const downAllMigrations = execSync("npm run dbmigratetest reset");
+    console.log(downAllMigrations.toString());
+
+    // run all migrations up until 31/10/2020 (which is just after the Patient Details migration)
+    const runMigrationsToJustAfterPatientDetailsMigration = execSync(
+      "npm run dbmigratetest up 20201031000000"
+    );
+    console.log(runMigrationsToJustAfterPatientDetailsMigration.toString());
+
+    const { wardId } = await setupWardWithinHospitalAndTrust();
+
+    const db = await container.getDb();
+
+    const { id } = await container.getInsertVisitGateway()(
+      db,
+      {
+        provider: "whereby",
+        callPassword: "TESTCALLPASSWORD2",
+        patientName: "Another Patient Name",
+        callTime: date,
+        contactEmail: "anothercontact@example.com",
+        contactName: "Another Contact Name",
+        callId: "TESTCALLID2",
+      },
+      wardId
+    );
+
+    // checking patient details in new table
+    const [
+      { patient_details_id: patientDetailsId },
+    ] = await db.any(
+      "SELECT patient_details_id FROM scheduled_calls_table WHERE id = $1",
+      [id]
+    );
+
+    const patientDetails = await db.any(
+      "SELECT * FROM patient_details WHERE id = $1",
+      [patientDetailsId]
+    );
+    expect(patientDetails).toEqual([
+      {
+        id: patientDetailsId,
+        patient_name: "Another Patient Name",
+        ward_id: wardId,
+      },
+    ]);
+
+    let { scheduledCall, error } = await container.getRetrieveVisitById()({
+      id,
+      wardId,
+    });
+
+    // checking visit
+    expect(scheduledCall).toEqual({
+      patientName: "Another Patient Name",
+      recipientName: "Another Contact Name",
+      recipientNumber: "",
+      recipientEmail: "anothercontact@example.com",
+      callTime: date,
+      callId: "TESTCALLID2",
+      provider: "whereby",
+      callPassword: "TESTCALLPASSWORD2",
+      status: SCHEDULED,
+      id,
+    });
+    expect(error).toBeNull();
+
+    // rolling back the patient_details migration
+    execSync("npm run dbmigratetest down");
+
+    const visit = await db.one(
+      `SELECT * FROM scheduled_calls_table
+      WHERE ward_id = $1
+      AND status = ANY(ARRAY[$2,$3]::text[])
+      AND pii_cleared_at IS NULL
+      `,
+      [id, wardId, SCHEDULED, COMPLETE]
+    );
+
+    // checking that the visit is there
+    expect(visit).toEqual({
+      patient_name: "Another Patient Name",
+      recipient_name: "Another Contact Name",
+      recipient_number: "",
+      recipient_email: "anothercontact@example.com",
+      call_time: date,
+      call_id: "TESTCALLID2",
+      provider: "whereby",
+      call_password: "TESTCALLPASSWORD2",
+      status: SCHEDULED,
+      id,
+      pii_cleared_at: null,
+      ward_id: wardId,
+    });
+
+    // checking patient_details table does not exist
+    const [{ exists: patientDetailsTableExists }] = await db.any(
+      "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'patient_details')"
+    );
+    expect(patientDetailsTableExists).toEqual(false);
+
+    // checking patient_details_id field does not exist on visits table
+    const [{ exists: patientDetailsColumnExists }] = await db.any(
+      `SELECT EXISTS
+      (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'scheduled_calls_table'
+        AND column_name = 'patient_details_id'
+      )`
+    );
+    expect(patientDetailsColumnExists).toEqual(false);
+
+    // check that patient name column exisits on the visits table
+    const [{ exists: patientNameColumnExists }] = await db.any(
+      `SELECT EXISTS
+      (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'scheduled_calls_table'
+        AND column_name = 'patient_name'
+      )`
+    );
+    expect(patientNameColumnExists).toEqual(true);
+  });
+});

--- a/db/tests/patient_details_migration.migrationTest.js
+++ b/db/tests/patient_details_migration.migrationTest.js
@@ -117,7 +117,7 @@ describe("patient details migration", () => {
     expect(patientDetails).toEqual([
       {
         id: patientDetailsId,
-        patient_name: "Patient Name",
+        patient_name: "incorrect name",
         ward_id: wardId,
       },
     ]);
@@ -225,7 +225,7 @@ describe("patient details migration", () => {
 
     // checking that the visit is there
     expect(visit).toEqual({
-      patient_name: "Another Patient Name",
+      patient_name: "",
       recipient_name: "Another Contact Name",
       recipient_number: "",
       recipient_email: "anothercontact@example.com",

--- a/db/tests/patient_details_migration.migrationTest.js
+++ b/db/tests/patient_details_migration.migrationTest.js
@@ -25,7 +25,7 @@ describe("patient details migration", () => {
     const { wardId } = await setupWardWithinHospitalAndTrust();
     const db = await container.getDb();
 
-    // inserting a visits into the db
+    // inserting visits into the db
     const { id: firstVisitId } = await insertVisit(
       "Patient Name",
       "Contact Name",
@@ -47,7 +47,7 @@ describe("patient details migration", () => {
       date
     );
 
-    // retrieving the visit from the db
+    // retrieving visits from the db
     const visits = await retrieveVisits(wardId, db);
 
     // checking the visits exists before the patient details migration is run
@@ -92,9 +92,9 @@ describe("patient details migration", () => {
     expect(patientDetailsTableExists).toEqual(true);
 
     // checking patient_details_id fields exists on visits table
-    const [{ exists: patientDetailsColumnExists }] = await patientDetailsColumn(
-      db
-    );
+    const [
+      { exists: patientDetailsColumnExists },
+    ] = await patientDetailsIdColumn(db);
     expect(patientDetailsColumnExists).toEqual(true);
 
     // checking patient_name field no longer exist on visits table
@@ -135,7 +135,7 @@ describe("patient details migration", () => {
       wardId,
     });
 
-    // checking first visit is still there
+    // checking first visit
     expect(scheduledCall).toEqual({
       patientName: "Patient Name",
       recipientName: "Contact Name",
@@ -158,7 +158,7 @@ describe("patient details migration", () => {
       wardId,
     });
 
-    // checking second visit is still there
+    // checking second visit
     expect(secondVisit).toEqual({
       patientName: "Alice",
       recipientName: "Bob",
@@ -231,7 +231,7 @@ describe("patient details migration", () => {
       },
     ]);
 
-    // checking patient details for second in new table
+    // checking patient details for second visit in new table
     const [
       { patient_details_id: patientDetailsIdForSecondVisit },
     ] = await retrievePatientDetailsId(secondVisitId, db);
@@ -296,7 +296,7 @@ describe("patient details migration", () => {
 
     const visits = await retrieveVisits(wardId, db);
 
-    // checking that the visit is there
+    // checking visits
     expect(visits).toEqual([
       expect.objectContaining({
         patient_name: "Another Patient Name",
@@ -335,12 +335,12 @@ describe("patient details migration", () => {
     expect(patientDetailsTableExists).toEqual(false);
 
     // checking patient_details_id field does not exist on visits table
-    const [{ exists: patientDetailsColumnExists }] = await patientDetailsColumn(
-      db
-    );
+    const [
+      { exists: patientDetailsColumnExists },
+    ] = await patientDetailsIdColumn(db);
     expect(patientDetailsColumnExists).toEqual(false);
 
-    // check that patient name column exists on the visits table
+    // checking that patient name column exists on the visits table
     const [{ exists: patientNameColumnExists }] = await patientNameColumn(db);
     expect(patientNameColumnExists).toEqual(true);
   });
@@ -389,7 +389,7 @@ const retrieveVisits = async (wardId, db) => {
   );
 };
 
-const patientDetailsColumn = async (db) => {
+const patientDetailsIdColumn = async (db) => {
   return await db.any(
     `SELECT EXISTS
     (

--- a/db/tests/patient_details_migration.migrationTest.js
+++ b/db/tests/patient_details_migration.migrationTest.js
@@ -117,7 +117,7 @@ describe("patient details migration", () => {
     expect(patientDetails).toEqual([
       {
         id: patientDetailsId,
-        patient_name: "incorrect name",
+        patient_name: "Patient Name",
         ward_id: wardId,
       },
     ]);
@@ -225,7 +225,7 @@ describe("patient details migration", () => {
 
     // checking that the visit is there
     expect(visit).toEqual({
-      patient_name: "",
+      patient_name: "Another Patient Name",
       recipient_name: "Another Contact Name",
       recipient_number: "",
       recipient_email: "anothercontact@example.com",

--- a/jest.migrations.config.js
+++ b/jest.migrations.config.js
@@ -1,0 +1,192 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // Respect "browser" field in package.json when resolving modules
+  // browser: false,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/tmp/jest_rs",
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  // coverageDirectory: undefined,
+
+  // An array of regexp pattern strings used to skip coverage collection
+  coveragePathIgnorePatterns: ["/node_modules/", "/db/docker-data"],
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  modulePathIgnorePatterns: ["/db/docker-data"],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  setupFilesAfterEnv: ["<rootDir>/testSetup.js", "<rootDir>/testTeardown.js"],
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  // testEnvironment: "jest-environment-jsdom",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: [
+    "**/__migrationTests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(migrationTest).[tj]s?(x)",
+  ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  testPathIgnorePatterns: ["/node_modules/", "/db/docker-data"],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  testTimeout: 10 * 1000,
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  transform: {
+    "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
+    "^.+\\.(css|styl|less|sass|scss)$":
+      "<rootDir>/node_modules/jest-css-modules-transform",
+  },
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  watchPathIgnorePatterns: ["/db/docker-data"],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:ci": "npm run format:check && npm run test:contract -- --runInBand && npm run test -- --runInBand",
     "test:migrate": "npm run dbmigratetest reset && npm run dbmigratetest up && npm run db:seed",
     "test:e2e2:open": "npm run test:e2e:open",
+    "test:migration": "jest --config ./jest.migrations.config.js",
     "build": "next build",
     "dev": "NODE_ENV=development node server.js",
     "start": "NODE_ENV=production node server.js",

--- a/src/gateways/insertVisit.js
+++ b/src/gateways/insertVisit.js
@@ -1,14 +1,22 @@
 import { SCHEDULED } from "../../src/helpers/visitStatus";
 
 const insertVisit = async (db, visit, wardId) => {
+  const { id: patientDetailsId } = await db.one(
+    `INSERT INTO patient_details
+      (id, patient_name, ward_id)
+      VALUES (default, $1, $2)
+      RETURNING id
+    `,
+    [visit.patientName, wardId]
+  );
+
   const { id, call_id } = await db.one(
     `INSERT INTO scheduled_calls_table
-      (id, patient_name, recipient_email, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password, status)
+      (id, recipient_email, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password, status, patient_details_id)
       VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
       RETURNING id, call_id
     `,
     [
-      visit.patientName,
       visit.contactEmail || "",
       visit.contactNumber || "",
       visit.contactName || "",
@@ -18,6 +26,7 @@ const insertVisit = async (db, visit, wardId) => {
       wardId,
       visit.callPassword,
       SCHEDULED,
+      patientDetailsId,
     ]
   );
 

--- a/src/gateways/insertVisit.test.js
+++ b/src/gateways/insertVisit.test.js
@@ -27,6 +27,10 @@ describe("insertVisit tests", () => {
 
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.patientName,
+      wardId,
+    ]);
+
+    expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.contactEmail,
       request.contactNumber,
       request.contactName,
@@ -36,6 +40,7 @@ describe("insertVisit tests", () => {
       wardId,
       request.callPassword,
       SCHEDULED,
+      10,
     ]);
   });
 });

--- a/src/testUtils/truncateAllTables.js
+++ b/src/testUtils/truncateAllTables.js
@@ -3,6 +3,10 @@ export default async ({ getDb }) => {
   await db.any("DELETE from events");
   await db.any("DELETE from ward_visit_totals");
   await db.any("DELETE from scheduled_calls_table");
+  const [{ exists: patientDetailsTableExists }] = await db.any(`
+    SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'patient_details')
+  `);
+  if (patientDetailsTableExists) await db.any("DELETE from patient_details");
   await db.any("DELETE from wards");
   await db.any("DELETE from hospitals");
   await db.any("DELETE from trusts");

--- a/src/usecases/retrieveVisitByCallId.js
+++ b/src/usecases/retrieveVisitByCallId.js
@@ -6,9 +6,15 @@ const retrieveVisitByCallId = ({ getDb }) => async (callId) => {
   logger.info(`Retrieving visit for ${callId}`);
   try {
     const scheduledCalls = await db.any(
-      `SELECT * FROM scheduled_calls_table
-         WHERE call_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
-         LIMIT 1`,
+      `SELECT *,
+      (
+        SELECT patient_name
+        FROM patient_details
+        WHERE scheduled_calls_table.patient_details_id = id
+      ) as patient_name
+      FROM scheduled_calls_table
+      WHERE call_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
+      LIMIT 1`,
       [callId, SCHEDULED, COMPLETE]
     );
 

--- a/src/usecases/retrieveVisitById.js
+++ b/src/usecases/retrieveVisitById.js
@@ -12,9 +12,15 @@ const retrieveVisitById = ({ getDb }) => async ({ id, wardId }) => {
 
   try {
     const scheduledCall = await db.one(
-      `SELECT * FROM scheduled_calls_table
-         WHERE id = $1 AND ward_id = $2 AND status = ANY(ARRAY[$3,$4]::text[]) AND pii_cleared_at IS NULL
-         LIMIT 1`,
+      `SELECT *,
+      (
+        SELECT patient_name
+        FROM patient_details
+        WHERE scheduled_calls_table.patient_details_id = id
+      ) as patient_name
+      FROM scheduled_calls_table
+      WHERE id = $1 AND ward_id = $2 AND status = ANY(ARRAY[$3,$4]::text[]) AND pii_cleared_at IS NULL
+      LIMIT 1`,
       [id, wardId, SCHEDULED, COMPLETE]
     );
 

--- a/src/usecases/retrieveVisits.js
+++ b/src/usecases/retrieveVisits.js
@@ -4,8 +4,15 @@ import { SCHEDULED, COMPLETE } from "../../src/helpers/visitStatus";
 const retrieveVisits = ({ getDb }) => async ({ wardId }) => {
   const db = await getDb();
   try {
-    let query = `SELECT * FROM scheduled_calls_table
-                 WHERE ward_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
+    let query = `SELECT *,
+                 (
+                   SELECT patient_name
+                   FROM patient_details
+                   WHERE scheduled_calls_table.patient_details_id = id
+                 ) as patient_name
+                 FROM scheduled_calls_table
+                 WHERE scheduled_calls_table.ward_id = $1 AND status = ANY(ARRAY[$2,$3]::text[])
+                 AND pii_cleared_at IS NULL
                  ORDER BY call_time ASC`;
 
     const scheduledCalls = await db.any(query, [wardId, SCHEDULED, COMPLETE]);

--- a/src/usecases/retrieveVisits.test.js
+++ b/src/usecases/retrieveVisits.test.js
@@ -86,12 +86,11 @@ describe("retrieveVisits", () => {
       wardId: 1,
     });
 
-    expect(anySpy).toHaveBeenCalledWith(
-      `SELECT * FROM scheduled_calls_table
-                 WHERE ward_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
-                 ORDER BY call_time ASC`,
-      [1, "scheduled", "complete"]
-    );
+    expect(anySpy).toHaveBeenCalledWith(expect.anything(), [
+      1,
+      "scheduled",
+      "complete",
+    ]);
   });
 
   it("returns an error object on db exception", async () => {

--- a/src/usecases/updateVisitById.js
+++ b/src/usecases/updateVisitById.js
@@ -10,28 +10,30 @@ const updateVisitById = ({ getDb }) => async ({
   try {
     const updatedVisit = await db.one(
       `UPDATE scheduled_calls_table
-      SET patient_name = $1,
-          recipient_name = $2,
-          recipient_email = $3,
-          recipient_number = $4,
-          call_time = $5
+      SET recipient_name = $1,
+          recipient_email = $2,
+          recipient_number = $3,
+          call_time = $4
       WHERE
-          id = $6
+          id = $5
       RETURNING *`,
-      [
-        patientName,
-        recipientName,
-        recipientEmail,
-        recipientNumber,
-        callTime,
-        id,
-      ]
+      [recipientName, recipientEmail, recipientNumber, callTime, id]
+    );
+
+    const updatedPatientDetails = await db.one(
+      `
+        UPDATE patient_details
+        SET patient_name = $1
+        WHERE id = $2
+        RETURNING *
+      `,
+      [patientName, updatedVisit.patient_details_id]
     );
 
     return {
       visit: {
         id: updatedVisit.id,
-        patientName: updatedVisit.patient_name,
+        patientName: updatedPatientDetails.patient_name,
         recipientName: updatedVisit.recipient_name,
         recipientNumber: updatedVisit.recipient_number,
         recipientEmail: updatedVisit.recipient_email,


### PR DESCRIPTION
# What
Create a new table for patient details (`patient_details`) and migrate the the patient data from the `scheduled_calls_table`
to the new `patient_details` table. The `scheduled_calls_table` references the corresponding entry in the patient_details table via a foreign key to the `id` column of `patient_details`.

# Why
The visits (`scheduled_calls_table`) table needs to be anonymous for the upcoming user journey tracking work.

# Notes
As this db migration involved migration of data, migration tests have been added to check the data is moved across correctly. These tests run in their own job in the CI pipeline.
