### PR TITLE
Migrate visitor details to new table

### DIFF
--- a/db/migrations/20201105091527-move-visitor-details-to-new-table.js
+++ b/db/migrations/20201105091527-move-visitor-details-to-new-table.js
@@ -1,0 +1,55 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var fs = require("fs");
+var path = require("path");
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20201105091527-move-visitor-details-to-new-table-up.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    "sqls",
+    "20201105091527-move-visitor-details-to-new-table-down.sql"
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/sqls/20201105091527-move-visitor-details-to-new-table-down.sql
+++ b/db/migrations/sqls/20201105091527-move-visitor-details-to-new-table-down.sql
@@ -1,0 +1,12 @@
+ALTER TABLE scheduled_calls_table ADD recipient_name varchar(255);
+ALTER TABLE scheduled_calls_table ADD recipient_email varchar(255);
+ALTER TABLE scheduled_calls_table ADD recipient_number varchar(255);
+
+UPDATE scheduled_calls_table
+SET recipient_name = visitor_details.recipient_name, recipient_email = visitor_details.recipient_email, recipient_number = visitor_details.recipient_number
+FROM visitor_details
+WHERE scheduled_calls_table.visitor_details_id = visitor_details.id;
+
+ALTER TABLE scheduled_calls_table DROP column visitor_details_id;
+
+DROP TABLE visitor_details;

--- a/db/migrations/sqls/20201105091527-move-visitor-details-to-new-table-up.sql
+++ b/db/migrations/sqls/20201105091527-move-visitor-details-to-new-table-up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE visitor_details (
+    id serial PRIMARY KEY,
+    recipient_name varchar(255) NOT NULL,
+    recipient_email varchar(255),
+    recipient_number varchar(255),
+    ward_id integer NOT NULL REFERENCES wards (id),
+    visit_id integer NOT NULL REFERENCES scheduled_calls_table (id)
+);
+
+INSERT INTO visitor_details (recipient_name, recipient_email, recipient_number, ward_id, visit_id) SELECT recipient_name, recipient_email, recipient_number, ward_id, id FROM scheduled_calls_table;
+
+ALTER TABLE scheduled_calls_table ADD visitor_details_id integer REFERENCES visitor_details (id);
+
+UPDATE scheduled_calls_table
+SET visitor_details_id = visitor_details.id
+FROM visitor_details
+WHERE scheduled_calls_table.id = visitor_details.visit_id;
+
+ALTER TABLE visitor_details DROP COLUMN visit_id;
+ALTER TABLE scheduled_calls_table DROP COLUMN recipient_name;
+ALTER TABLE scheduled_calls_table DROP COLUMN recipient_email;
+ALTER TABLE scheduled_calls_table DROP COLUMN recipient_number;

--- a/db/scripts/seed_database.js
+++ b/db/scripts/seed_database.js
@@ -45,17 +45,31 @@ async function seedDatabase() {
     [wardId]
   );
 
+  const {
+    id: visitorDetailsId,
+  } = await db.one(
+    "INSERT INTO visitor_details (recipient_name, recipient_email, ward_id) VALUES ('Bob', 'bob@example.com', $1) RETURNING id",
+    [wardId]
+  );
+
+  const {
+    id: secondVisitorDetailsId,
+  } = await db.one(
+    "INSERT INTO visitor_details (recipient_name, recipient_email, ward_id) VALUES ('Darlene', 'darlene@example.com', $1) RETURNING id",
+    [wardId]
+  );
+
   await db.result(
     `INSERT INTO scheduled_calls_table
-    (recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status, patient_details_id)
-    VALUES ('bob@example.com', 'Bob', CURRENT_TIMESTAMP + interval '1 hour', '123', 'whereby', $1, 'password', 'scheduled', $2)`,
-    [wardId, patientDetailsId]
+    (call_time, call_id, provider, ward_id, call_password, status, patient_details_id, visitor_details_id)
+    VALUES (CURRENT_TIMESTAMP + interval '1 hour', '123', 'whereby', $1, 'password', 'scheduled', $2, $3)`,
+    [wardId, patientDetailsId, visitorDetailsId]
   );
   await db.result(
     `INSERT INTO scheduled_calls_table
-    (recipient_email, recipient_name, call_time, call_id, provider, ward_id, call_password, status, patient_details_id)
-    VALUES ('darlene@example.com', 'Darlene', CURRENT_TIMESTAMP + interval '1 hour', '456', 'whereby', $1, 'password', 'scheduled', $2)`,
-    [wardId, secondPatientDetailsId]
+    (call_time, call_id, provider, ward_id, call_password, status, patient_details_id, visitor_details_id)
+    VALUES (CURRENT_TIMESTAMP + interval '1 hour', '456', 'whereby', $1, 'password', 'scheduled', $2, $3)`,
+    [wardId, secondPatientDetailsId, secondVisitorDetailsId]
   );
   db.$pool.end();
 }

--- a/db/tests/patient_details_migration.migrationTest.js
+++ b/db/tests/patient_details_migration.migrationTest.js
@@ -13,14 +13,10 @@ describe("patient details migration", () => {
   });
 
   it("migrates the patient details data from the visits table to the patient_details table", async () => {
-    const downAllMigrations = execSync("npm run dbmigratetest reset");
-    console.log(downAllMigrations.toString());
+    execSync("npm run dbmigratetest reset");
 
     // run all migrations up until 24/07/2020 (which is just before the patient details migration)
-    const runMigrationsToBeforePatientDetailsMigration = execSync(
-      "npm run dbmigratetest up 20200724000000"
-    );
-    console.log(runMigrationsToBeforePatientDetailsMigration.toString());
+    execSync("npm run dbmigratetest up 20200724000000");
 
     const { wardId } = await setupWardWithinHospitalAndTrust();
     const db = await container.getDb();
@@ -175,14 +171,10 @@ describe("patient details migration", () => {
   });
 
   it("migrates the patient details data from the patient_details table to the visits table on the down migration", async () => {
-    const downAllMigrations = execSync("npm run dbmigratetest reset");
-    console.log(downAllMigrations.toString());
+    execSync("npm run dbmigratetest reset");
 
     // run all migrations up until 06/11/2020 (just after the visitor details migration)
-    const runMigrationsToJustAfterPatientDetailsMigration = execSync(
-      "npm run dbmigratetest up 20201106000000"
-    );
-    console.log(runMigrationsToJustAfterPatientDetailsMigration.toString());
+    execSync("npm run dbmigratetest up 20201106000000");
 
     const { wardId } = await setupWardWithinHospitalAndTrust();
     const db = await container.getDb();

--- a/db/tests/visitor_details_migration.migrationTest.js
+++ b/db/tests/visitor_details_migration.migrationTest.js
@@ -13,14 +13,10 @@ describe("visitor details migration", () => {
   });
 
   it("migrates the visitor details data from the visits table to the visitor_details table", async () => {
-    const downAllMigrations = execSync("npm run dbmigratetest reset");
-    console.log(downAllMigrations.toString());
+    execSync("npm run dbmigratetest reset");
 
     // run all migrations up until 31/10/2020 (which is just before the visitor details migration)
-    const runMigrationsToBeforeVisitorDetailsMigration = execSync(
-      "npm run dbmigratetest up 20201031000000"
-    );
-    console.log(runMigrationsToBeforeVisitorDetailsMigration.toString());
+    execSync("npm run dbmigratetest up 20201031000000");
 
     const { wardId } = await setupWardWithinHospitalAndTrust();
     const db = await container.getDb();
@@ -55,7 +51,7 @@ describe("visitor details migration", () => {
     // retrieving visits from the db
     const visits = await retrieveVisits(wardId, db);
 
-    // checking the visits exists before the visitor details migration is run
+    // checking the visits exist
     expect(visits).toEqual([
       expect.objectContaining({
         patient_details_id: patientDetailsId,
@@ -102,9 +98,15 @@ describe("visitor details migration", () => {
     ] = await visitorDetailsIdColumn(db);
     expect(visitorDetailsColumnExists).toEqual(true);
 
-    // checking recipient_name field no longer exist on visits table NEED TO CHECK OTHER 2 FIELDS TOO
+    // checking visitor fields no longer exist on visits table
     const [{ exists: visitorNameColumnExists }] = await visitorNameColumn(db);
+    const [{ exists: visitorEmailColumnExists }] = await visitorEmailColumn(db);
+    const [{ exists: visitorNumberColumnExists }] = await visitorNumberColumn(
+      db
+    );
     expect(visitorNameColumnExists).toEqual(false);
+    expect(visitorEmailColumnExists).toEqual(false);
+    expect(visitorNumberColumnExists).toEqual(false);
 
     // checking visitor details in new table
     const [
@@ -184,14 +186,10 @@ describe("visitor details migration", () => {
   });
 
   it("migrates the visitor details data from the visitor_details table to the visits table on the down migration", async () => {
-    const downAllMigrations = execSync("npm run dbmigratetest reset");
-    console.log(downAllMigrations.toString());
+    execSync("npm run dbmigratetest reset");
 
     // run all migrations up until 06/11/2020 (just after the visitor details migration)
-    const runMigrationsToJustAfterVisitorDetailsMigration = execSync(
-      "npm run dbmigratetest up 20201106000000"
-    );
-    console.log(runMigrationsToJustAfterVisitorDetailsMigration.toString());
+    execSync("npm run dbmigratetest up 20201106000000");
 
     const { wardId } = await setupWardWithinHospitalAndTrust();
     const db = await container.getDb();
@@ -306,7 +304,7 @@ describe("visitor details migration", () => {
     });
     expect(errorForSecondVisit).toBeNull();
 
-    // rolling back the patient details migration
+    // rolling back the visitor details migration
     execSync("npm run dbmigratetest down");
 
     const visits = await retrieveVisits(wardId, db);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:ci": "npm run format:check && npm run test:contract -- --runInBand && npm run test -- --runInBand",
     "test:migrate": "npm run dbmigratetest reset && npm run dbmigratetest up && npm run db:seed",
     "test:e2e2:open": "npm run test:e2e:open",
-    "test:migration": "jest --config ./jest.migrations.config.js",
+    "test:migration": "jest --config ./jest.migrations.config.js --runInBand",
     "build": "next build",
     "dev": "NODE_ENV=development node server.js",
     "start": "NODE_ENV=production node server.js",

--- a/src/gateways/insertVisit.contractTest.js
+++ b/src/gateways/insertVisit.contractTest.js
@@ -14,7 +14,7 @@ describe("insertVisit contract tests", () => {
 
     const visit = {
       patientName: "Patient Test",
-      contactEmail: "test@testemail.com",
+      contactEmail: "test1@testemail.com",
       contactName: "Contact Test",
       contactNumber: "07123456789",
       callTime: new Date(),
@@ -26,9 +26,9 @@ describe("insertVisit contract tests", () => {
 
     const anotherVisit = {
       patientName: "Test Patient",
-      contactEmail: "test@testemail.com",
+      contactEmail: "test2@testemail.com",
       contactName: "Test Contact",
-      contactNumber: "07123456789",
+      contactNumber: "07123456788",
       callTime: new Date(),
       callId: "456",
       provider: "jitsi",
@@ -38,8 +38,18 @@ describe("insertVisit contract tests", () => {
 
     const { scheduledCalls } = await container.getRetrieveVisits()({ wardId });
     expect(scheduledCalls).toEqual([
-      expect.objectContaining({ patientName: "Patient Test" }),
-      expect.objectContaining({ patientName: "Test Patient" }),
+      expect.objectContaining({
+        patientName: "Patient Test",
+        recipientName: "Contact Test",
+        recipientEmail: "test1@testemail.com",
+        recipientNumber: "07123456789",
+      }),
+      expect.objectContaining({
+        patientName: "Test Patient",
+        recipientName: "Test Contact",
+        recipientEmail: "test2@testemail.com",
+        recipientNumber: "07123456788",
+      }),
     ]);
   });
 });

--- a/src/gateways/insertVisit.js
+++ b/src/gateways/insertVisit.js
@@ -19,7 +19,7 @@ const insertVisit = async (db, visit, wardId) => {
     [visit.contactName, visit.contactEmail, visit.contactNumber, wardId]
   );
 
-  const { id, call_id } = await db.one(
+  const { id } = await db.one(
     `INSERT INTO scheduled_calls_table
       (id, call_time, call_id, provider, ward_id, call_password, status, patient_details_id, visitor_details_id)
       VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8)
@@ -37,7 +37,7 @@ const insertVisit = async (db, visit, wardId) => {
     ]
   );
 
-  return { id, callId: call_id };
+  return { id };
 };
 
 export default insertVisit;

--- a/src/gateways/insertVisit.js
+++ b/src/gateways/insertVisit.js
@@ -10,16 +10,22 @@ const insertVisit = async (db, visit, wardId) => {
     [visit.patientName, wardId]
   );
 
+  const { id: visitorDetailsId } = await db.one(
+    `INSERT INTO visitor_details
+      (id, recipient_name, recipient_email, recipient_number, ward_id)
+      VALUES (default, $1, $2, $3, $4)
+      RETURNING id
+    `,
+    [visit.contactName, visit.contactEmail, visit.contactNumber, wardId]
+  );
+
   const { id, call_id } = await db.one(
     `INSERT INTO scheduled_calls_table
-      (id, recipient_email, recipient_number, recipient_name, call_time, call_id, provider, ward_id, call_password, status, patient_details_id)
-      VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      (id, call_time, call_id, provider, ward_id, call_password, status, patient_details_id, visitor_details_id)
+      VALUES (default, $1, $2, $3, $4, $5, $6, $7, $8)
       RETURNING id, call_id
     `,
     [
-      visit.contactEmail || "",
-      visit.contactNumber || "",
-      visit.contactName || "",
       visit.callTime,
       visit.callId,
       visit.provider,
@@ -27,6 +33,7 @@ const insertVisit = async (db, visit, wardId) => {
       visit.callPassword,
       SCHEDULED,
       patientDetailsId,
+      visitorDetailsId,
     ]
   );
 

--- a/src/gateways/insertVisit.test.js
+++ b/src/gateways/insertVisit.test.js
@@ -3,7 +3,10 @@ import { SCHEDULED } from "../helpers/visitStatus";
 
 describe("insertVisit tests", () => {
   it("creates a visit in the db when valid", async () => {
-    const oneSpy = jest.fn().mockResolvedValue({ id: 10, call_id: "12345" });
+    const oneSpy = jest.fn();
+    oneSpy.mockResolvedValueOnce({ id: 10 });
+    oneSpy.mockResolvedValueOnce({ id: 8 });
+    oneSpy.mockResolvedValue({ id: 6, call_id: "12345" });
     const db = {
       one: oneSpy,
     };
@@ -22,7 +25,7 @@ describe("insertVisit tests", () => {
     const wardId = "wardId";
     const { id, callId } = await insertVisit(db, request, wardId);
 
-    expect(id).toEqual(10);
+    expect(id).toEqual(6);
     expect(callId).toEqual("12345");
 
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
@@ -31,9 +34,13 @@ describe("insertVisit tests", () => {
     ]);
 
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
+      request.contactName,
       request.contactEmail,
       request.contactNumber,
-      request.contactName,
+      wardId,
+    ]);
+
+    expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.callTime,
       request.callId,
       request.provider,
@@ -41,6 +48,7 @@ describe("insertVisit tests", () => {
       request.callPassword,
       SCHEDULED,
       10,
+      8,
     ]);
   });
 });

--- a/src/gateways/insertVisit.test.js
+++ b/src/gateways/insertVisit.test.js
@@ -23,11 +23,9 @@ describe("insertVisit tests", () => {
       callPassword: "securePassword",
     };
     const wardId = "wardId";
-    const { id, callId } = await insertVisit(db, request, wardId);
+    const { id } = await insertVisit(db, request, wardId);
 
     expect(id).toEqual(6);
-    expect(callId).toEqual("12345");
-
     expect(oneSpy).toHaveBeenCalledWith(expect.anything(), [
       request.patientName,
       wardId,

--- a/src/testUtils/truncateAllTables.js
+++ b/src/testUtils/truncateAllTables.js
@@ -3,10 +3,17 @@ export default async ({ getDb }) => {
   await db.any("DELETE from events");
   await db.any("DELETE from ward_visit_totals");
   await db.any("DELETE from scheduled_calls_table");
+
   const [{ exists: patientDetailsTableExists }] = await db.any(`
     SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'patient_details')
   `);
   if (patientDetailsTableExists) await db.any("DELETE from patient_details");
+
+  const [{ exists: visitorDetailsTableExists }] = await db.any(`
+    SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'visitor_details')
+  `);
+  if (visitorDetailsTableExists) await db.any("DELETE from visitor_details");
+
   await db.any("DELETE from wards");
   await db.any("DELETE from hospitals");
   await db.any("DELETE from trusts");

--- a/src/usecases/deleteVisitByCallId.contractTest.js
+++ b/src/usecases/deleteVisitByCallId.contractTest.js
@@ -9,7 +9,7 @@ describe("deleteVisitByCallId contract tests", () => {
     const { trustId } = await setupTrust();
     const { wardId } = await setupWard({ trustId: trustId });
 
-    const { callId } = await setupVisit({ wardId });
+    await setupVisit({ wardId, callId: "CALLID" });
     await setupVisit({
       wardId,
       patientName: "Test patient",
@@ -22,7 +22,7 @@ describe("deleteVisitByCallId contract tests", () => {
       expect.objectContaining({ patientName: "Test patient" }),
     ]);
 
-    await container.getDeleteVisitByCallId()(callId);
+    await container.getDeleteVisitByCallId()("CALLID");
 
     const {
       scheduledCalls: scheduledCallsAfterDelete,

--- a/src/usecases/retrieveVisitByCallId.js
+++ b/src/usecases/retrieveVisitByCallId.js
@@ -11,7 +11,22 @@ const retrieveVisitByCallId = ({ getDb }) => async (callId) => {
         SELECT patient_name
         FROM patient_details
         WHERE scheduled_calls_table.patient_details_id = id
-      ) as patient_name
+      ) as patient_name,
+      (
+        SELECT recipient_name
+        FROM visitor_details
+        WHERE scheduled_calls_table.visitor_details_id = id
+      ),
+      (
+        SELECT recipient_email
+        FROM visitor_details
+        WHERE scheduled_calls_table.visitor_details_id = id
+      ),
+      (
+        SELECT recipient_number
+        FROM visitor_details
+        WHERE scheduled_calls_table.visitor_details_id = id
+      ) as recipient_number
       FROM scheduled_calls_table
       WHERE call_id = $1 AND status = ANY(ARRAY[$2,$3]::text[]) AND pii_cleared_at IS NULL
       LIMIT 1`,

--- a/src/usecases/retrieveVisitById.contractTest.js
+++ b/src/usecases/retrieveVisitById.contractTest.js
@@ -21,7 +21,7 @@ describe("retrieveVisitById contract tests", () => {
     expect(scheduledCall).toEqual({
       patientName: "Patient Name",
       recipientName: "Contact Name",
-      recipientNumber: "",
+      recipientNumber: null,
       recipientEmail: "contact@example.com",
       callTime: new Date("2020-06-01 13:00"),
       callId: "TESTCALLID",

--- a/src/usecases/retrieveVisitById.js
+++ b/src/usecases/retrieveVisitById.js
@@ -17,7 +17,22 @@ const retrieveVisitById = ({ getDb }) => async ({ id, wardId }) => {
         SELECT patient_name
         FROM patient_details
         WHERE scheduled_calls_table.patient_details_id = id
-      ) as patient_name
+      ) as patient_name,
+      (
+        SELECT recipient_name
+        FROM visitor_details
+        WHERE scheduled_calls_table.visitor_details_id = id
+      ),
+      (
+        SELECT recipient_email
+        FROM visitor_details
+        WHERE scheduled_calls_table.visitor_details_id = id
+      ),
+      (
+        SELECT recipient_number
+        FROM visitor_details
+        WHERE scheduled_calls_table.visitor_details_id = id
+      ) as recipient_number
       FROM scheduled_calls_table
       WHERE id = $1 AND ward_id = $2 AND status = ANY(ARRAY[$3,$4]::text[]) AND pii_cleared_at IS NULL
       LIMIT 1`,

--- a/src/usecases/retrieveVisits.contractTest.js
+++ b/src/usecases/retrieveVisits.contractTest.js
@@ -62,7 +62,7 @@ describe("retrieveVisits contract tests", () => {
     );
 
     // Cancelled visits are not returned
-    const visitToBeCancelled = await container.getInsertVisitGateway()(
+    await container.getInsertVisitGateway()(
       db,
       {
         provider: "test",
@@ -76,7 +76,7 @@ describe("retrieveVisits contract tests", () => {
       wardId
     );
 
-    await deleteVisitByCallId(container)(visitToBeCancelled.callId);
+    await deleteVisitByCallId(container)("cancelledVisit");
 
     // Visits from other wards are not returned
     await container.getInsertVisitGateway()(

--- a/src/usecases/retrieveVisits.js
+++ b/src/usecases/retrieveVisits.js
@@ -9,7 +9,22 @@ const retrieveVisits = ({ getDb }) => async ({ wardId }) => {
                    SELECT patient_name
                    FROM patient_details
                    WHERE scheduled_calls_table.patient_details_id = id
-                 ) as patient_name
+                 ),
+                 (
+                  SELECT recipient_name
+                  FROM visitor_details
+                  WHERE scheduled_calls_table.visitor_details_id = id
+                 ),
+                 (
+                  SELECT recipient_email
+                  FROM visitor_details
+                  WHERE scheduled_calls_table.visitor_details_id = id
+                 ),
+                 (
+                  SELECT recipient_number
+                  FROM visitor_details
+                  WHERE scheduled_calls_table.visitor_details_id = id
+                 ) as recipient_number
                  FROM scheduled_calls_table
                  WHERE scheduled_calls_table.ward_id = $1 AND status = ANY(ARRAY[$2,$3]::text[])
                  AND pii_cleared_at IS NULL

--- a/src/usecases/updateVisitById.contractTest.js
+++ b/src/usecases/updateVisitById.contractTest.js
@@ -11,7 +11,7 @@ describe("updateVisitById contract tests", () => {
     const { wardId } = await setupWardWithinHospitalAndTrust();
     const { id } = await setupVisit({ wardId });
 
-    const { visit, error } = await container.getUpdateVisitById()({
+    await container.getUpdateVisitById()({
       id,
       patientName: "Aang",
       recipientName: "Katara",
@@ -20,11 +20,16 @@ describe("updateVisitById contract tests", () => {
       callTime: new Date("2020-08-01 18:00"),
     });
 
-    expect(visit.patientName).toEqual("Aang");
-    expect(visit.recipientName).toEqual("Katara");
-    expect(visit.recipientEmail).toEqual("katara@example.com");
-    expect(visit.recipientNumber).toEqual("07123456789");
-    expect(visit.callTime).toEqual(new Date("2020-08-01 18:00"));
+    const { scheduledCall, error } = await container.getRetrieveVisitById()({
+      id,
+      wardId,
+    });
+
+    expect(scheduledCall.patientName).toEqual("Aang");
+    expect(scheduledCall.recipientName).toEqual("Katara");
+    expect(scheduledCall.recipientEmail).toEqual("katara@example.com");
+    expect(scheduledCall.recipientNumber).toEqual("07123456789");
+    expect(scheduledCall.callTime).toEqual(new Date("2020-08-01 18:00"));
     expect(error).toBeNull();
   });
 

--- a/src/usecases/updateVisitById.js
+++ b/src/usecases/updateVisitById.js
@@ -10,14 +10,11 @@ const updateVisitById = ({ getDb }) => async ({
   try {
     const updatedVisit = await db.one(
       `UPDATE scheduled_calls_table
-      SET recipient_name = $1,
-          recipient_email = $2,
-          recipient_number = $3,
-          call_time = $4
+      SET call_time = $1
       WHERE
-          id = $5
+          id = $2
       RETURNING *`,
-      [recipientName, recipientEmail, recipientNumber, callTime, id]
+      [callTime, id]
     );
 
     const updatedPatientDetails = await db.one(
@@ -30,13 +27,30 @@ const updateVisitById = ({ getDb }) => async ({
       [patientName, updatedVisit.patient_details_id]
     );
 
+    const updatedVisitorDetails = await db.one(
+      `
+        UPDATE visitor_details
+        SET recipient_name = $1,
+            recipient_email = $2,
+            recipient_number = $3
+        WHERE id = $4
+        RETURNING *
+      `,
+      [
+        recipientName,
+        recipientEmail,
+        recipientNumber,
+        updatedVisit.visitor_details_id,
+      ]
+    );
+
     return {
       visit: {
         id: updatedVisit.id,
         patientName: updatedPatientDetails.patient_name,
-        recipientName: updatedVisit.recipient_name,
-        recipientNumber: updatedVisit.recipient_number,
-        recipientEmail: updatedVisit.recipient_email,
+        recipientName: updatedVisitorDetails.recipient_name,
+        recipientNumber: updatedVisitorDetails.recipient_number,
+        recipientEmail: updatedVisitorDetails.recipient_email,
         callTime: updatedVisit.call_time,
         callId: updatedVisit.call_id,
       },


### PR DESCRIPTION
# What

Create a new table for visitor details (visitor_details) and migrate the the visitor data from the scheduled_calls_table
to the new visitor_details table. The scheduled_calls_table references the corresponding entry in the visitor_details table via a foreign key to the id column of visitor_details.

# Why
The visits (scheduled_calls_table) table needs to be anonymous for the upcoming user journey tracking work.

# Notes
As this db migration involved migration of data, migration tests have been added to check the data is moved across correctly. These tests run in their own job in the CI pipeline (added as part of #650).
