### PR TITLE
Migrate retrieveVisits to MSSQL as retrieveOrderedActiveCallsByDepartmentId

### DIFF
--- a/contractTest/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.contractTest.js
+++ b/contractTest/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.contractTest.js
@@ -1,0 +1,15 @@
+import retrieveOrderedActiveCallsByDepartmentId from "../../../src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId";
+import { setupOrganisationFacilityDepartmentAndManager, setupVisitMsSQL } from "../../../test/testUtils/factories";
+import AppContainer from "../../../src/containers/AppContainer";
+
+describe("retrieveOrderedActiveCallsByDepartmentId", () => {
+  // Arrange
+  const container = AppContainer.getInstance();
+  it("returns an object containing the active calls", async () => {
+    const { departmentId, userId } = await setupOrganisationFacilityDepartmentAndManager();
+    const { visitId } = await setupVisitMsSQL({departmentId});
+    //create a few more calls, not just one, including some that aren't active
+    //then test to make sure we've only recieved the active ones  and to make sure
+    //they're in order
+  });
+});

--- a/contractTest/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.contractTest.js
+++ b/contractTest/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.contractTest.js
@@ -1,13 +1,28 @@
+<<<<<<< HEAD
 import retrieveOrderedActiveCallsByDepartmentId from "../../../src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId";
 import { setupOrganisationFacilityDepartmentAndManager, setupVisitMsSQL } from "../../../test/testUtils/factories";
 import AppContainer from "../../../src/containers/AppContainer";
+=======
+// import retrieveOrderedActiveCallsByDepartmentId from "../../../src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId";
+import {
+  setupOrganisationFacilityDepartmentAndManager,
+  setUpScheduledCall,
+} from "../../../test/testUtils/factories";
+// import AppContainer from "../../../src/containers/AppContainer";
+>>>>>>> change setupVisitMsSQL to setUpScheduledCall
 
 describe("retrieveOrderedActiveCallsByDepartmentId", () => {
   // Arrange
   const container = AppContainer.getInstance();
   it("returns an object containing the active calls", async () => {
-    const { departmentId, userId } = await setupOrganisationFacilityDepartmentAndManager();
-    const { visitId } = await setupVisitMsSQL({departmentId});
+    const {
+      departmentId,
+      userId,
+    } = await setupOrganisationFacilityDepartmentAndManager();
+    const { visitId } = await setUpScheduledCall({ departmentId });
+
+    console.log(visitId);
+    console.log(userId);
     //create a few more calls, not just one, including some that aren't active
     //then test to make sure we've only recieved the active ones  and to make sure
     //they're in order

--- a/contractTest/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.contractTest.js
+++ b/contractTest/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.contractTest.js
@@ -1,19 +1,13 @@
-<<<<<<< HEAD
-import retrieveOrderedActiveCallsByDepartmentId from "../../../src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId";
-import { setupOrganisationFacilityDepartmentAndManager, setupVisitMsSQL } from "../../../test/testUtils/factories";
-import AppContainer from "../../../src/containers/AppContainer";
-=======
 // import retrieveOrderedActiveCallsByDepartmentId from "../../../src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId";
 import {
   setupOrganisationFacilityDepartmentAndManager,
   setUpScheduledCall,
 } from "../../../test/testUtils/factories";
 // import AppContainer from "../../../src/containers/AppContainer";
->>>>>>> change setupVisitMsSQL to setUpScheduledCall
 
 describe("retrieveOrderedActiveCallsByDepartmentId", () => {
   // Arrange
-  const container = AppContainer.getInstance();
+  //const container = AppContainer.getInstance();
   it("returns an object containing the active calls", async () => {
     const {
       departmentId,

--- a/contractTest/gateways/MsSQL/updateVisitStatusByCallId.contractTest.js
+++ b/contractTest/gateways/MsSQL/updateVisitStatusByCallId.contractTest.js
@@ -26,7 +26,6 @@ describe("updateVisitStatusByCallIdGateway", () => {
       departmentId,
       status: statusToId(COMPLETE),
     });
-    console.log(visit);
     // Assert
     expect(visit.status).toEqual(statusToId(COMPLETE));
     expect(error).toBeNull();

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -109,6 +109,7 @@ import updateOrganisationGateway from "../gateways/MsSQL/updateOrganisation";
 import insertScheduledCallGateway from "../gateways/MsSQL/insertVisit";
 import deleteVisitByCallIdGateway from "../gateways/MsSQL/deleteVisitByCallId";
 import retrieveActiveManagersByOrgIdGateway from "../gateways/MsSQL/retrieveActiveManagersByOrgId";
+import updateVisitStatusByCallIdGateway from "../gateways/MsSQL/updateVisitStatusByCallId";
 
 /* GW Imports */
 import findWardByCode from "../gateways/PostgreSQL/findWardByCode";
@@ -687,6 +688,10 @@ class AppContainer {
 
   getUpdateFacilityByIdGateway = () => {
     return updateFacilityByIdGateway(this);
+  };
+
+  getUpdateVisitStatusByCallIdGateway = () => {
+    return updateVisitStatusByCallIdGateway(this);
   };
 
   getVerifyUserLogin = () => {

--- a/src/gateways/MsSQL/retrieveFacilityByUuid.js
+++ b/src/gateways/MsSQL/retrieveFacilityByUuid.js
@@ -8,5 +8,6 @@ export default ({ getMsSqlConnPool }) => async (uuid) => {
     .query(
       "SELECT id, name, code, status, uuid FROM dbo.[facility] WHERE uuid=@uuid"
     );
+
   return res.recordset[0];
 };

--- a/src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.js
+++ b/src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.js
@@ -1,0 +1,47 @@
+import logger from "../../../logger";
+import { SCHEDULED, COMPLETE, statusToId } from "../../helpers/visitStatus";
+
+export default ({ getMsSqlConnPool }) => async (departmentId) => {
+  const db = await getMsSqlConnPool();
+  try {
+    //the more complex SELECT clauses are no longer needed because the necessary
+    // tables have been merged into scheduled_call as part of the move to MSSQL
+    const result = await db.request()
+      .input("scheduled", statusToId(SCHEDULED)) //[SCHEDULED]: 0,
+      .input("complete", statusToId(COMPLETE)) //[COMPLETE]: 3,
+      .input("department_id", departmentId)
+      .query(
+        `SELECT * FROM dbo.[scheduled_call]
+        WHERE department_id = @department_id
+        AND pii_cleared_at IS NULL
+        AND (status = @scheduled OR status = @complete)
+        ORDER BY call_time ASC` //patient_name, recipient_name, recipient_email, recipient_number 
+      );
+    const scheduledCalls = result.recordset;
+
+    //none of the following is tested, it's likely it will need to be medified somewhat to conform to the contract
+    //the contract for this should be the same as PostgreSQL/retrieveVisits.js
+    return {
+      scheduledCalls: scheduledCalls.map((scheduledCall) => ({
+        id: scheduledCall.id,
+        patientName: scheduledCall.patient_name,
+        recipientName: scheduledCall.recipient_name,
+        recipientNumber: scheduledCall.recipient_number,
+        recipientEmail: scheduledCall.recipient_email,
+        callTime: scheduledCall.call_time
+          ? scheduledCall.call_time.toISOString()
+          : null,
+        callId: scheduledCall.call_id,
+        provider: scheduledCall.provider,
+        status: scheduledCall.status,
+      })),
+      error: null,
+    };
+  } catch (error) {
+    logger.error(error);
+    return {
+      scheduledCalls: null,
+      error: error.toString(),
+    };
+  }
+};

--- a/src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.js
+++ b/src/gateways/MsSQL/retrieveOrderedActiveCallsByDepartmentId.js
@@ -6,19 +6,19 @@ export default ({ getMsSqlConnPool }) => async (departmentId) => {
   try {
     //the more complex SELECT clauses are no longer needed because the necessary
     // tables have been merged into scheduled_call as part of the move to MSSQL
-    const result = await db.request()
+    const result = await db
+      .request()
       .input("scheduled", statusToId(SCHEDULED)) //[SCHEDULED]: 0,
       .input("complete", statusToId(COMPLETE)) //[COMPLETE]: 3,
       .input("department_id", departmentId)
       .query(
         `SELECT * FROM dbo.[scheduled_call]
         WHERE department_id = @department_id
-        AND pii_cleared_at IS NULL
+        AND pii_cleared_out IS NULL
         AND (status = @scheduled OR status = @complete)
-        ORDER BY call_time ASC` //patient_name, recipient_name, recipient_email, recipient_number 
+        ORDER BY call_time ASC` //patient_name, recipient_name, recipient_email, recipient_number
       );
     const scheduledCalls = result.recordset;
-
     //none of the following is tested, it's likely it will need to be medified somewhat to conform to the contract
     //the contract for this should be the same as PostgreSQL/retrieveVisits.js
     return {
@@ -31,8 +31,6 @@ export default ({ getMsSqlConnPool }) => async (departmentId) => {
         callTime: scheduledCall.call_time
           ? scheduledCall.call_time.toISOString()
           : null,
-        callId: scheduledCall.call_id,
-        provider: scheduledCall.provider,
         status: scheduledCall.status,
       })),
       error: null,

--- a/test/testUtils/factories.js
+++ b/test/testUtils/factories.js
@@ -1,5 +1,6 @@
 import AppContainer from "../../src/containers/AppContainer";
 const container = AppContainer.getInstance();
+import insertVisitMsSQLGateway from "../../src/gateways/MsSQL/insertVisit"; //We can't use this for every test yet so we won't put it into the AppContainer until later
 
 export const setUpManager = async (args = {}) => {
   return await container.getInsertManagerGateway()({
@@ -158,7 +159,7 @@ export const setupOrganisationFacilityAndManager = async (
     createdBy: userId,
     ...args.facilityArgs,
   });
-
+  
   const {
     id: facilityId,
     uuid: facilityUuid,
@@ -185,7 +186,7 @@ export const setupOrganisationFacilityDepartmentAndManager = async (
     organisationArgs: args.organisationArgs,
     facilityArgs: args.facilityArgs,
   });
-
+  
   const uuid = await setUpDepartment({
     facilityId,
     createdBy: userId,
@@ -195,7 +196,7 @@ export const setupOrganisationFacilityDepartmentAndManager = async (
     id: departmentId,
     uuid: departmentUuid,
   } = await container.getRetrieveDepartmentByUuidGateway()(uuid);
-
+  
   return {
     userId,
     orgId,
@@ -242,6 +243,21 @@ export const setUpScheduledCall = async (args = {}) => {
     visit,
     args.departmentId
   );
+//Some tests still need the old setupVisit(), so let's seperate the MsSQL into a different function
+export const setupVisitMsSQL = async (args = {}) => {
+  const db = await container.getMsSqlConnPool();
+  const visit = {
+    patientName: "Patient Name",
+    contactEmail: "contact@example.com",
+    contactName: "Contact Name",
+    callTime: new Date("2020-06-01 13:00"),
+    callId: "TESTCALLID",
+    provider: "whereby",
+    callPassword: "TESTCALLPASSWORD",
+    ...args,
+  };
+  const { id: visitId, error } = await insertVisitMsSQLGateway(db, visit, args.departmentId);
+  return { visitId, error };
 };
 
 export const setupVisit = async (args = {}) => {

--- a/test/testUtils/factories.js
+++ b/test/testUtils/factories.js
@@ -1,6 +1,5 @@
 import AppContainer from "../../src/containers/AppContainer";
 const container = AppContainer.getInstance();
-import insertVisitMsSQLGateway from "../../src/gateways/MsSQL/insertVisit"; //We can't use this for every test yet so we won't put it into the AppContainer until later
 
 export const setUpManager = async (args = {}) => {
   return await container.getInsertManagerGateway()({
@@ -159,7 +158,7 @@ export const setupOrganisationFacilityAndManager = async (
     createdBy: userId,
     ...args.facilityArgs,
   });
-  
+
   const {
     id: facilityId,
     uuid: facilityUuid,
@@ -186,7 +185,7 @@ export const setupOrganisationFacilityDepartmentAndManager = async (
     organisationArgs: args.organisationArgs,
     facilityArgs: args.facilityArgs,
   });
-  
+
   const uuid = await setUpDepartment({
     facilityId,
     createdBy: userId,
@@ -196,7 +195,7 @@ export const setupOrganisationFacilityDepartmentAndManager = async (
     id: departmentId,
     uuid: departmentUuid,
   } = await container.getRetrieveDepartmentByUuidGateway()(uuid);
-  
+
   return {
     userId,
     orgId,
@@ -243,22 +242,23 @@ export const setUpScheduledCall = async (args = {}) => {
     visit,
     args.departmentId
   );
-//Some tests still need the old setupVisit(), so let's seperate the MsSQL into a different function
-export const setupVisitMsSQL = async (args = {}) => {
-  const db = await container.getMsSqlConnPool();
-  const visit = {
-    patientName: "Patient Name",
-    contactEmail: "contact@example.com",
-    contactName: "Contact Name",
-    callTime: new Date("2020-06-01 13:00"),
-    callId: "TESTCALLID",
-    provider: "whereby",
-    callPassword: "TESTCALLPASSWORD",
-    ...args,
-  };
-  const { id: visitId, error } = await insertVisitMsSQLGateway(db, visit, args.departmentId);
-  return { visitId, error };
 };
+//Some tests still need the old setupVisit(), so let's seperate the MsSQL into a different function
+// export const setupVisitMsSQL = async (args = {}) => {
+//   const db = await container.getMsSqlConnPool();
+//   const visit = {
+//     patientName: "Patient Name",
+//     contactEmail: "contact@example.com",
+//     contactName: "Contact Name",
+//     callTime: new Date("2020-06-01 13:00"),
+//     callId: "TESTCALLID",
+//     provider: "whereby",
+//     callPassword: "TESTCALLPASSWORD",
+//     ...args,
+//   };
+//   const { id: visitId, error } = await insertVisitMsSQLGateway(db, visit, args.departmentId);
+//   return { visitId, error };
+// };
 
 export const setupVisit = async (args = {}) => {
   const visit = {


### PR DESCRIPTION
# What
Similar to findCallsByDepartmentId but ordered and only including active calls that haven't had their PII cleared. This is based on retrieveVisits from the PostgreSQL gateways.  
 
# Why

# Screenshots

# Notes
