### PR TITLE
Disable scrolling on date input

### DIFF
--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -48,7 +48,7 @@ const DateSelect = ({
           <FormGroup>
             <Label htmlFor="day">Day</Label>
             <Input
-              type="number"
+              type="text"
               hasError={hasDateError}
               onChange={(event) => {
                 setDate({ ...date, day: parseInt(event.target.value) });
@@ -67,7 +67,7 @@ const DateSelect = ({
           <FormGroup>
             <Label htmlFor="month">Month</Label>
             <Input
-              type="number"
+              type="text"
               hasError={hasDateError}
               className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--width-10"
               id="month"
@@ -86,7 +86,7 @@ const DateSelect = ({
           <FormGroup>
             <Label htmlFor="year">Year</Label>
             <Input
-              type="number"
+              type="text"
               hasError={hasDateError}
               className="nhsuk-input--width-4 nhsuk-input--width-10"
               id="year"
@@ -112,7 +112,7 @@ const DateSelect = ({
           <FormGroup>
             <Label htmlFor="hour">Hour</Label>
             <Input
-              type="number"
+              type="tet"
               hasError={hasTimeError}
               className="nhsuk-input--width-2"
               id="hour"
@@ -122,6 +122,8 @@ const DateSelect = ({
               }}
               value={date.hour}
               autoComplete="off"
+              pattern="[0-9]*"
+              inputMode="numeric"
             />
           </FormGroup>
         </div>
@@ -129,7 +131,7 @@ const DateSelect = ({
           <FormGroup>
             <Label htmlFor="minute">Minutes</Label>
             <Input
-              type="number"
+              type="text"
               hasError={hasTimeError}
               className="nhsuk-input--width-2"
               id="minute"
@@ -139,6 +141,8 @@ const DateSelect = ({
               }}
               value={date.minute}
               autoComplete="off"
+              pattern="[0-9]*"
+              inputMode="numeric"
             />
           </FormGroup>
         </div>

--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -112,7 +112,7 @@ const DateSelect = ({
           <FormGroup>
             <Label htmlFor="hour">Hour</Label>
             <Input
-              type="tet"
+              type="text"
               hasError={hasTimeError}
               className="nhsuk-input--width-2"
               id="hour"

--- a/src/components/DateSelect/index.js
+++ b/src/components/DateSelect/index.js
@@ -58,6 +58,8 @@ const DateSelect = ({
               name="day"
               value={date.day}
               autoComplete="off"
+              pattern="[0-9]*"
+              inputMode="numeric"
             />
           </FormGroup>
         </div>
@@ -75,6 +77,8 @@ const DateSelect = ({
               }}
               value={Number(date.month) + 1}
               autoComplete="off"
+              pattern="[0-9]*"
+              inputMode="numeric"
             />
           </FormGroup>
         </div>
@@ -92,6 +96,8 @@ const DateSelect = ({
               }}
               value={date.year}
               autoComplete="off"
+              pattern="[0-9]*"
+              inputMode="numeric"
             />
           </FormGroup>
         </div>


### PR DESCRIPTION
# What

Refactor date entry fields so that the resultant HTML matches the example used in: https://service-manual.nhs.uk/design-system/components/date-input

This prevents erroneous input, including those caused by accidentally scrolling the mousewheel

# Why
The design system sets out best practices that have been user tested quite thoroughly - we should only deviate from it wnen absolutely necessary and when we have performed our own testing

# Screenshots

# Notes

See: https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/
