### PR TITLE
Move RetrieveActiveWards SQL into retrieveActiveWardsByTrustGW

### DIFF
--- a/contractTest/gateways/PostgreSQL/retrieveActiveWardsByTrustId.contractTest.js
+++ b/contractTest/gateways/PostgreSQL/retrieveActiveWardsByTrustId.contractTest.js
@@ -1,0 +1,74 @@
+import AppContainer from "../../../src/containers/AppContainer";
+import retrieveActiveWardsByTrustId from "../../../src/gateways/PostgreSQL/retrieveActiveWardsByTrustId";
+
+import {
+  setupTrust,
+  setupWard,
+  setupHospital,
+} from "../../../test/testUtils/factories";
+
+describe("retrieveActiveWardsByTrustId() contract", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns the appropriate ward", async () => {
+    const { trustId: trustIdA } = await setupTrust();
+    const hospitalNameA = "hospital A";
+    const { hospitalId: hospitalIdA } = await setupHospital({
+      trustId: trustIdA,
+      name: hospitalNameA,
+    });
+    const wardCodeA = "A";
+    const wardNameA = "Ward A";
+    const { wardId: wardIdA } = await setupWard({
+      trustId: trustIdA,
+      code: wardCodeA,
+      name: wardNameA,
+      hospitalId: hospitalIdA,
+    });
+
+    const hospitalNameB = "hospital B";
+    const { hospitalId: hospitalIdB } = await setupHospital({
+      trustId: trustIdA,
+      name: hospitalNameB,
+    });
+    const wardCodeB = "B";
+    const wardNameB = "Ward B";
+    const { wardId: wardIdB } = await setupWard({
+      trustId: trustIdA,
+      code: wardCodeB,
+      name: wardNameB,
+      hospitalId: hospitalIdB,
+    });
+
+    const { trustId: trustIdB } = await setupTrust();
+    const hospitalNameC = "hospital C";
+    const { hospitalId: hospitalIdC } = await setupHospital({
+      trustId: trustIdB,
+      name: hospitalNameC,
+    });
+    const wardCodeC = "C";
+    const wardNameC = "Ward C";
+    await setupWard({
+      trustId: trustIdB,
+      code: wardCodeC,
+      name: wardNameC,
+      hospitalId: hospitalIdC,
+    });
+
+    const results = await retrieveActiveWardsByTrustId(container)(trustIdA);
+    expect(results).orderlessEqual([
+      {
+        wardId: wardIdA,
+        wardName: wardNameA,
+        wardCode: wardCodeA,
+        hospitalName: hospitalNameA,
+      },
+      {
+        wardId: wardIdB,
+        wardName: wardNameB,
+        wardCode: wardCodeB,
+        hospitalName: hospitalNameB,
+      },
+    ]);
+  });
+});

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -82,6 +82,7 @@ import retrieveTrustById from "../gateways/PostgreSQL/retrieveTrustById";
 import retrieveOrganizationById from "../gateways/PostgreSQL/retrieveOrganizationById";
 import retrieveOrganizationsGW from "../gateways/PostgreSQL/retrieveOrganizations";
 import retrieveVisitByIdGW from "../gateways/PostgreSQL/retrieveVisitById";
+import retrieveActiveWardsByTrustIdGW from "../gateways/PostgreSQL/retrieveActiveWardsByTrustId";
 import captureEventGW from "../gateways/PostgreSQL/captureEvent";
 import retrieveReportingStartDateByTrustIdGW from "../gateways/PostgreSQL/retrieveReportingStartDateByTrustId";
 import retrieveAverageParticipantsInVisitGW from "../gateways/PostgreSQL/retrieveAverageParticipantsInVisit";
@@ -349,6 +350,9 @@ class AppContainer {
   getUpdateWardArchiveTimeByIdGateway = () => {
     return updateWardArchiveTimeById(this);
   };
+
+  getRetrieveActiveWardsByTrustIdGW = () =>
+    retrieveActiveWardsByTrustIdGW(this);
 
   getRetrieveHospitalVisitTotalsGateway = () => {
     return retrieveHospitalVisitTotalsGW(this);

--- a/src/gateways/PostgreSQL/retrieveActiveWardsByTrustId.js
+++ b/src/gateways/PostgreSQL/retrieveActiveWardsByTrustId.js
@@ -1,0 +1,40 @@
+const recordToDomain = ({ hospital_name, ward_code, ward_id, ward_name }) => ({
+  hospitalName: hospital_name,
+  wardCode: ward_code,
+  wardName: ward_name,
+  wardId: ward_id,
+});
+const recordsToDomain = (records) => records.map(recordToDomain);
+
+const retrieveActiveWardsByTrustIdQuery = async (db, trustId) =>
+  await db.any(
+    `SELECT
+      id as ward_id,
+      name as ward_name,
+      (
+        SELECT
+          name
+        FROM
+          hospitals
+        WHERE
+          wards.hospital_id = id
+          AND trust_id = $1
+      ) as hospital_name,
+      wards.code as ward_code
+    FROM
+      wards
+    WHERE
+      wards.trust_id = $1
+    AND
+      wards.archived_at IS NULL
+    ORDER BY
+      name ASC,
+      name ASC
+  `,
+    [trustId]
+  );
+
+export default ({ getDb }) => async (trustId) =>
+  recordsToDomain(
+    await retrieveActiveWardsByTrustIdQuery(await getDb(), trustId)
+  );

--- a/src/usecases/retrieveWards.js
+++ b/src/usecases/retrieveWards.js
@@ -1,41 +1,18 @@
 import logger from "../../logger";
 
-const retrieveWards = ({ getDb }) => async (trustId) => {
-  const db = await getDb();
+const retrieveWards = ({ getRetrieveActiveWardsByTrustIdGW }) => async (
+  trustId
+) => {
+  const retrieveActiveWardsByTrustIdGW = getRetrieveActiveWardsByTrustIdGW();
   try {
-    const wards = await db.any(
-      `SELECT
-        id as ward_id,
-        name as ward_name,
-        (
-          SELECT
-            name
-          FROM
-            hospitals
-          WHERE
-            wards.hospital_id = id
-            AND trust_id = $1
-        ) as hospital_name,
-        wards.code as ward_code
-      FROM
-        wards
-      WHERE
-        wards.trust_id = $1
-      AND
-        wards.archived_at IS NULL
-      ORDER BY
-        name ASC,
-        name ASC
-    `,
-      [trustId]
-    );
+    const wards = await retrieveActiveWardsByTrustIdGW(trustId);
 
     return {
-      wards: wards.map((ward) => ({
-        id: ward.ward_id,
-        name: ward.ward_name,
-        hospitalName: ward.hospital_name,
-        code: ward.ward_code,
+      wards: wards.map(({ wardId, wardName, hospitalName, wardCode }) => ({
+        id: wardId,
+        name: wardName,
+        hospitalName: hospitalName,
+        code: wardCode,
       })),
       error: null,
     };

--- a/test/usecases/retrieveWards.test.js
+++ b/test/usecases/retrieveWards.test.js
@@ -2,27 +2,23 @@ import retrieveWards from "../../src/usecases/retrieveWards";
 
 describe("retrieveWards", () => {
   it("returns a json object containing the wards", async () => {
-    const anySpy = jest.fn(() => [
+    const retrieveActiveWardsByTrustIdSpy = jest.fn(async () => [
       {
-        ward_id: 1,
-        ward_name: "Defoe Ward",
-        hospital_name: "Test Hospital",
-        ward_code: "test_code",
+        wardId: 1,
+        wardName: "Defoe Ward",
+        wardCode: "test_code",
+        hospitalName: "Test Hospital",
       },
       {
-        ward_id: 2,
-        ward_name: "Willem Ward",
-        hospital_name: "Test Hospital 2",
-        ward_code: "test_code_2",
+        wardId: 2,
+        wardName: "Willem Ward",
+        wardCode: "test_code_2",
+        hospitalName: "Test Hospital 2",
       },
     ]);
 
     const container = {
-      async getDb() {
-        return {
-          any: anySpy,
-        };
-      },
+      getRetrieveActiveWardsByTrustIdGW: () => retrieveActiveWardsByTrustIdSpy,
     };
 
     const trustId = 3;
@@ -30,7 +26,7 @@ describe("retrieveWards", () => {
     const { wards, error } = await retrieveWards(container)(trustId);
 
     expect(error).toBeNull();
-    expect(anySpy).toHaveBeenCalledWith(expect.anything(), [trustId]);
+    expect(retrieveActiveWardsByTrustIdSpy).toHaveBeenCalledWith(trustId);
     expect(wards).toHaveLength(2);
     expect(wards[0]).toEqual({
       id: 1,
@@ -48,16 +44,13 @@ describe("retrieveWards", () => {
 
   it("returns an error object on db exception", async () => {
     const container = {
-      async getDb() {
-        return {
-          any: jest.fn(() => {
-            throw new Error("DB Error!");
-          }),
-        };
+      getDb: () => () => {},
+      getRetrieveActiveWardsByTrustIdGW: () => async () => {
+        throw new Error("Dummy");
       },
     };
 
     const { error } = await retrieveWards(container)();
-    expect(error).toBeDefined();
+    expect(error).toEqual("Error: Dummy");
   });
 });


### PR DESCRIPTION
# What
Continuing from previous PRs, this PR moves the SQL in RetrieveActiveWards into its own gateway, this may also correct a false positive in the tests for RetrieveActiveWards  

# Why
In order to move from Postgres to Microsoft SQL Server we need to cleave business and data logic, this will also further the maintainability of the project.

# Screenshots

# Notes
https://virtualvisits.atlassian.net/secure/RapidBoard.jspa?rapidView=3&modal=detail&selectedIssue=VV-106