### PR TITLE
chore: break archiveWard's SQL into gateways

### DIFF
--- a/contractTest/gateways/findWardByCode.contractTest.js
+++ b/contractTest/gateways/findWardByCode.contractTest.js
@@ -1,3 +1,5 @@
+import moment from "moment";
+
 import AppContainer from "../../src/containers/AppContainer";
 import findWardByCode from "../../src/gateways/findWardByCode";
 
@@ -15,17 +17,20 @@ describe("findWardByCode() contract", () => {
     const wardName = "Deutsche ward";
     const { trustId } = await setupTrust();
     const { hospitalId } = await setupHospital({ trustId });
+    const archived_at = moment("1986-04-05").toISOString();
     const { wardId } = await setupWard({
       trustId,
       code: wardCode,
       name: wardName,
       hospital_id: hospitalId,
+      archived_at,
     });
 
     expect(await findWardByCode(container)(wardCode)).toEqual({
       wardCode,
       wardId,
       trustId,
+      archivedAt: archived_at,
     });
   });
 

--- a/contractTest/gateways/findWardByCode.contractTest.js
+++ b/contractTest/gateways/findWardByCode.contractTest.js
@@ -1,5 +1,3 @@
-import moment from "moment";
-
 import AppContainer from "../../src/containers/AppContainer";
 import findWardByCode from "../../src/gateways/findWardByCode";
 
@@ -17,20 +15,18 @@ describe("findWardByCode() contract", () => {
     const wardName = "Deutsche ward";
     const { trustId } = await setupTrust();
     const { hospitalId } = await setupHospital({ trustId });
-    const archived_at = moment("1986-04-05").toISOString();
     const { wardId } = await setupWard({
       trustId,
       code: wardCode,
       name: wardName,
       hospital_id: hospitalId,
-      archived_at,
     });
 
     expect(await findWardByCode(container)(wardCode)).toEqual({
       wardCode,
       wardId,
       trustId,
-      archivedAt: archived_at,
+      archivedAt: null,
     });
   });
 

--- a/contractTest/gateways/retrieveOrganizationById.contractTest.js
+++ b/contractTest/gateways/retrieveOrganizationById.contractTest.js
@@ -17,15 +17,17 @@ describe("retrieveOrganizationById", () => {
     });
   });
 
-  it("returns an error when trust not found for id", async () => {
+  it("returns an error when organization not found for id", async () => {
     const { error } = await retrieveOrganizationById(12);
     expect(error).toBeDefined();
-    expect(error).toEqual("Trust not found for id");
+    expect(error).toEqual("Organization not found for id");
   });
 
-  it("returns an error when trust id not set", async () => {
+  it("returns an error when organization id not set", async () => {
     const { error } = await retrieveOrganizationById();
     expect(error).toBeDefined();
-    expect(error).toEqual("Attempting to retrieve trust with no trust Id set");
+    expect(error).toEqual(
+      "Attempting to retrieve organization with no organization ID set"
+    );
   });
 });

--- a/contractTest/gateways/updateCallStatusesByWardId.contractTest.js
+++ b/contractTest/gateways/updateCallStatusesByWardId.contractTest.js
@@ -1,0 +1,48 @@
+import AppContainer from "../../src/containers/AppContainer";
+import Database from "../../src/gateways/Database";
+
+import findCallsByWardId from "../../src/gateways/findCallsByWardId";
+import updateCallStatusesByWardId from "../../src/gateways/updateCallStatusesByWardId";
+import { ARCHIVED } from "../../src/helpers/visitStatus";
+
+import {
+  setupTrust,
+  setupWard,
+  setupHospital,
+  setupVisit,
+} from "../../test/testUtils/factories";
+
+describe("updateCallStatusesByWardId() contract", () => {
+  const container = AppContainer.getInstance();
+
+  it("updates the call statuses", async () => {
+    await Database.getInstance();
+
+    const { trustId } = await setupTrust();
+    const { hospitalId } = await setupHospital({ trustId });
+    const { wardId } = await setupWard({ trustId, hospitalId });
+    await setupVisit({ wardId, callId: "ID1" });
+    await setupVisit({ wardId, callId: "ID2" });
+    await setupVisit({ wardId, callId: "ID3" });
+
+    await updateCallStatusesByWardId(container)(wardId, ARCHIVED);
+    const scheduledCalls = await findCallsByWardId(container)(wardId);
+    expect(scheduledCalls).orderlessEqual([
+      {
+        wardId,
+        callId: "ID1",
+        status: ARCHIVED,
+      },
+      {
+        wardId,
+        callId: "ID2",
+        status: ARCHIVED,
+      },
+      {
+        wardId,
+        callId: "ID3",
+        status: ARCHIVED,
+      },
+    ]);
+  });
+});

--- a/contractTest/gateways/updateWardArchiveTimeById.contractTest.js
+++ b/contractTest/gateways/updateWardArchiveTimeById.contractTest.js
@@ -1,0 +1,36 @@
+import moment from "moment";
+
+import AppContainer from "../../src/containers/AppContainer";
+import Database from "../../src/gateways/Database";
+
+import findWardByCode from "../../src/gateways/findWardByCode";
+import updateWardArchiveTimeById from "../../src/gateways/updateWardArchiveTimeById";
+
+import {
+  setupTrust,
+  setupWard,
+  setupHospital,
+} from "../../test/testUtils/factories";
+
+describe("updateWardArchiveTimeById() contract", () => {
+  const container = AppContainer.getInstance();
+
+  it("updates the call statuses", async () => {
+    await Database.getInstance();
+
+    const wardCode = "TestWard";
+    const { trustId } = await setupTrust();
+    const { hospitalId } = await setupHospital({ trustId });
+    const { wardId } = await setupWard({ trustId, hospitalId, code: wardCode });
+
+    const archivedAt = moment("1986-04-05").toISOString();
+    await updateWardArchiveTimeById(container)(wardId, archivedAt);
+    const ward = await findWardByCode(container)(wardCode);
+    expect(ward).toEqual({
+      wardCode,
+      wardId,
+      trustId,
+      archivedAt,
+    });
+  });
+});

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -48,6 +48,8 @@ import updateTrust from "../usecases/updateTrust";
 import findWardByCode from "../gateways/findWardByCode";
 import createOrganization from "../usecases/createOrganization";
 import retrieveOrganizations from "../usecases/retrieveOrganizations";
+import updateCallStatusesByWardId from "../gateways/updateCallStatusesByWardId";
+import updateWardArchiveTimeById from "../gateways/updateWardArchiveTimeById";
 import updateWardVisitTotals from "../gateways/updateWardVisitTotals";
 import retrieveWardById from "../gateways/retrieveWardById";
 import retrieveTrustById from "../gateways/retrieveTrustById";
@@ -145,6 +147,10 @@ class AppContainer {
   getFindWardByCodeGateway = () => {
     return findWardByCode(this);
   };
+
+  getUpdateCallStatusesByWardIdGateway = () => updateCallStatusesByWardId(this);
+
+  getUpdateWardArchiveTimeByIdGateway = () => updateWardArchiveTimeById(this);
 
   getUpdateWardVisitTotals = () => {
     return updateWardVisitTotalsDb(this);

--- a/src/gateways/findCallsByWardId.js
+++ b/src/gateways/findCallsByWardId.js
@@ -1,0 +1,15 @@
+const recordToDomain = ({ ward_id, call_id, status }) => ({
+  wardId: ward_id,
+  callId: call_id,
+  status,
+});
+const recordsToDomain = (records) => records.map(recordToDomain);
+
+const findCallsByWardIdQuery = async (db, wardId) =>
+  await db.any(
+    `SELECT ward_id, call_id, status FROM scheduled_calls_table WHERE ward_id = $1`,
+    wardId
+  ); //add columns as needed
+
+export default ({ getDb }) => async (wardId) =>
+  recordsToDomain(await findCallsByWardIdQuery(await getDb(), wardId));

--- a/src/gateways/findWardByCode.js
+++ b/src/gateways/findWardByCode.js
@@ -1,12 +1,16 @@
-const recordToDomain = ({ id, code, trust_id }) => ({
+import moment from "moment";
+
+const recordToDomain = ({ id, code, trust_id, archived_at }) => ({
   wardId: id,
   wardCode: code,
   trustId: trust_id,
+  archivedAt: archived_at && moment(archived_at).toISOString(),
 });
 const findWardQuery = async (db, wardCode) =>
-  await db.any(`SELECT id, code, trust_id FROM wards WHERE code = $1 LIMIT 1`, [
-    wardCode,
-  ]);
+  await db.any(
+    `SELECT id, code, trust_id, archived_at FROM wards WHERE code = $1 LIMIT 1`,
+    [wardCode]
+  );
 const applyIfDefined = async (value, func) =>
   value !== undefined ? await func(value) : null;
 

--- a/src/gateways/retrieveOrganizationById.js
+++ b/src/gateways/retrieveOrganizationById.js
@@ -8,13 +8,13 @@ const retrieveOrganizationById = async (organizationId) => {
 
   try {
     if (!organizationId)
-      throw "Attempting to retrieve trust with no trust Id set";
+      throw "Attempting to retrieve organization with no organization ID set";
     const organization = await db.oneOrNone(
       "SELECT * FROM organization WHERE id = $1 LIMIT 1",
       organizationId
     );
 
-    if (!organization) throw "Trust not found for id";
+    if (!organization) throw "Organization not found for id";
 
     return {
       organization: {

--- a/src/gateways/updateCallStatusesByWardId.js
+++ b/src/gateways/updateCallStatusesByWardId.js
@@ -1,0 +1,10 @@
+const updateCallStatusesByWardIdQuery = async (db, wardId, status) =>
+  await db.any(
+    `UPDATE scheduled_calls_table SET status = $1 WHERE ward_id = $2`,
+    [status, wardId]
+  );
+
+const returnsNull = () => null;
+
+export default ({ getDb }) => async (wardId, status) =>
+  returnsNull(updateCallStatusesByWardIdQuery(await getDb(), wardId, status));

--- a/src/gateways/updateWardArchiveTimeById.js
+++ b/src/gateways/updateWardArchiveTimeById.js
@@ -1,0 +1,12 @@
+const updateWardArchiveTimeByIdQuery = async (db, wardId, time) =>
+  await db.result(`UPDATE wards SET archived_at = $1 WHERE id = $2`, [
+    time,
+    wardId,
+  ]);
+
+const returnsNull = () => null;
+
+export default ({ getDb }) => async (wardId, time) =>
+  returnsNull(
+    await updateWardArchiveTimeByIdQuery(await getDb(), wardId, time)
+  );

--- a/src/usecases/archiveWard.js
+++ b/src/usecases/archiveWard.js
@@ -2,11 +2,14 @@ import moment from "moment";
 import { ARCHIVED } from "../../src/helpers/visitStatus";
 import logger from "../../logger";
 
-const archiveWard = ({ getRetrieveWardById, getDb }) => async (
-  wardId,
-  trustId
-) => {
+const archiveWard = ({
+  getRetrieveWardById,
+  getUpdateWardArchiveTimeByIdGateway,
+  getUpdateCallStatusesByWardIdGateway,
+}) => async (wardId, trustId) => {
   const retrieveWardById = getRetrieveWardById();
+  const updateCallStatusesByWardIdGateway = getUpdateCallStatusesByWardIdGateway();
+  const updateWardArchiveTimeByIdGateway = getUpdateWardArchiveTimeByIdGateway();
 
   const retrieveResult = await retrieveWardById(wardId, trustId);
 
@@ -14,15 +17,8 @@ const archiveWard = ({ getRetrieveWardById, getDb }) => async (
     return { success: false, error: "Ward does not exist" };
   }
 
-  const db = await getDb();
-
   try {
-    await db.result(
-      `UPDATE scheduled_calls_table
-       SET status = $1
-       WHERE ward_id = $2`,
-      [ARCHIVED, wardId]
-    );
+    await updateCallStatusesByWardIdGateway(wardId, ARCHIVED);
   } catch (err) {
     logger.error(
       `Failed to remove visits [${wardId}] from ward ${trustId}`,
@@ -32,13 +28,7 @@ const archiveWard = ({ getRetrieveWardById, getDb }) => async (
   }
 
   try {
-    await db.result(
-      `UPDATE wards
-        SET archived_at = $2
-        WHERE id = $1
-    `,
-      [wardId, moment().toISOString()]
-    );
+    await updateWardArchiveTimeByIdGateway(wardId, moment().toISOString());
   } catch (err) {
     logger.error(
       `Failed to remove ward [${wardId}] from trust ${trustId}`,

--- a/src/usecases/createWard.js
+++ b/src/usecases/createWard.js
@@ -6,18 +6,11 @@ const createWard = ({ getDb }) => async (ward) => {
     logger.info(`Creating ward for ${JSON.stringify(ward)}`, ward);
     const createdWard = await db.one(
       `INSERT INTO wards
-        (id, name, code, trust_id, hospital_id, pin, archived_at)
+        (id, name, code, trust_id, hospital_id, pin)
         VALUES (default, $1, $2, $3, $4, $5)
         RETURNING id
       `,
-      [
-        ward.name,
-        ward.code,
-        ward.trustId,
-        ward.hospitalId,
-        ward.pin,
-        ward.archived_at || null,
-      ]
+      [ward.name, ward.code, ward.trustId, ward.hospitalId, ward.pin]
     );
 
     return {

--- a/src/usecases/createWard.js
+++ b/src/usecases/createWard.js
@@ -6,11 +6,18 @@ const createWard = ({ getDb }) => async (ward) => {
     logger.info(`Creating ward for ${JSON.stringify(ward)}`, ward);
     const createdWard = await db.one(
       `INSERT INTO wards
-        (id, name, code, trust_id, hospital_id, pin)
+        (id, name, code, trust_id, hospital_id, pin, archived_at)
         VALUES (default, $1, $2, $3, $4, $5)
         RETURNING id
       `,
-      [ward.name, ward.code, ward.trustId, ward.hospitalId, ward.pin]
+      [
+        ward.name,
+        ward.code,
+        ward.trustId,
+        ward.hospitalId,
+        ward.pin,
+        ward.archived_at || null,
+      ]
     );
 
     return {

--- a/test/testUtils/truncateAllTables.js
+++ b/test/testUtils/truncateAllTables.js
@@ -18,4 +18,5 @@ export default async ({ getDb }) => {
   await db.any("DELETE from hospitals");
   await db.any("DELETE from trusts");
   await db.any("DELETE from admins");
+  await db.any("DELETE from organization");
 };

--- a/test/usecases/createWard.test.js
+++ b/test/usecases/createWard.test.js
@@ -30,6 +30,7 @@ describe("createWard", () => {
       request.trustId,
       request.hospitalId,
       request.pin,
+      null,
     ]);
   });
 });

--- a/test/usecases/createWard.test.js
+++ b/test/usecases/createWard.test.js
@@ -29,8 +29,7 @@ describe("createWard", () => {
       request.code,
       request.trustId,
       request.hospitalId,
-      request.pin,
-      null,
+      request.pin
     ]);
   });
 });


### PR DESCRIPTION
# What
Continuing on from https://github.com/madetech/nhs-virtual-visit/pull/679 this breaks out archiveWard's queries into their own gateway functions  

# Why
In order to being coupled to the database we need to pull every query out of the usecases, this is important because we plan to move to MSSQL. In addition, it also just makes it more convenient to write code in future.

# Notes
This has largely kept the same format as the first, for update queries I've elected to split these up into distinct gateways since this simplifies things as far as refactoring what's already there but if that becomes very messy feel free to refactor them into update gateways for each domain that can update various properties instead of only being able to update one at a time as they are now.

The failing tests are just things that are currently failing on master, prior to rebase everything passed so once that's fixed on master and this branch gets rebased again it should pass.