### PR TITLE
Fix issues with update-a-trust tests

### DIFF
--- a/pages/api/update-a-trust.js
+++ b/pages/api/update-a-trust.js
@@ -12,7 +12,7 @@ export default withContainer(async (req, res, { container }) => {
 
   const token = adminIsAuthenticated(req.headers.cookie);
 
-  checkIfAuthorised(token, res);
+  if(!checkIfAuthorised(token, res)) { return; }
 
   const { id, videoProvider } = req.body;
 

--- a/src/helpers/apiErrorHandler.js
+++ b/src/helpers/apiErrorHandler.js
@@ -10,8 +10,10 @@ export function checkIfAuthorised(token, res) {
   if (!token) {
     res.status(401);
     res.end(JSON.stringify({ err: "Unauthorized" }));
-    return;
+    return false;
   }
+
+  return true;
 }
 
 export default validateHttpMethod;

--- a/test/pages/api/update-a-trust.test.js
+++ b/test/pages/api/update-a-trust.test.js
@@ -1,11 +1,12 @@
 import updateATrust from "../../../pages/api/update-a-trust";
 
 describe("/api/update-a-trust", () => {
-  it("returns a 200 if the method is PATCH", async () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
+  const response = {
+    status: jest.fn().mockReturnValue({end: jest.fn()}),
+    end: jest.fn()
+  };
 
+  it("returns a 200 if the method is PATCH", async () => {
     const req = {
       headers: { cookie: "token" },
       body: {
@@ -25,22 +26,15 @@ describe("/api/update-a-trust", () => {
     expect(response.status).toBeCalledWith(200);
   });
 
-  it("returns a 405 if the action is not PATCH", () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-    const req = { body: {}, method: "GET" };
+  it("returns agi 405 if the action is not PATCH", async () => {
+    const req = { body: {}, method: "GET", headers: { cookie: "" } };
 
-    updateATrust(req, response);
+    await updateATrust(req, response);
 
     expect(response.status).toBeCalledWith(405);
   });
 
-  it("returns a 400 if the id is not present", () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
+  it("returns a 400 if the id is not present", async () => {
     const body = {
       videoProvider: "whereby",
     };
@@ -51,16 +45,12 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, { container });
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
 
-  it("returns a 400 if the id is invalid", () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
+  it("returns a 400 if the id is invalid", async () => {
     const body = {
       id: "hello",
       videoProvider: "whereby",
@@ -72,16 +62,12 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, { container });
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
 
-  it("returns a 400 if the videoProvider is not present", () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
+  it("returns a 400 if the videoProvider is not present", async () => {
     const body = {
       id: 5,
     };
@@ -92,16 +78,12 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, { container });
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
 
-  it("returns a 400 if the videoProvider is invalid", () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
+  it("returns a 400 if the videoProvider is invalid", async () => {
     const body = {
       id: 5,
       videoProvider: "hello",
@@ -113,16 +95,12 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, { container });
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(400);
   });
 
-  it("returns a 401 if user is not an admin", () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
+  it("returns a 401 if user is not an admin", async () => {
     const body = {
       id: 5,
       videoProvider: "whereby",
@@ -135,17 +113,13 @@ describe("/api/update-a-trust", () => {
 
     const req = { headers: { cookie: "token" }, body, method: "PATCH" };
 
-    updateATrust(req, response, { container });
+    await updateATrust(req, response, { container });
 
     expect(response.status).toBeCalledWith(401);
     expect(adminIsAuthenticatedStub).toBeCalledWith("token");
   });
 
   it("updates a trust", async () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
     const body = {
       id: 5,
       videoProvider: "whereby",
@@ -170,10 +144,6 @@ describe("/api/update-a-trust", () => {
   });
 
   it("returns a 404 if trust doesn't exist", async () => {
-    const response = {
-      status: jest.fn().mockReturnValue({ end: jest.fn() }),
-    };
-
     const body = {
       id: 12345,
       videoProvider: "whereby",


### PR DESCRIPTION
During testing another task, noticed that update-a-trust was failing for weird reasons.

I went through the tests and refactored, now passing and makes a bit more sense.