### PR TITLE
Add CaptureEvents gateway to MSSQL

### DIFF
--- a/contractTest/gateways/MsSQL/captureEvent.contractTest.js
+++ b/contractTest/gateways/MsSQL/captureEvent.contractTest.js
@@ -1,0 +1,30 @@
+import captureEvent from "../../../src/gateways/MsSQL/captureEvent";
+import AppContainer from "../../../src/containers/AppContainer";
+
+describe("captureEvent()", () => {
+  const container = AppContainer.getInstance();
+
+  it("returns an id & timestamp", async () => {
+    const {
+      event: { id },
+    } = await captureEvent(container)({
+      action: "test",
+      //we don't yet have the ability to create mssql visits so we will use a dummy value for now
+      visitId: null,
+      callSessionId: "123e4567-e89b-12d3-a456-426614174000",
+    });
+
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("catches errors", async () => {
+    const nonexistentVisitId = 25565;
+    const { error } = await captureEvent(container)({
+      action: "test",
+      visitId: nonexistentVisitId,
+      callSessionId: "123e4567-e89b-12d3-a456-426614174000",
+    });
+
+    expect(error).toEqual("Failed to add test event for visit 25565");
+  });
+});

--- a/src/gateways/MsSQL/captureEvent.js
+++ b/src/gateways/MsSQL/captureEvent.js
@@ -1,0 +1,39 @@
+import moment from "moment";
+import logger from "../../../logger";
+
+const captureEvent = ({ getMsSqlConnPool }) => async ({
+  action,
+  visitId,
+  callSessionId,
+}) => {
+  try {
+    const db = await getMsSqlConnPool();
+    const timestamp = moment().utc().toISOString();
+    const event = await db
+      .request()
+      .input("created_at", timestamp)
+      .input("action", action)
+      .input("scheduled_call_id", visitId)
+      .input("session_id", callSessionId)
+      .query(
+        "INSERT INTO dbo.[events] ([created_at], [action], [scheduled_call_id], [session_id]) OUTPUT inserted.id VALUES (@created_at, @action, @scheduled_call_id, @session_id)"
+      );
+
+    return {
+      event: {
+        id: event.recordset[0].id,
+        time: timestamp,
+        action,
+        visitId,
+        callSessionId,
+      },
+      error: null,
+    };
+  } catch (err) {
+    logger.error(err);
+    const message = `Failed to add ${action} event for visit ${visitId}`;
+    return { event: null, error: message };
+  }
+};
+
+export default captureEvent;


### PR DESCRIPTION
# What
This adds a gateway for event capture in MSSQL.

# Why
Moving to MSSQL, see earlier Prs

# Screenshots

# Notes
The MSSQL event capture gateway will not be added to the AppContainer just yet because it requires visitIds to be in the MSSQL database first before it can be made useful. For now it's sufficient to simply have the gateway ready for that.