### PR TITLE
Move ward query into gateway

### DIFF
--- a/contractTest/gateways/findWardByCode.contractTest.js
+++ b/contractTest/gateways/findWardByCode.contractTest.js
@@ -1,0 +1,21 @@
+import AppContainer from "../../src/containers/AppContainer";
+import findWardByCode from "../../src/gateways/findWardByCode";
+//import Database from "../../src/gateways/Database";
+import { setupTrust, setupWard } from "../../test/testUtils/factories";
+
+describe("findWardByCode() contract", () => {
+  const container = AppContainer.getInstance();
+
+  it("inserts visit into the db", async () => {
+    //const db = await Database.getInstance();
+
+    const wardCode = "32p+";
+    const { trustId } = await setupTrust();
+    const { wardId } = await setupWard({ trustId: trustId, code: wardCode });
+    expect(await findWardByCode(container)(wardCode)).toEqual({
+      wardCode,
+      wardId,
+      trustId,
+    });
+  });
+});

--- a/contractTest/gateways/findWardByCode.contractTest.js
+++ b/contractTest/gateways/findWardByCode.contractTest.js
@@ -1,6 +1,6 @@
 import AppContainer from "../../src/containers/AppContainer";
 import findWardByCode from "../../src/gateways/findWardByCode";
-//import Database from "../../src/gateways/Database";
+
 import {
   setupTrust,
   setupWard,

--- a/contractTest/gateways/findWardByCode.contractTest.js
+++ b/contractTest/gateways/findWardByCode.contractTest.js
@@ -1,7 +1,11 @@
 import AppContainer from "../../src/containers/AppContainer";
 import findWardByCode from "../../src/gateways/findWardByCode";
 //import Database from "../../src/gateways/Database";
-import { setupTrust, setupWard } from "../../test/testUtils/factories";
+import {
+  setupTrust,
+  setupWard,
+  setupHospital,
+} from "../../test/testUtils/factories";
 
 describe("findWardByCode() contract", () => {
   const container = AppContainer.getInstance();
@@ -10,8 +14,16 @@ describe("findWardByCode() contract", () => {
     //const db = await Database.getInstance();
 
     const wardCode = "32p+";
+    const wardName = "Deutsche ward";
     const { trustId } = await setupTrust();
-    const { wardId } = await setupWard({ trustId: trustId, code: wardCode });
+    const { hospitalId } = await setupHospital({ trustId });
+    const { wardId } = await setupWard({
+      trustId,
+      code: wardCode,
+      name: wardName,
+      hospital_id: hospitalId,
+    });
+
     expect(await findWardByCode(container)(wardCode)).toEqual({
       wardCode,
       wardId,

--- a/contractTest/gateways/findWardByCode.contractTest.js
+++ b/contractTest/gateways/findWardByCode.contractTest.js
@@ -10,9 +10,7 @@ import {
 describe("findWardByCode() contract", () => {
   const container = AppContainer.getInstance();
 
-  it("inserts visit into the db", async () => {
-    //const db = await Database.getInstance();
-
+  it("returns the appropriate ward", async () => {
     const wardCode = "32p+";
     const wardName = "Deutsche ward";
     const { trustId } = await setupTrust();
@@ -29,5 +27,20 @@ describe("findWardByCode() contract", () => {
       wardId,
       trustId,
     });
+  });
+
+  it("returns null when the ward code can't be found", async () => {
+    const wardCode = "32p+";
+    const wardName = "Deutsche ward";
+    const { trustId } = await setupTrust();
+    const { hospitalId } = await setupHospital({ trustId });
+    await setupWard({
+      trustId,
+      code: wardCode,
+      name: wardName,
+      hospital_id: hospitalId,
+    });
+
+    expect(await findWardByCode(container)("14p+")).toBeNull();
   });
 });

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -45,6 +45,7 @@ import sendBookingNotification from "../usecases/sendBookingNotification";
 import retrieveVisitById from "../usecases/retrieveVisitById";
 import markVisitAsComplete from "../usecases/markVisitAsComplete";
 import updateTrust from "../usecases/updateTrust";
+import findWardByCode from "../gateways/findWardByCode";
 import updateWardVisitTotals from "../gateways/updateWardVisitTotals";
 import retrieveWardById from "../gateways/retrieveWardById";
 import retrieveTrustById from "../gateways/retrieveTrustById";
@@ -131,6 +132,10 @@ class AppContainer {
 
   getRetrieveWards = () => {
     return retrieveWards(this);
+  };
+
+  getFindWardByCode = () => {
+    return findWardByCode(this);
   };
 
   getUpdateWardVisitTotals = () => {

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -134,7 +134,7 @@ class AppContainer {
     return retrieveWards(this);
   };
 
-  getFindWardByCode = () => {
+  getFindWardByCodeGateway = () => {
     return findWardByCode(this);
   };
 

--- a/src/gateways/findWardByCode.js
+++ b/src/gateways/findWardByCode.js
@@ -1,0 +1,12 @@
+const recordToDomain = ({ id, code, trust_id }) => ({
+  wardId: id,
+  wardCode: code,
+  trustId: trust_id,
+});
+const findWardQuery = async (db, wardCode) =>
+  await db.any(`SELECT id, code, trust_id FROM wards WHERE code = $1 LIMIT 1`, [
+    wardCode,
+  ]);
+
+export default ({ getDb }) => async (wardCode) =>
+  recordToDomain((await findWardQuery(await getDb(), wardCode))[0]);

--- a/src/gateways/findWardByCode.js
+++ b/src/gateways/findWardByCode.js
@@ -7,10 +7,11 @@ const findWardQuery = async (db, wardCode) =>
   await db.any(`SELECT id, code, trust_id FROM wards WHERE code = $1 LIMIT 1`, [
     wardCode,
   ]);
-const ifDefined = async (value, func) =>
-  (value !== undefined && (await func(value))) || null;
+const applyIfDefined = async (value, func) =>
+  value !== undefined ? await func(value) : null;
 
 export default ({ getDb }) => async (wardCode) =>
-  ifDefined((await findWardQuery(await getDb(), wardCode))[0], async (record) =>
-    recordToDomain(record)
+  applyIfDefined(
+    (await findWardQuery(await getDb(), wardCode))[0],
+    async (record) => recordToDomain(record)
   );

--- a/src/gateways/findWardByCode.js
+++ b/src/gateways/findWardByCode.js
@@ -7,6 +7,10 @@ const findWardQuery = async (db, wardCode) =>
   await db.any(`SELECT id, code, trust_id FROM wards WHERE code = $1 LIMIT 1`, [
     wardCode,
   ]);
+const ifDefined = async (value, func) =>
+  (value !== undefined && (await func(value))) || null;
 
 export default ({ getDb }) => async (wardCode) =>
-  recordToDomain((await findWardQuery(await getDb(), wardCode))[0]);
+  ifDefined((await findWardQuery(await getDb(), wardCode))[0], async (record) =>
+    recordToDomain(record)
+  );

--- a/src/usecases/verifyWardCode.js
+++ b/src/usecases/verifyWardCode.js
@@ -1,20 +1,14 @@
 import logger from "../../logger";
 
-const verifyWardCode = ({ getDb }) => async (wardCode) => {
-  const db = await getDb();
-
+const verifyWardCode = ({ getFindWardByCodeGateway }) => async (wardCode) => {
+  const findWardByCodeGateway = await getFindWardByCodeGateway();
   try {
-    const dbResponse = await db.any(
-      `SELECT id, code, trust_id FROM wards WHERE code = $1 LIMIT 1`,
-      [wardCode]
-    );
+    const ward = await findWardByCodeGateway(wardCode);
 
-    if (dbResponse.length > 0) {
-      let [ward] = dbResponse;
-
+    if (ward) {
       return {
         validWardCode: true,
-        ward: { id: ward.id, code: ward.code, trustId: ward.trust_id },
+        ward: { id: ward.wardId, code: ward.wardCode, trustId: ward.trustId },
         error: null,
       };
     } else {

--- a/test/usecases/verifyWardCode.test.js
+++ b/test/usecases/verifyWardCode.test.js
@@ -2,19 +2,28 @@ import verifyWardCode from "../../src/usecases/verifyWardCode";
 
 describe("verifyWardCode", () => {
   describe("Given a matching ward code", () => {
-    it("Returns true with the matching ward ID", async () => {
+    it("Calls the findWardByCode gateway", async () => {
+      const findWardByCodeGateway = jest.fn(async () => ({
+        wardId: 1,
+        wardCode: "14p+",
+        trustId: 1,
+      }));
       const container = {
-        getDb: async () => ({
-          any: jest.fn(async () => [
-            {
-              id: 1,
-              name: "Ward name",
-              hospital_name: "London Meowdical Hospital",
-              code: "MEOW",
-              trust_id: 1,
-            },
-          ]),
-        }),
+        getFindWardByCodeGateway: () => findWardByCodeGateway,
+      };
+
+      await verifyWardCode(container)("14p+");
+      expect(findWardByCodeGateway).toHaveBeenCalledWith("14p+");
+    });
+
+    it("Returns true with the matching ward ID", async () => {
+      const findWardByCodeGateway = jest.fn(async () => ({
+        wardId: 1,
+        wardCode: "MEOW",
+        trustId: 1,
+      }));
+      const container = {
+        getFindWardByCodeGateway: () => findWardByCodeGateway,
       };
 
       let response = await verifyWardCode(container)("MEOW");
@@ -30,7 +39,7 @@ describe("verifyWardCode", () => {
   describe("Given a non matching ward code", () => {
     it("Returns false", async () => {
       const container = {
-        getDb: async () => ({
+        getFindWardByCodeGateway: async () => ({
           any: jest.fn(async () => []),
         }),
       };
@@ -43,12 +52,8 @@ describe("verifyWardCode", () => {
   describe("Given a DB error", () => {
     it("Returns an error", async () => {
       const container = {
-        async getDb() {
-          return {
-            any: jest.fn(() => {
-              throw new Error("DB Error!");
-            }),
-          };
+        getFindWardByCodeGateway: () => async () => {
+          throw new Error("DB Error!");
         },
       };
 


### PR DESCRIPTION
# What
This is the first of what will be a series of PRs moving SQL queries out of usecases and into gateways, which will later be placed under their own folder. This PR will likely serve as the precedent for future changes of this nature.

# Why
In order to being coupled to the database we need to pull every query out of the usecases, this is important because we plan to move to MSSQL. In addition, it also just makes it more convenient to write code in future.