### PR TITLE
Use local time in booking email, rather than UTC

### DIFF
--- a/src/usecases/createVisit.js
+++ b/src/usecases/createVisit.js
@@ -45,7 +45,7 @@ const createVisit = ({
       emailAddress: visit.recipientEmail,
       wardName: ward.name,
       hospitalName: facility.name,
-      visitDateAndTime: visit.callTime,
+      visitDateAndTime: visit.callTimeLocal,
     });
 
     if (bookingNotificationErrors) {


### PR DESCRIPTION
# What

When sending out a booking notification for a visit, the service was using the time in UTC - during BST this has a 1-hour offset. Use the local time object to send out the correct time.

# Why

So that there is no confusion about booking times which may now occur in the past.

# Screenshots

# Notes
