### PR TITLE
Vv 74 trust manager flow standardise headers

### DIFF
--- a/cypress/integration/trust-admin/addingandEditingAHospital.js
+++ b/cypress/integration/trust-admin/addingandEditingAHospital.js
@@ -97,7 +97,7 @@ describe("As a trust admin, I want to add a hospital so that I can manage virtua
   }
 
   function ThenISeeTheAddAHospitalForm() {
-    cy.get("h1").should("contain", "Add a hospital");
+    cy.get("h2").should("contain", "Add a hospital");
   }
 
   function WhenIFillOutTheForm(name) {

--- a/cypress/integration/trust-admin/loggingInAndOut.js
+++ b/cypress/integration/trust-admin/loggingInAndOut.js
@@ -78,7 +78,7 @@ describe("As a trust admin, I want to log in so that I can access the service.",
   }
 
   function ThenISeeTheTrustAdminLogInPage() {
-    cy.get("h1").should("contain", "Log in to manage your trust");
+    cy.get("h1.nhsuk-heading-xl").contains("Log in to manage your trust");
   }
 
   // Displays an error for an invalid code

--- a/cypress/integration/trust-admin/trustAdminCommonSteps.js
+++ b/cypress/integration/trust-admin/trustAdminCommonSteps.js
@@ -42,7 +42,7 @@ function AndISubmitTheAddWardForm() {
 }
 
 function ThenISeeTheAddAWardForm() {
-  cy.get("h1").should("contain", "Add a ward");
+  cy.get("h2").should("contain", "Add a ward");
 }
 
 function WhenIClickToEditAWard(name) {

--- a/cypress/integration/trust-admin/trustAdminCommonSteps.js
+++ b/cypress/integration/trust-admin/trustAdminCommonSteps.js
@@ -50,7 +50,7 @@ function WhenIClickToEditAWard(name) {
 }
 
 function ThenISeeTheEditAWardForm() {
-  cy.get("h1").should("contain", "Edit a ward");
+  cy.get("h2").should("contain", "Edit a ward");
 }
 
 function AndISubmitTheEditWardForm() {

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -4,7 +4,7 @@ import Router from "next/router";
 import propsWithContainer from "../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../src/usecases/verifyTrustAdminToken";
 import Button from "../../../src/components/Button";
-import Heading from "../../../src/components/Heading";
+import TrustAdminHeading from "../../../src/components/TrustAdminHeading";
 import { GridRow, GridColumn } from "../../../src/components/Grid";
 import Layout from "../../../src/components/Layout";
 import WardsTable from "../../../src/components/WardsTable";
@@ -33,15 +33,10 @@ const ShowHospital = ({
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading={hospital.name} />
+
       <GridRow>
         <GridColumn width="full">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            {hospital.name}
-          </Heading>
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
               className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"

--- a/pages/trust-admin/hospitals/[id].js
+++ b/pages/trust-admin/hospitals/[id].js
@@ -14,6 +14,7 @@ import HospitalSummaryList from "../../../src/components/HospitalSummaryList";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
 
 const ShowHospital = ({
+  trust,
   hospital,
   wards,
   error,
@@ -34,7 +35,13 @@ const ShowHospital = ({
     >
       <GridRow>
         <GridColumn width="full">
-          <Heading>{hospital.name}</Heading>
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            {hospital.name}
+          </Heading>
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
               className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"
@@ -108,6 +115,10 @@ export const getServerSideProps = propsWithContainer(
     const { id: hospitalId } = query;
     const trustId = authenticationToken.trustId;
 
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
+
     const {
       hospital,
       error: hospitalError,
@@ -134,6 +145,7 @@ export const getServerSideProps = propsWithContainer(
 
     return {
       props: {
+        trust: { name: trustResponse.trust?.name },
         hospital,
         wards,
         error: hospitalError || wardsError,

--- a/pages/trust-admin/hospitals/[id]/add-success.js
+++ b/pages/trust-admin/hospitals/[id]/add-success.js
@@ -6,8 +6,10 @@ import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../../../src/components/ActionLink";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
+import { GridRow, GridColumn } from "../../../../src/components/Grid";
+import Heading from "../../../../src/components/Heading";
 
-const AddAHospitalSuccess = ({ error, name, id }) => {
+const AddAHospitalSuccess = ({ trust, error, name, id }) => {
   if (error) {
     return <Error />;
   }
@@ -18,6 +20,17 @@ const AddAHospitalSuccess = ({ error, name, id }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            Hospitals
+          </Heading>
+        </GridColumn>
+      </GridRow>
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div
@@ -45,6 +58,10 @@ const AddAHospitalSuccess = ({ error, name, id }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ container, query, authenticationToken }) => {
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
+
     const getRetrieveHospitalById = container.getRetrieveHospitalById();
     const { hospital, error } = await getRetrieveHospitalById(
       query.id,
@@ -59,6 +76,7 @@ export const getServerSideProps = propsWithContainer(
           error: error,
           name: hospital.name,
           id: hospital.id,
+          trust: { name: trustResponse.trust?.name },
         },
       };
     }

--- a/pages/trust-admin/hospitals/[id]/add-success.js
+++ b/pages/trust-admin/hospitals/[id]/add-success.js
@@ -6,8 +6,7 @@ import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../../../src/components/ActionLink";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
-import { GridRow, GridColumn } from "../../../../src/components/Grid";
-import Heading from "../../../../src/components/Heading";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
 
 const AddAHospitalSuccess = ({ trust, error, name, id }) => {
   if (error) {
@@ -20,17 +19,8 @@ const AddAHospitalSuccess = ({ trust, error, name, id }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
-      <GridRow>
-        <GridColumn width="two-thirds">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            Hospitals
-          </Heading>
-        </GridColumn>
-      </GridRow>
+      <TrustAdminHeading trustName={trust.name} subHeading="Hospitals" />
+
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div

--- a/pages/trust-admin/hospitals/[id]/edit-success.js
+++ b/pages/trust-admin/hospitals/[id]/edit-success.js
@@ -6,8 +6,10 @@ import AnchorLink from "../../../../src/components/AnchorLink";
 import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToken";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
+import { GridRow, GridColumn } from "../../../../src/components/Grid";
+import Heading from "../../../../src/components/Heading";
 
-const EditAHospitalSuccess = ({ error, hospitalName, hospitalId }) => {
+const EditAHospitalSuccess = ({ trust, error, hospitalName, hospitalId }) => {
   if (error) {
     return <Error />;
   }
@@ -18,6 +20,17 @@ const EditAHospitalSuccess = ({ error, hospitalName, hospitalId }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <GridRow>
+        <GridColumn width="two-thirds">
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            Hospitals
+          </Heading>
+        </GridColumn>
+      </GridRow>
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div
@@ -45,6 +58,10 @@ const EditAHospitalSuccess = ({ error, hospitalName, hospitalId }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ container, query, authenticationToken }) => {
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
+
     const getRetrieveHospitalById = container.getRetrieveHospitalById();
     const { hospital, error } = await getRetrieveHospitalById(
       query.id,
@@ -56,6 +73,7 @@ export const getServerSideProps = propsWithContainer(
         error: error,
         hospitalName: hospital.name,
         hospitalId: hospital.id,
+        trust: { name: trustResponse.trust?.name },
       },
     };
   })

--- a/pages/trust-admin/hospitals/[id]/edit-success.js
+++ b/pages/trust-admin/hospitals/[id]/edit-success.js
@@ -6,8 +6,7 @@ import AnchorLink from "../../../../src/components/AnchorLink";
 import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToken";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
-import { GridRow, GridColumn } from "../../../../src/components/Grid";
-import Heading from "../../../../src/components/Heading";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
 
 const EditAHospitalSuccess = ({ trust, error, hospitalName, hospitalId }) => {
   if (error) {
@@ -20,17 +19,8 @@ const EditAHospitalSuccess = ({ trust, error, hospitalName, hospitalId }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
-      <GridRow>
-        <GridColumn width="two-thirds">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            Hospitals
-          </Heading>
-        </GridColumn>
-      </GridRow>
+      <TrustAdminHeading trustName={trust.name} subHeading="Hospitals" />
+
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div

--- a/pages/trust-admin/hospitals/[id]/edit.js
+++ b/pages/trust-admin/hospitals/[id]/edit.js
@@ -8,7 +8,7 @@ import Layout from "../../../../src/components/Layout";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
 import EditHospitalForm from "../../../../src/components/EditHospitalForm";
 import ErrorSummary from "../../../../src/components/ErrorSummary";
-import Heading from "../../../../src/components/Heading";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
 
 const EditHospital = ({ trust, hospital, error }) => {
   if (error) {
@@ -60,15 +60,10 @@ const EditHospital = ({ trust, hospital, error }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading="Hospitals" />
+
       <GridRow>
         <GridColumn width="two-thirds">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            Hospitals
-          </Heading>
           <ErrorSummary errors={errors} />
           <EditHospitalForm
             errors={errors}

--- a/pages/trust-admin/hospitals/[id]/edit.js
+++ b/pages/trust-admin/hospitals/[id]/edit.js
@@ -8,8 +8,9 @@ import Layout from "../../../../src/components/Layout";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
 import EditHospitalForm from "../../../../src/components/EditHospitalForm";
 import ErrorSummary from "../../../../src/components/ErrorSummary";
+import Heading from "../../../../src/components/Heading";
 
-const EditHospital = ({ hospital, error }) => {
+const EditHospital = ({ trust, hospital, error }) => {
   if (error) {
     return <Error err={error} />;
   }
@@ -61,6 +62,13 @@ const EditHospital = ({ hospital, error }) => {
     >
       <GridRow>
         <GridColumn width="two-thirds">
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            Hospitals
+          </Heading>
           <ErrorSummary errors={errors} />
           <EditHospitalForm
             errors={errors}
@@ -78,7 +86,9 @@ export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ authenticationToken, container, query }) => {
     const { id: hospitalId } = query;
     const trustId = authenticationToken.trustId;
-
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
     const {
       hospital,
       error: hospitalError,
@@ -88,6 +98,7 @@ export const getServerSideProps = propsWithContainer(
       props: {
         hospital,
         error: hospitalError,
+        trust: { name: trustResponse.trust?.name },
       },
     };
   })

--- a/pages/trust-admin/hospitals/add.js
+++ b/pages/trust-admin/hospitals/add.js
@@ -8,7 +8,7 @@ import propsWithContainer from "../../../src/middleware/propsWithContainer";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
 import EditHospitalForm from "../../../src/components/EditHospitalForm";
 import ErrorSummary from "../../../src/components/ErrorSummary";
-import Heading from "../../../src/components/Heading";
+import TrustAdminHeading from "../../../src/components/TrustAdminHeading";
 
 const AddAHospital = ({ trust, error, trustId }) => {
   if (error) {
@@ -72,17 +72,7 @@ const AddAHospital = ({ trust, error, trustId }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
-      <GridRow>
-        <GridColumn width="two-thirds">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            Hospitals
-          </Heading>
-        </GridColumn>
-      </GridRow>
+      <TrustAdminHeading trustName={trust.name} subHeading="Hospitals" />
       <GridRow>
         <GridColumn width="two-thirds">
           <ErrorSummary errors={errors} />

--- a/pages/trust-admin/hospitals/add.js
+++ b/pages/trust-admin/hospitals/add.js
@@ -8,8 +8,9 @@ import propsWithContainer from "../../../src/middleware/propsWithContainer";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
 import EditHospitalForm from "../../../src/components/EditHospitalForm";
 import ErrorSummary from "../../../src/components/ErrorSummary";
+import Heading from "../../../src/components/Heading";
 
-const AddAHospital = ({ error, trustId }) => {
+const AddAHospital = ({ trust, error, trustId }) => {
   if (error) {
     return <Error />;
   }
@@ -24,7 +25,7 @@ const AddAHospital = ({ error, trustId }) => {
 
   const getGenericError = () => {
     return {
-      id: 'generic-error',
+      id: "generic-error",
       message: "Something went wrong, please try again later.",
     };
   };
@@ -73,6 +74,17 @@ const AddAHospital = ({ error, trustId }) => {
     >
       <GridRow>
         <GridColumn width="two-thirds">
+          <Heading>
+            <span className="nhsuk-caption-l">
+              {trust.name}
+              <span className="nhsuk-u-visually-hidden">-</span>
+            </span>
+            Hospitals
+          </Heading>
+        </GridColumn>
+      </GridRow>
+      <GridRow>
+        <GridColumn width="two-thirds">
           <ErrorSummary errors={errors} />
           <EditHospitalForm
             errors={errors}
@@ -86,11 +98,15 @@ const AddAHospital = ({ error, trustId }) => {
 };
 
 export const getServerSideProps = propsWithContainer(
-  verifyTrustAdminToken(async ({ authenticationToken }) => {
+  verifyTrustAdminToken(async ({ authenticationToken, container }) => {
     const trustId = authenticationToken.trustId;
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
     return {
       props: {
         trustId,
+        trust: { name: trustResponse.trust?.name },
       },
     };
   })

--- a/pages/trust-admin/hospitals/index.js
+++ b/pages/trust-admin/hospitals/index.js
@@ -5,7 +5,7 @@ import propsWithContainer from "../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../src/usecases/verifyTrustAdminToken";
 import HospitalsTable from "../../../src/components/HospitalsTable";
 import { GridRow, GridColumn } from "../../../src/components/Grid";
-import Heading from "../../../src/components/Heading";
+import TrustAdminHeading from "../../../src/components/TrustAdminHeading";
 import ActionLink from "../../../src/components/ActionLink";
 import Text from "../../../src/components/Text";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
@@ -21,15 +21,9 @@ const TrustAdmin = ({ hospitals, hospitalError, trust, trustError }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading="Hospitals" />
       <GridRow>
         <GridColumn width="full">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            Hospitals
-          </Heading>
           <ActionLink href={`/trust-admin/hospitals/add`}>
             Add a hospital
           </ActionLink>

--- a/pages/trust-admin/index.js
+++ b/pages/trust-admin/index.js
@@ -4,7 +4,7 @@ import Layout from "../../src/components/Layout";
 import propsWithContainer from "../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../src/usecases/verifyTrustAdminToken";
 import { GridRow, GridColumn } from "../../src/components/Grid";
-import Heading from "../../src/components/Heading";
+import TrustAdminHeading from "../../src/components/TrustAdminHeading";
 import NumberTile from "../../src/components/NumberTile";
 import Text from "../../src/components/Text";
 import AnchorLink from "../../src/components/AnchorLink";
@@ -35,16 +35,9 @@ const TrustAdmin = ({
       showNavigationBarForType={TRUST_ADMIN}
       showNavigationBar={true}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading="Dashboard" />
       <GridRow>
         <GridColumn width="full">
-          <Heading>
-            <span className="nhsuk-caption-l">
-              {trust.name}
-              <span className="nhsuk-u-visually-hidden">-</span>
-            </span>
-            Dashboard
-          </Heading>
-
           <GridRow className="nhsuk-u-padding-bottom-3">
             <GridColumn
               className="nhsuk-u-padding-bottom-3 nhsuk-u-one-half"

--- a/pages/trust-admin/wards/[id]/add-success.js
+++ b/pages/trust-admin/wards/[id]/add-success.js
@@ -5,9 +5,10 @@ import AnchorLink from "../../../../src/components/AnchorLink";
 import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../../../src/components/ActionLink";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
 
-const AddAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
+const AddAWardSuccess = ({ trust, error, name, hospitalName, hospitalId }) => {
   if (error) {
     return <Error />;
   }
@@ -18,6 +19,7 @@ const AddAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading={hospitalName} />
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div
@@ -50,6 +52,10 @@ const AddAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ container, query, authenticationToken }) => {
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
+
     const getRetrieveWardById = container.getRetrieveWardById();
     const { ward, error } = await getRetrieveWardById(
       query.id,
@@ -61,6 +67,7 @@ export const getServerSideProps = propsWithContainer(
         name: ward.name,
         hospitalName: ward.hospitalName,
         hospitalId: ward.hospitalId,
+        trust: { name: trustResponse.trust?.name },
       },
     };
   })

--- a/pages/trust-admin/wards/[id]/add-success.js
+++ b/pages/trust-admin/wards/[id]/add-success.js
@@ -32,8 +32,8 @@ const AddAWardSuccess = ({ trust, error, name, hospitalName, hospitalId }) => {
           </div>
           <h2>What happens next</h2>
 
-          <ActionLink href={`/trust-admin/wards/add`}>
-            Add another ward
+          <ActionLink href={`/trust-admin/wards/add?hospitalId=${hospitalId}`}>
+            Add another ward for {hospitalName}
           </ActionLink>
 
           <p>

--- a/pages/trust-admin/wards/[id]/edit-success.js
+++ b/pages/trust-admin/wards/[id]/edit-success.js
@@ -32,7 +32,9 @@ const EditAWardSuccess = ({ error, name, hospitalName, hospitalId, trust }) => {
           </div>
           <h2>What happens next</h2>
 
-          <ActionLink href={`/trust-admin/wards/add`}>Add a ward</ActionLink>
+          <ActionLink href={`/trust-admin/wards/add?hospitalId=${hospitalId}`}>
+            Add a ward for {hospitalName}
+          </ActionLink>
 
           <p>
             <AnchorLink

--- a/pages/trust-admin/wards/[id]/edit-success.js
+++ b/pages/trust-admin/wards/[id]/edit-success.js
@@ -6,8 +6,9 @@ import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToken";
 import ActionLink from "../../../../src/components/ActionLink";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
 
-const EditAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
+const EditAWardSuccess = ({ error, name, hospitalName, hospitalId, trust }) => {
   if (error) {
     return <Error />;
   }
@@ -18,6 +19,7 @@ const EditAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading={hospitalName} />
       <div className="nhsuk-grid-row">
         <div className="nhsuk-grid-column-two-thirds">
           <div
@@ -48,6 +50,9 @@ const EditAWardSuccess = ({ error, name, hospitalName, hospitalId }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ container, query, authenticationToken }) => {
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
     const getRetrieveWardById = container.getRetrieveWardById();
     const { ward, error } = await getRetrieveWardById(
       query.id,
@@ -60,6 +65,7 @@ export const getServerSideProps = propsWithContainer(
         name: ward.name,
         hospitalName: ward.hospitalName,
         hospitalId: ward.hospitalId,
+        trust: { name: trustResponse.trust?.name },
       },
     };
   })

--- a/pages/trust-admin/wards/[id]/edit.js
+++ b/pages/trust-admin/wards/[id]/edit.js
@@ -6,13 +6,15 @@ import verifyTrustAdminToken from "../../../../src/usecases/verifyTrustAdminToke
 import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import EditWardForm from "../../../../src/components/EditWardForm";
 import { TRUST_ADMIN } from "../../../../src/helpers/userTypes";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
 
-const EditAWard = ({ error, id, name, hospitalId, hospitals }) => {
+const EditAWard = ({ trust, error, id, name, hospitalId, hospitals }) => {
   if (error) {
     return <Error />;
   }
 
   const [errors, setErrors] = useState([]);
+  const hospital = hospitals.filter((hospital) => hospital.id == hospitalId)[0];
 
   return (
     <Layout
@@ -21,6 +23,7 @@ const EditAWard = ({ error, id, name, hospitalId, hospitals }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading={hospital.name} />
       <GridRow>
         <GridColumn width="two-thirds">
           <EditWardForm
@@ -40,6 +43,9 @@ const EditAWard = ({ error, id, name, hospitalId, hospitals }) => {
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ container, query, authenticationToken }) => {
     const getRetrieveWardById = container.getRetrieveWardById();
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
 
     let error = null;
     const getRetrieveWardByIdResponse = await getRetrieveWardById(
@@ -64,6 +70,7 @@ export const getServerSideProps = propsWithContainer(
           name: getRetrieveWardByIdResponse.ward.name,
           hospitalId: getRetrieveWardByIdResponse.ward.hospitalId,
           hospitals: retrieveHospitalsResponse.hospitals,
+          trust: { name: trustResponse.trust?.name },
         },
       };
     }

--- a/pages/trust-admin/wards/[id]/edit.js
+++ b/pages/trust-admin/wards/[id]/edit.js
@@ -14,7 +14,7 @@ const EditAWard = ({ trust, error, id, name, hospitalId, hospitals }) => {
   }
 
   const [errors, setErrors] = useState([]);
-  const hospital = hospitals.filter((hospital) => hospital.id == hospitalId)[0];
+  const hospital = hospitals.find((hospital) => hospital.id == hospitalId);
 
   return (
     <Layout

--- a/pages/trust-admin/wards/add.js
+++ b/pages/trust-admin/wards/add.js
@@ -13,7 +13,7 @@ const AddAWard = ({ trust, hospitals, error, hospitalId }) => {
     return <Error />;
   }
   const [errors, setErrors] = useState([]);
-  const hospital = hospitals.filter((hospital) => hospital.id == hospitalId)[0];
+  const hospital = hospitals.find((hospital) => hospital.id == hospitalId);
 
   return (
     <Layout

--- a/pages/trust-admin/wards/add.js
+++ b/pages/trust-admin/wards/add.js
@@ -1,17 +1,19 @@
 import React, { useState } from "react";
 import { GridRow, GridColumn } from "../../../src/components/Grid";
 import Layout from "../../../src/components/Layout";
+import TrustAdminHeading from "../../../src/components/TrustAdminHeading";
 import verifyTrustAdminToken from "../../../src/usecases/verifyTrustAdminToken";
 import propsWithContainer from "../../../src/middleware/propsWithContainer";
 import AddWardForm from "../../../src/components/AddWardForm";
 import Error from "next/error";
 import { TRUST_ADMIN } from "../../../src/helpers/userTypes";
 
-const AddAWard = ({ hospitals, error, hospitalId }) => {
+const AddAWard = ({ trust, hospitals, error, hospitalId }) => {
   if (error) {
     return <Error />;
   }
   const [errors, setErrors] = useState([]);
+  const hospital = hospitals.filter((hospital) => hospital.id == hospitalId)[0];
 
   return (
     <Layout
@@ -20,6 +22,7 @@ const AddAWard = ({ hospitals, error, hospitalId }) => {
       showNavigationBar={true}
       showNavigationBarForType={TRUST_ADMIN}
     >
+      <TrustAdminHeading trustName={trust.name} subHeading={hospital.name} />
       <GridRow>
         <GridColumn width="two-thirds">
           <AddWardForm
@@ -36,6 +39,9 @@ const AddAWard = ({ hospitals, error, hospitalId }) => {
 
 export const getServerSideProps = propsWithContainer(
   verifyTrustAdminToken(async ({ container, authenticationToken, query }) => {
+    const trustResponse = await container.getRetrieveTrustById()(
+      authenticationToken.trustId
+    );
     const retrieveHospitalsByTrustId = container.getRetrieveHospitalsByTrustId();
     const { hospitals, error } = await retrieveHospitalsByTrustId(
       authenticationToken.trustId
@@ -47,6 +53,7 @@ export const getServerSideProps = propsWithContainer(
         error,
         hospitals,
         hospitalId,
+        trust: { name: trustResponse.trust?.name },
       },
     };
   })

--- a/src/components/AddWardForm/index.js
+++ b/src/components/AddWardForm/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Button from "../Button";
 import FormGroup from "../FormGroup";
-import Heading from "../Heading";
+import FormHeading from "../FormHeading";
 import Input from "../Input";
 import ErrorSummary from "../ErrorSummary";
 import Label from "../Label";
@@ -130,7 +130,7 @@ const AddWardForm = ({ errors, setErrors, hospitals, defaultHospitalId }) => {
     <>
       <ErrorSummary errors={errors} />
       <Form onSubmit={onSubmit}>
-        <Heading>Add a ward</Heading>
+        <FormHeading>Add a ward</FormHeading>
         <FormGroup>
           <Label htmlFor="ward-name" className="nhsuk-label--m">
             What is the ward name?

--- a/src/components/EditHospitalForm/index.js
+++ b/src/components/EditHospitalForm/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Button from "../Button";
 import FormGroup from "../FormGroup";
-import Heading from "../Heading";
+import FormHeading from "../FormHeading";
 import Input from "../Input";
 import Label from "../Label";
 import Form from "../Form";
@@ -74,7 +74,7 @@ const EditHospitalForm = ({ errors, setErrors, hospital = {}, submit }) => {
 
   return (
     <Form onSubmit={onSubmit}>
-      <Heading>{action} a hospital</Heading>
+      <FormHeading>{action} a hospital</FormHeading>
       <FormGroup>
         <Label htmlFor="hospital-name" className="nhsuk-label--m">
           What is the hospital name?

--- a/src/components/EditWardForm/index.js
+++ b/src/components/EditWardForm/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Button from "../Button";
 import FormGroup from "../FormGroup";
-import Heading from "../Heading";
+import FormHeading from "../FormHeading";
 import Input from "../Input";
 import ErrorSummary from "../ErrorSummary";
 import Label from "../Label";
@@ -100,7 +100,7 @@ const EditWardForm = ({
     <>
       <ErrorSummary errors={errors} />
       <Form onSubmit={onSubmit}>
-        <Heading>Edit a ward</Heading>
+        <FormHeading>Edit a ward</FormHeading>
         <FormGroup>
           <Label htmlFor="ward-name" className="nhsuk-label--m">
             What is the ward name?

--- a/src/components/FormHeading/index.js
+++ b/src/components/FormHeading/index.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const FormHeading = ({ children }) => <h2>{children}</h2>;
+
+export default FormHeading;

--- a/src/components/TrustAdminHeading/index.js
+++ b/src/components/TrustAdminHeading/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import Heading from "../Heading";
+import { GridRow, GridColumn } from "../../../src/components/Grid";
+
+const TrustAdminHeading = ({ trustName, subHeading }) => (
+  <GridRow>
+    <GridColumn width="two-thirds">
+      <Heading>
+        <span className="nhsuk-caption-l">
+          {trustName}
+          <span className="nhsuk-u-visually-hidden">-</span>
+        </span>
+        {subHeading}
+      </Heading>
+    </GridColumn>
+  </GridRow>
+);
+
+export default TrustAdminHeading;

--- a/test/pages/trust-admin/hospitals/[id].test.js
+++ b/test/pages/trust-admin/hospitals/[id].test.js
@@ -35,7 +35,7 @@ describe("trust-admin/hospitals/[id]", () => {
       });
     });
 
-    it("provides the hospital and wards as props", async () => {
+    it("provides the trust, hospital and wards as props", async () => {
       const hospitalId = 1;
 
       const TrustSpy = jest.fn(async () => ({

--- a/test/pages/trust-admin/hospitals/[id].test.js
+++ b/test/pages/trust-admin/hospitals/[id].test.js
@@ -38,6 +38,10 @@ describe("trust-admin/hospitals/[id]", () => {
     it("provides the hospital and wards as props", async () => {
       const hospitalId = 1;
 
+      const TrustSpy = jest.fn(async () => ({
+        trust: { name: "Doggo Trust" },
+        error: null,
+      }));
       const wardsSpy = jest.fn(async () => ({
         wards: [{ id: 1 }, { id: 2 }],
         error: null,
@@ -64,6 +68,7 @@ describe("trust-admin/hospitals/[id]", () => {
       });
 
       const container = {
+        getRetrieveTrustById: () => TrustSpy,
         getRetrieveWardsByHospitalId: () => wardsSpy,
         getRetrieveHospitalById: () => hospitalSpy,
         getRetrieveHospitalVisitTotals: () => visitTotalsSpy,

--- a/test/pages/trust-admin/hospitals/[id]/add-success.test.js
+++ b/test/pages/trust-admin/hospitals/[id]/add-success.test.js
@@ -36,6 +36,11 @@ describe("/trust-admin/hospitals/[id]/add-success", () => {
 
     describe("with hospitalId parameter", () => {
       it("retrieves a hospital by the hospitalId parameter", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveHospitalByIdSpy = jest.fn().mockReturnValue({
           hospital: {
             id: 1,
@@ -45,6 +50,7 @@ describe("/trust-admin/hospitals/[id]/add-success", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
           getTokenProvider: () => tokenProvider,
           getRegenerateToken: () => jest.fn().mockReturnValue({}),
@@ -63,6 +69,11 @@ describe("/trust-admin/hospitals/[id]/add-success", () => {
       });
 
       it("set a hospital prop based on the retrieved hospital", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveHospitalByIdSpy = jest.fn().mockReturnValue({
           hospital: {
             id: 1,
@@ -72,6 +83,7 @@ describe("/trust-admin/hospitals/[id]/add-success", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
           getTokenProvider: () => tokenProvider,
           getRegenerateToken: () => jest.fn().mockReturnValue({}),

--- a/test/pages/trust-admin/hospitals/[id]/edit.test.js
+++ b/test/pages/trust-admin/hospitals/[id]/edit.test.js
@@ -38,6 +38,12 @@ describe("/trust-admin/hospitals/[id]/edit", () => {
 
     it("retrieves the hospital by ID", async () => {
       const hospitalId = 2;
+
+      const retrieveTrustByIdSpy = jest.fn(async () => ({
+        trust: { name: "Doggo Trust" },
+        error: null,
+      }));
+
       const retrieveHospitalByIdSpy = jest.fn().mockResolvedValue({
         hospital: {
           id: hospitalId,
@@ -49,6 +55,7 @@ describe("/trust-admin/hospitals/[id]/edit", () => {
       });
 
       const container = {
+        getRetrieveTrustById: () => retrieveTrustByIdSpy,
         getRetrieveHospitalById: () => retrieveHospitalByIdSpy,
         getTokenProvider: () => tokenProvider,
         getRegenerateToken: () => jest.fn().mockReturnValue({}),

--- a/test/pages/trust-admin/wards/[id]/add-success.test.js
+++ b/test/pages/trust-admin/wards/[id]/add-success.test.js
@@ -36,6 +36,11 @@ describe("/trust-admin/wards/[id]/add-success", () => {
 
     describe("with wardId parameter", () => {
       it("retrieves a ward by the wardId parameter", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveWardByIdSpy = jest.fn().mockReturnValue({
           ward: {
             id: 1,
@@ -46,6 +51,7 @@ describe("/trust-admin/wards/[id]/add-success", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
           getRegenerateToken: () => jest.fn().mockReturnValue({}),
@@ -64,6 +70,11 @@ describe("/trust-admin/wards/[id]/add-success", () => {
       });
 
       it("set a ward prop based on the retrieved ward", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveWardByIdSpy = jest.fn().mockReturnValue({
           ward: {
             id: 1,
@@ -74,6 +85,7 @@ describe("/trust-admin/wards/[id]/add-success", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
           getRegenerateToken: () => jest.fn().mockReturnValue({}),

--- a/test/pages/trust-admin/wards/[id]/edit-a-ward.test.js
+++ b/test/pages/trust-admin/wards/[id]/edit-a-ward.test.js
@@ -36,6 +36,11 @@ describe("/trust-admin/wards/[id]/edit", () => {
 
     describe("with wardId parameter", () => {
       it("retrieves a ward by the wardId parameter", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveWardByIdSpy = jest.fn().mockReturnValue({
           ward: {
             id: 1,
@@ -46,6 +51,7 @@ describe("/trust-admin/wards/[id]/edit", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getRetrieveHospitalsByTrustId: () =>
             jest.fn().mockReturnValue({
@@ -69,6 +75,11 @@ describe("/trust-admin/wards/[id]/edit", () => {
       });
 
       it("set a ward prop based on the retrieved ward", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveWardByIdSpy = jest.fn().mockReturnValue({
           ward: {
             id: 1,
@@ -79,6 +90,7 @@ describe("/trust-admin/wards/[id]/edit", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getRetrieveHospitalsByTrustId: () =>
             jest.fn().mockReturnValue({

--- a/test/pages/trust-admin/wards/[id]/edit-success.test.js
+++ b/test/pages/trust-admin/wards/[id]/edit-success.test.js
@@ -36,6 +36,10 @@ describe("/trust-admin/wards/[id]/edit-success", () => {
 
     describe("with wardId parameter", () => {
       it("retrieves a ward by the wardId parameter", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
         const retrieveWardByIdSpy = jest.fn().mockReturnValue({
           ward: {
             id: 1,
@@ -46,6 +50,7 @@ describe("/trust-admin/wards/[id]/edit-success", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
           getRegenerateToken: () => jest.fn().mockReturnValue({}),
@@ -64,6 +69,11 @@ describe("/trust-admin/wards/[id]/edit-success", () => {
       });
 
       it("set a ward prop based on the retrieved ward", async () => {
+        const retrieveTrustByIdSpy = jest.fn(async () => ({
+          trust: { name: "Doggo Trust" },
+          error: null,
+        }));
+
         const retrieveWardByIdSpy = jest.fn().mockReturnValue({
           ward: {
             id: 1,
@@ -74,6 +84,7 @@ describe("/trust-admin/wards/[id]/edit-success", () => {
         });
 
         const container = {
+          getRetrieveTrustById: () => retrieveTrustByIdSpy,
           getRetrieveWardById: () => retrieveWardByIdSpy,
           getTokenProvider: () => tokenProvider,
           getRegenerateToken: () => jest.fn().mockReturnValue({}),

--- a/test/pages/trust-admin/wards/add.test.js
+++ b/test/pages/trust-admin/wards/add.test.js
@@ -38,6 +38,7 @@ describe("/trust-admin/wards/add", () => {
             { id: "2", name: "Catra Hospital" },
           ]}
           hospitalId={1}
+          trust={{ name: "Trust Test" }}
         />
       );
 

--- a/test/pages/trust-admin/wards/add.test.js
+++ b/test/pages/trust-admin/wards/add.test.js
@@ -28,7 +28,8 @@ describe("/trust-admin/wards/add", () => {
     });
   });
 
-  describe("AddAWard", () => {
+  /*** hospital drop down will be taken out skip test for now */
+  xdescribe("AddAWard", () => {
     it("does not throw a hospital error when default select hospital option", () => {
       render(
         <AddAWard

--- a/test/pages/trust-admin/wards/add.test.js
+++ b/test/pages/trust-admin/wards/add.test.js
@@ -28,7 +28,6 @@ describe("/trust-admin/wards/add", () => {
     });
   });
 
-  /*** hospital drop down will be taken out skip test for now */
   describe("AddAWard", () => {
     it("does not throw a hospital error when default select hospital option", () => {
       render(

--- a/test/pages/trust-admin/wards/add.test.js
+++ b/test/pages/trust-admin/wards/add.test.js
@@ -29,7 +29,7 @@ describe("/trust-admin/wards/add", () => {
   });
 
   /*** hospital drop down will be taken out skip test for now */
-  xdescribe("AddAWard", () => {
+  describe("AddAWard", () => {
     it("does not throw a hospital error when default select hospital option", () => {
       render(
         <AddAWard


### PR DESCRIPTION
# What
   Added TrustAdminHeading and FormHeading components and Standardised Headers for Trust Admin Flow to include Trust Name and Hospitals
# Why
   So that pages are more consistent throughout and User know what Trusts he is adding hospitals to and what hospitals he is adding Wards to.
# Screenshots

![image](https://user-images.githubusercontent.com/60115746/102761294-a5ad6580-436e-11eb-9fe9-1fe0ec8018e3.png)
# Notes
 Pages affected 

- Individual Hospital page
- 
- Add and Edit Hospital page
- 
- Add Success and Edit Success Hospital page
- 
- Add and Edit Ward Page
- 
- Add Success and Edit Success Ward Page
- 