### PR TITLE
Fix admin home link

### DIFF
--- a/pages/admin/trusts/[id]/index.js
+++ b/pages/admin/trusts/[id]/index.js
@@ -3,14 +3,14 @@ import Layout from "../../../../src/components/Layout";
 import propsWithContainer from "../../../../src/middleware/propsWithContainer";
 import verifyAdminToken from "../../../../src/usecases/verifyAdminToken";
 import { GridRow, GridColumn } from "../../../../src/components/Grid";
-import Heading from "../../../../src/components/Heading";
-// import ActionLink from "../../../src/components/ActionLink";
-// import TrustsTable from "../../../src/components/TrustsTable";
-// import Text from "../../../src/components/Text";
+import Text from "../../../../src/components/Text";
+import ManagersTable from "../../../../src/components/ManagersTable";
+import TrustAdminHeading from "../../../../src/components/TrustAdminHeading";
+
 import Error from "next/error";
 import { ADMIN } from "../../../../src/helpers/userTypes";
 
-const Organisation = ({ organisation, error }) => {
+const Organisation = ({ organisation, managers, error }) => {
   if (error) {
     return <Error err={error} />;
   }
@@ -21,16 +21,19 @@ const Organisation = ({ organisation, error }) => {
       showNavigationBarForType={ADMIN}
       showNavigationBar={true}
     >
+      <TrustAdminHeading 
+        trustName={organisation.name}
+        subHeading="Managers"
+      />
       <GridRow>
         <GridColumn width="full">
-          <Heading>{organisation.name}</Heading>
-          {/* <ActionLink href="trusts/add-a-trust">Add a trust</ActionLink> */}
-
-          {/* {organizations.length > 0 ? (
-            <TrustsTable trusts={organizations} />
-          ) : (
-            <Text>There are no trusts</Text>
-          )} */}
+          { 
+            managers && managers.length > 0 ? (
+              <ManagersTable managers={managers} />
+            ) : (
+              <Text>There are no managers.</Text>
+            )
+          }
         </GridColumn>
       </GridRow>
     </Layout>
@@ -40,13 +43,25 @@ const Organisation = ({ organisation, error }) => {
 export const getServerSideProps = propsWithContainer(
   verifyAdminToken(async ({ container, query }) => {
     const { id } = query;
-    const {
-      organisation,
-      error,
-    } = await container.getRetrieveOrganisationById()(id);
 
+    const retrieveOrganisationById = container.getRetrieveOrganisationById();
+    const { 
+      organisation,
+      error: organisationError 
+    } = await retrieveOrganisationById(id);
+
+    const retrieveActiveManagersByOrgId = container.getRetrieveActiveManagersByOrgId();
+    const {
+      managers,
+      error: managersError,
+    } = await retrieveActiveManagersByOrgId(id);
+    
     return {
-      props: { organisation, error },
+      props: { 
+        organisation,
+        managers, 
+        error: organisationError || managersError, 
+      },
     };
   })
 );

--- a/src/components/AdminsNavigationBar/index.js
+++ b/src/components/AdminsNavigationBar/index.js
@@ -5,7 +5,7 @@ const AdminsNavigationBar = () => {
   const links = [
     {
       text: "Home",
-      href: "/",
+      href: "/admin",
     },
     {
       text: "Log out",

--- a/src/components/AdminsNavigationBar/index.js
+++ b/src/components/AdminsNavigationBar/index.js
@@ -9,7 +9,7 @@ const AdminsNavigationBar = () => {
     },
     {
       text: "Log out",
-      href: "/admin#",
+      href: "/login",
       onClick: logout,
     },
   ];

--- a/src/components/TrustAdminsNavigationBar/index.js
+++ b/src/components/TrustAdminsNavigationBar/index.js
@@ -17,7 +17,7 @@ const TrustAdminsNavigationBar = () => {
     },
     {
       text: "Log out",
-      href: "/trust-admin#",
+      href: "/login",
       onClick: logout,
     },
   ];

--- a/src/components/WardsNavigationBar/index.js
+++ b/src/components/WardsNavigationBar/index.js
@@ -13,7 +13,7 @@ const WardsNavigationBar = () => {
     },
     {
       text: "Log out",
-      href: "#",
+      href: "/wards/login",
       onClick: logout,
     },
   ];

--- a/test/pages/admin/trusts/[id]/edit.test.js
+++ b/test/pages/admin/trusts/[id]/edit.test.js
@@ -35,7 +35,7 @@ describe("/admin/admin/trusts/[id]/edit", () => {
     });
 
     it("retrieves a trust by the trustId parameter", async () => {
-      const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+      const retrieveOrganisationByIdSpy = jest.fn().mockReturnValue({
         trust: {
           id: 1,
           name: "Northwick Park Trust",
@@ -45,7 +45,7 @@ describe("/admin/admin/trusts/[id]/edit", () => {
       });
 
       const container = {
-        getRetrieveOrganisationById: () => retrieveTrustByIdSpy,
+        getRetrieveOrganisationById: () => retrieveOrganisationByIdSpy,
         getTokenProvider: () => tokenProvider,
         getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };
@@ -59,11 +59,11 @@ describe("/admin/admin/trusts/[id]/edit", () => {
         container,
       });
 
-      expect(retrieveTrustByIdSpy).toHaveBeenCalledWith("1");
+      expect(retrieveOrganisationByIdSpy).toHaveBeenCalledWith("1");
     });
 
     it("set a trust prop based on the retrieved trust", async () => {
-      const retrieveTrustByIdSpy = jest.fn().mockReturnValue({
+      const retrieveOrganisationByIdSpy = jest.fn().mockReturnValue({
         trust: {
           id: 1,
           name: "Northwick Park Trust",
@@ -73,7 +73,7 @@ describe("/admin/admin/trusts/[id]/edit", () => {
       });
 
       const container = {
-        getRetrieveOrganisationById: () => retrieveTrustByIdSpy,
+        getRetrieveOrganisationById: () => retrieveOrganisationByIdSpy,
         getTokenProvider: () => tokenProvider,
         getRegenerateToken: () => jest.fn().mockReturnValue({}),
       };

--- a/test/pages/admin/trusts/[id]/index.test.js
+++ b/test/pages/admin/trusts/[id]/index.test.js
@@ -1,0 +1,165 @@
+import { getServerSideProps } from "../../../../../pages/admin/trusts/[id]";
+
+const authenticatedReq = {
+  headers: {
+    cookie: "token=123",
+  },
+};
+
+const tokenProvider = {
+  validate: jest.fn(() => ({ type: "admin" })),
+};
+
+describe("/admin/admin/trusts/[id]", () => {
+  const anonymousReq = {
+    headers: {
+      cookie: "",
+    },
+  };
+
+  let res;
+
+  beforeEach(() => {
+    res = {
+      writeHead: jest.fn().mockReturnValue({ end: () => {} }),
+    };
+  });
+
+  describe("getServerSideProps", () => {
+    it("redirects to login page if not authenticated", async () => {
+      await getServerSideProps({ req: anonymousReq, res });
+
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: "/admin/login",
+      });
+    });
+
+    it("retrieves a organisation by organisationId and sets the organisation prop", async () => {
+      const retrieveOrganisationByIdSpy = jest.fn().mockReturnValue({
+        organisation: {
+          id: 1,
+          name: "Northwick Park Trust",
+        },
+        error: null,
+      });
+
+      const container = {
+        getRetrieveOrganisationById: () => retrieveOrganisationByIdSpy,
+        getRetrieveActiveManagersByOrgId: () => jest.fn().mockReturnValue({
+          managers: ["nhs-manager@nhs.co.uk"],
+          error: null,
+        }),
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          id: "1",
+        },
+        container,
+      });
+
+      expect(props.organisation).toEqual({
+        id: 1, 
+        name: "Northwick Park Trust"
+      });
+      expect(props.error).toBeNull();
+      expect(retrieveOrganisationByIdSpy).toHaveBeenCalledWith("1");
+    });
+
+    it("returns an error as a prop if there is an error with retrieving organisation", async () => {
+      const container = {
+        getRetrieveOrganisationById: () => jest.fn().mockReturnValue({
+          organisation: null,
+          error: "Organisation could not be found",
+        }),
+        getRetrieveActiveManagersByOrgId: () => jest.fn().mockReturnValue({
+          managers: ["nhs-manager@nhs.co.uk"],
+          error: null,
+        }),
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          id: "1",
+        },
+        container,
+      });
+
+      expect(props.organisation).toBeNull();
+      expect(props.error).toEqual("Organisation could not be found");
+    });
+
+    it("retrieves the managers for an organisation and sets the managers prop", async () => {
+      const retrieveActiveManagersByOrgIdSpy = jest.fn().mockReturnValue({
+        managers: ["nhs-manager@nhs.co.uk", "nhs-manager2@nhs.co.uk"],
+        error: null,
+      });
+
+      const container = {
+        getRetrieveOrganisationById: () => jest.fn().mockReturnValue({
+          organisation: {
+            id: 1,
+            name: "Northwick Park Trust",
+          },
+          error: null,
+        }),
+        getRetrieveActiveManagersByOrgId: () => retrieveActiveManagersByOrgIdSpy, 
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          id: "1",
+        },
+        container,
+      });
+
+      expect(props.managers).toEqual(
+        ["nhs-manager@nhs.co.uk", "nhs-manager2@nhs.co.uk"]
+      );
+      expect(props.error).toBeNull()
+      expect(retrieveActiveManagersByOrgIdSpy).toHaveBeenCalledWith("1");
+    });
+
+    it("returns an error as a prop if there is an error with retrieving managers", async () => {
+      const container = {
+        getRetrieveOrganisationById: () => jest.fn().mockReturnValue({
+          organisation: {
+            id: 1,
+            name: "Northwick Park Trust",
+          },
+          error: null,
+        }),
+        getRetrieveActiveManagersByOrgId: () => jest.fn().mockReturnValue({
+          managers: null,
+          error: "There was an error retrieving managers",
+        }),
+        getTokenProvider: () => tokenProvider,
+        getRegenerateToken: () => jest.fn().mockReturnValue({}),
+      };
+
+      const { props } = await getServerSideProps({
+        req: authenticatedReq,
+        res,
+        query: {
+          id: "1",
+        },
+        container,
+      });
+
+      expect(props.managers).toBeNull();
+      expect(props.error).toEqual("There was an error retrieving managers");
+    });
+  });
+});

--- a/test/pages/admin/trusts/add-a-trust.test.js
+++ b/test/pages/admin/trusts/add-a-trust.test.js
@@ -1,4 +1,4 @@
-import { getServerSideProps } from "../../../pages/admin/trusts/add-a-trust";
+import { getServerSideProps } from "../../../../pages/admin/trusts/add-a-trust";
 
 describe("/trust-admin/add-a-trust", () => {
   const anonymousReq = {


### PR DESCRIPTION
# What
1. Home link in admin navigation bar sent the user to the landing page, href has been changed to send the admin flow home page.
2. Logout link in admin and trust-manager navigation bar href has been changed to '/login' to improve user experience. Previously href was set to '/admin or /trust-manager' meaning that if a user was on a page other than the flow home page the user would go to the flow home page for a split second before being redirected to the login page and logging out .
3. Added the manager table to the trust page in the admin flow, and created the unit test for this page
# Why

# Screenshots

# Notes
